### PR TITLE
refactor: use basket struct in fund method

### DIFF
--- a/pkg/storage/internal/actions/create.go
+++ b/pkg/storage/internal/actions/create.go
@@ -51,7 +51,7 @@ type Funder interface {
 	// @param numberOfDesiredUTXOs - the number of UTXOs in basket #TakeFromBasket
 	// @param minimumDesiredUTXOValue - the minimum value of UTXO in basket #TakeFromBasket
 	// @param userID - the user ID
-	Fund(ctx context.Context, targetSat int64, currentTxSize uint64, numberOfDesiredUTXOs int, minimumDesiredUTXOValue uint64, userID int) (*FundingResult, error)
+	Fund(ctx context.Context, targetSat int64, currentTxSize uint64, basket *wdk.TableOutputBasket, userID int) (*FundingResult, error)
 }
 
 type BasketRepo interface {
@@ -92,7 +92,7 @@ func (c *create) Create(auth wdk.AuthID, args CreateActionParams) (*wdk.StorageC
 		return nil, fmt.Errorf("failed to calculate target satoshis: %w", err)
 	}
 
-	_, err = c.funder.Fund(context.Background(), targetSat, initialTxSize, basket.NumberOfDesiredUTXOs, basket.MinimumDesiredUTXOValue, *auth.UserID)
+	_, err = c.funder.Fund(context.Background(), targetSat, initialTxSize, basket, *auth.UserID)
 	if err != nil {
 		return nil, fmt.Errorf("funding failed: %w", err)
 	}

--- a/pkg/storage/internal/actions/funder/sql.go
+++ b/pkg/storage/internal/actions/funder/sql.go
@@ -13,6 +13,7 @@ import (
 	"github.com/4chain-ag/go-wallet-toolbox/pkg/storage/internal/database/models"
 	"github.com/4chain-ag/go-wallet-toolbox/pkg/storage/internal/paging"
 	"github.com/4chain-ag/go-wallet-toolbox/pkg/storage/internal/txutils"
+	"github.com/4chain-ag/go-wallet-toolbox/pkg/wdk"
 	"github.com/go-softwarelab/common/pkg/must"
 	"github.com/go-softwarelab/common/pkg/seqerr"
 	"github.com/go-softwarelab/common/pkg/to"
@@ -49,8 +50,9 @@ func NewSQL(logger *slog.Logger, utxoRepository UTXORepository, feeModel defs.Fe
 // @param numberOfDesiredUTXOs - the number of UTXOs in basket #TakeFromBasket
 // @param minimumDesiredUTXOValue - the minimum value of UTXO in basket #TakeFromBasket
 // @param userID - the user ID.
-func (f *SQL) Fund(ctx context.Context, targetSat int64, currentTxSize uint64, numberOfDesiredUTXOs int, minimumDesiredUTXOValue uint64, userID int) (*actions.FundingResult, error) {
-	collector, err := newCollector(targetSat, currentTxSize, numberOfDesiredUTXOs, minimumDesiredUTXOValue, f.feeCalculator)
+func (f *SQL) Fund(ctx context.Context, targetSat int64, currentTxSize uint64, basket *wdk.TableOutputBasket, userID int) (*actions.FundingResult, error) {
+
+	collector, err := newCollector(targetSat, currentTxSize, basket.NumberOfDesiredUTXOs, basket.MinimumDesiredUTXOValue, f.feeCalculator)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start collecting utxo: %w", err)
 	}

--- a/pkg/storage/internal/actions/funder/sql_test.go
+++ b/pkg/storage/internal/actions/funder/sql_test.go
@@ -9,340 +9,280 @@ import (
 	"github.com/go-softwarelab/common/pkg/must"
 )
 
-const smallTransactionSize = 44
-const desiredUTXONumberToPreferSingleChange = 1
-const testDesiredUTXOValue = 1000
-
-var ctx = context.Background()
-
-func TestFunderSQLFundSuccessResult(t *testing.T) {
-	t.Run("return error when user has no utxo", func(t *testing.T) {
-		// given:
-		given, then, cleanup := testabilities.New(t)
-		defer cleanup()
-
-		// and:
-		funder := given.NewFunderService()
-
-		// when:
-		result, err := funder.Fund(ctx, 100, smallTransactionSize, desiredUTXONumberToPreferSingleChange, testDesiredUTXOValue, testusers.Alice.ID)
-
-		// then:
-		then.Result(result).WithError(err)
-	})
-
-	t.Run("user has funded exactly the transaction and fee by himself", func(t *testing.T) {
-		// given:
-		given, then, cleanup := testabilities.New(t)
-		defer cleanup()
-
-		// and:
-		funder := given.NewFunderService()
-
-		// when:
-		result, err := funder.Fund(ctx, -1, smallTransactionSize, desiredUTXONumberToPreferSingleChange, testDesiredUTXOValue, testusers.Alice.ID)
-
-		// then:
-		then.Result(result).WithoutError(err).
-			DoesNotAllocateUTXOs().
-			HasNoChange().
-			HasFee(1)
-
-	})
-
-	t.Run("user has funded exactly the transaction and fee for bigger size of tx by himself", func(t *testing.T) {
-		// given:
-		given, then, cleanup := testabilities.New(t)
-		defer cleanup()
-
-		// and:
-		funder := given.NewFunderService()
-
-		// when:
-		result, err := funder.Fund(ctx, -2, 1001, desiredUTXONumberToPreferSingleChange, testDesiredUTXOValue, testusers.Alice.ID)
-
-		// then:
-		then.Result(result).WithoutError(err).
-			DoesNotAllocateUTXOs().
-			HasNoChange().
-			HasFee(2)
-
-	})
-
-	t.Run("return error when user fund the transaction by himself but has not enough utxo to cover the fee", func(t *testing.T) {
-		// given:
-		given, then, cleanup := testabilities.New(t)
-		defer cleanup()
-
-		// and:
-		funder := given.NewFunderService()
-
-		// when:
-		result, err := funder.Fund(ctx, 0, smallTransactionSize, desiredUTXONumberToPreferSingleChange, testDesiredUTXOValue, testusers.Alice.ID)
-
-		// then:
-		then.Result(result).WithError(err)
-	})
-
-	t.Run("user has funded by himself the transaction but not the fee", func(t *testing.T) {
-		// given:
-		given, then, cleanup := testabilities.New(t)
-		defer cleanup()
-
-		// and:
-		funder := given.NewFunderService()
-
-		// and:
-		given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(1).P2PKH().Stored()
-
-		// when:
-		result, err := funder.Fund(ctx, 0, smallTransactionSize, desiredUTXONumberToPreferSingleChange, testDesiredUTXOValue, testusers.Alice.ID)
-
-		// then:
-		then.Result(result).WithoutError(err).
-			HasAllocatedUTXOs().RowIndexes(0).
-			HasNoChange().
-			HasFee(1)
-	})
-
-	t.Run("user has funded by himself the transaction and part of the fee", func(t *testing.T) {
-		// given:
-		given, then, cleanup := testabilities.New(t)
-		defer cleanup()
-
-		// and:
-		funder := given.NewFunderService()
-
-		// and:
-		given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(1).P2PKH().Stored()
-
-		// when:
-		result, err := funder.Fund(ctx, -1, 1500, desiredUTXONumberToPreferSingleChange, testDesiredUTXOValue, testusers.Alice.ID)
-
-		// then:
-		then.Result(result).WithoutError(err).
-			HasAllocatedUTXOs().RowIndexes(0).
-			HasNoChange().
-			HasFee(2)
-	})
-
-	t.Run("user has funded by himself more then the transaction and fee", func(t *testing.T) {
-		// given:
-		given, then, cleanup := testabilities.New(t)
-		defer cleanup()
-
-		// and:
-		funder := given.NewFunderService()
-
-		// when:
-		result, err := funder.Fund(ctx, -1001, smallTransactionSize, desiredUTXONumberToPreferSingleChange, testDesiredUTXOValue, testusers.Alice.ID)
-
-		// then:
-		then.Result(result).WithoutError(err).
-			DoesNotAllocateUTXOs().
-			HasChangeCount(1).ForAmount(1000).
-			HasFee(1)
-
-	})
-
-	t.Run("return error when user has not enough utxo to cover the transaction", func(t *testing.T) {
-		// given:
-		given, then, cleanup := testabilities.New(t)
-		defer cleanup()
-
-		// and:
-		funder := given.NewFunderService()
-
-		given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(10).P2PKH().Stored()
-
-		// when:
-		result, err := funder.Fund(ctx, 100, smallTransactionSize, desiredUTXONumberToPreferSingleChange, testDesiredUTXOValue, testusers.Alice.ID)
-
-		// then:
-		then.Result(result).WithError(err)
-	})
-
-	t.Run("target satoshis and fee are equal to the only one utxo satoshis", func(t *testing.T) {
-		// given:
-		given, then, cleanup := testabilities.New(t)
-		defer cleanup()
-
-		// and:
-		funder := given.NewFunderService()
-
-		// and:
-		given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(101).P2PKH().Stored()
-
-		// when:
-		result, err := funder.Fund(ctx, 100, smallTransactionSize, desiredUTXONumberToPreferSingleChange, testDesiredUTXOValue, testusers.Alice.ID)
-
-		// then:
-		then.Result(result).WithoutError(err).
-			HasAllocatedUTXOs().RowIndexes(0).
-			HasNoChange().
-			HasFee(1)
-
-	})
-
-	t.Run("return error when user has not enough utxos to cover fee", func(t *testing.T) {
-		// given:
-		given, then, cleanup := testabilities.New(t)
-		defer cleanup()
-
-		// and:
-		funder := given.NewFunderService()
-
-		// and:
-		targetSatoshis := int64(100)
-
-		// Because apart from target satoshis we need to cover the fee also, therefore it's not enough to have only utxo for target satoshis.
-		given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(targetSatoshis).P2PKH().Stored()
-
-		// when:
-		result, err := funder.Fund(ctx, targetSatoshis, smallTransactionSize, desiredUTXONumberToPreferSingleChange, testDesiredUTXOValue, testusers.Alice.ID)
-
-		// then:
-		then.Result(result).WithError(err)
-	})
-
-	t.Run("return error when user has not enough utxos to cover fee for bigger tx", func(t *testing.T) {
-		// given:
-		given, then, cleanup := testabilities.New(t)
-		defer cleanup()
-
-		// and:
-		funder := given.NewFunderService()
-
-		// and:
-		targetSatoshis := int64(100)
-
-		// Because the transaction size makes the fee = 2, one satoshi above the target satoshis is not enough.
-		given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(targetSatoshis + 1).P2PKH().Stored()
-
-		// when:
-		result, err := funder.Fund(ctx, targetSatoshis, 1500, desiredUTXONumberToPreferSingleChange, testDesiredUTXOValue, testusers.Alice.ID)
-
-		// then:
-		then.Result(result).WithError(err)
-	})
-
-	t.Run("adding utxo can increase the fee", func(t *testing.T) {
-		// given:
-		given, then, cleanup := testabilities.New(t)
-		defer cleanup()
-
-		// and:
-		funder := given.NewFunderService()
-
-		// and:
-		given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(102).P2PKH().Stored()
-
-		// when:
-		result, err := funder.Fund(ctx, 100, 999, desiredUTXONumberToPreferSingleChange, testDesiredUTXOValue, testusers.Alice.ID)
-
-		// then:
-		then.Result(result).WithoutError(err).
-			HasAllocatedUTXOs().RowIndexes(0).
-			HasFee(2).
-			HasNoChange()
-	})
-
-	t.Run("user has a lot of small utxo but they will cover the target sats and fee", func(t *testing.T) {
-		// given:
-		given, then, cleanup := testabilities.New(t)
-		defer cleanup()
-
-		// and:
-		funder := given.NewFunderService()
-
-		// and:
-		// Funder is collecting utxos by 1000 rows, so we need to have more than 1000 utxos to test this case.
-		for range 1600 {
-			given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(1).P2PKH().Stored()
-		}
-
-		// when:
-		result, err := funder.Fund(ctx, 1363, smallTransactionSize, desiredUTXONumberToPreferSingleChange, testDesiredUTXOValue, testusers.Alice.ID)
-
-		// then:
-		then.Result(result).WithoutError(err).
-			HasAllocatedUTXOs().ForTotalAmount(1600).
-			HasNoChange()
-
-	})
-
-	t.Run("user has single big utxo and aiming for smallest number of changes", func(t *testing.T) {
-		// given:
-		given, then, cleanup := testabilities.New(t)
-		defer cleanup()
-
-		// and:
-		funder := given.NewFunderService()
-
-		// and:
-		given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(10101).P2PKH().Stored()
-
-		// when:
-		result, err := funder.Fund(ctx, 100, smallTransactionSize, desiredUTXONumberToPreferSingleChange, testDesiredUTXOValue, testusers.Alice.ID)
-
-		// then:
-		then.Result(result).WithoutError(err).
-			HasAllocatedUTXOs().RowIndexes(0).
-			HasFee(1).
-			HasChangeCount(1).ForAmount(10000)
-
-	})
-
-	t.Run("allocate biggest utxos first", func(t *testing.T) {
-		// given:
-		given, then, cleanup := testabilities.New(t)
-		defer cleanup()
-
-		// and:
-		funder := given.NewFunderService()
-
-		// and:
-		given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(200).P2PKH().Stored()
-		given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(100).P2PKH().Stored()
-		given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(10101).P2PKH().Stored()
-		given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(1).P2PKH().Stored()
-		given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(300).P2PKH().Stored()
-
-		// when:
-		result, err := funder.Fund(ctx, 100, smallTransactionSize, desiredUTXONumberToPreferSingleChange, testDesiredUTXOValue, testusers.Alice.ID)
-
-		// then:
-		then.Result(result).WithoutError(err).
-			HasAllocatedUTXOs().RowIndexes(2).
-			HasFee(1).
-			HasChangeCount(1).ForAmount(10000)
-
-	})
-
-	t.Run("allocate several utxos and calculate the change from them", func(t *testing.T) {
-		// given:
-		given, then, cleanup := testabilities.New(t)
-		defer cleanup()
-
-		// and:
-		funder := given.NewFunderService()
-
-		// and:
-		given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(200).P2PKH().Stored()
-		given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(100).P2PKH().Stored()
-		given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(1).P2PKH().Stored()
-		given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(300).P2PKH().Stored()
-
-		// when:
-		result, err := funder.Fund(ctx, 549, smallTransactionSize, desiredUTXONumberToPreferSingleChange, testDesiredUTXOValue, testusers.Alice.ID)
-
-		// then:
-		then.Result(result).WithoutError(err).
-			HasAllocatedUTXOs().RowIndexes(0, 1, 3).
-			HasFee(1).
-			HasChangeCount(1).ForAmount(50)
-
-	})
+func TestRefactoring(t *testing.T) {
+	const smallTransactionSize = 44
+	const transactionSizeForHigherFee = 1001
+	var ctx = context.Background()
+
+	testCasesErrors := map[string]struct {
+		possessedUTXOs int64
+		targetSatoshis int64
+		txSize         uint64
+	}{
+		"return error when user has no utxo": {
+			possessedUTXOs: 0,
+			targetSatoshis: 100,
+			txSize:         smallTransactionSize,
+		},
+		"return error when user fund the transaction by himself but has not enough utxo to cover the fee": {
+			possessedUTXOs: 0,
+			targetSatoshis: 0,
+			txSize:         smallTransactionSize,
+		},
+		"return error when user has not enough utxo to cover the transaction": {
+			possessedUTXOs: 50,
+			targetSatoshis: 100,
+			txSize:         smallTransactionSize,
+		},
+		"return error when user has not enough utxos to cover fee": {
+			possessedUTXOs: 100,
+			targetSatoshis: 100,
+			txSize:         smallTransactionSize,
+		},
+		"return error when user has not enough utxos to cover fee for bigger tx": {
+			// Because the transaction size makes the fee = 2, one satoshi above the target satoshis is not enough.
+			possessedUTXOs: 101,
+			targetSatoshis: 100,
+			txSize:         transactionSizeForHigherFee,
+		},
+	}
+	for name, test := range testCasesErrors {
+		t.Run(name, func(t *testing.T) {
+			// given:
+			given, then, cleanup := testabilities.New(t)
+			defer cleanup()
+
+			// and:
+			funder := given.NewFunderService()
+
+			// and:
+			given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(test.possessedUTXOs).P2PKH().Stored()
+
+			// and:
+			basket := given.BasketFor(testusers.Alice).ThatPrefersSingleChange()
+
+			// when:
+			result, err := funder.Fund(ctx, test.targetSatoshis, test.txSize, basket, testusers.Alice.ID)
+
+			// then:
+			then.Result(result).WithError(err)
+		})
+	}
+
+	// CreateAction can receive args with inputs that aren't tracked by this wallet
+	// those are the test cases for handling such transactions with inputs.
+	testCasesForFundingWithoutAllocatingUTXO := map[string]struct {
+		possessedUTXOs int64
+		targetSatoshis int64
+		txSize         uint64
+		expectations   func(testabilities.SuccessFundingResultAssertion)
+	}{
+		"user has funded exactly the transaction and fee by himself": {
+			targetSatoshis: -1,
+			txSize:         smallTransactionSize,
+
+			expectations: func(thenResult testabilities.SuccessFundingResultAssertion) {
+				thenResult.DoesNotAllocateUTXOs().
+					HasNoChange().
+					HasFee(1)
+			},
+		},
+		"user has funded exactly the transaction and fee for bigger size of tx by himself": {
+			targetSatoshis: -2,
+			txSize:         transactionSizeForHigherFee,
+
+			expectations: func(thenResult testabilities.SuccessFundingResultAssertion) {
+				thenResult.DoesNotAllocateUTXOs().
+					HasNoChange().
+					HasFee(2)
+			},
+		},
+		"user has funded by himself more then the transaction and fee": {
+			targetSatoshis: -1001,
+			txSize:         smallTransactionSize,
+
+			expectations: func(thenResult testabilities.SuccessFundingResultAssertion) {
+				thenResult.DoesNotAllocateUTXOs().
+					HasChangeCount(1).ForAmount(1000).
+					HasFee(1)
+			},
+		},
+		"user has funded by himself the transaction but not the fee": {
+			possessedUTXOs: 1,
+
+			targetSatoshis: 0,
+			txSize:         smallTransactionSize,
+
+			expectations: func(thenResult testabilities.SuccessFundingResultAssertion) {
+				thenResult.HasAllocatedUTXOs().ForTotalAmount(1).
+					HasNoChange().
+					HasFee(1)
+			},
+		},
+		"user has funded by himself the transaction and part of the fee": {
+			possessedUTXOs: 1,
+
+			targetSatoshis: -1,
+			txSize:         transactionSizeForHigherFee,
+
+			expectations: func(thenResult testabilities.SuccessFundingResultAssertion) {
+				thenResult.HasAllocatedUTXOs().ForTotalAmount(1).
+					HasNoChange().
+					HasFee(2)
+			},
+		},
+	}
+	for name, test := range testCasesForFundingWithoutAllocatingUTXO {
+		t.Run(name, func(t *testing.T) {
+			// given:
+			given, then, cleanup := testabilities.New(t)
+			defer cleanup()
+
+			// and:
+			funder := given.NewFunderService()
+
+			// and:
+			given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(test.possessedUTXOs).P2PKH().Stored()
+
+			// and:
+			basket := given.BasketFor(testusers.Alice).ThatPrefersSingleChange()
+
+			// when:
+			result, err := funder.Fund(ctx, test.targetSatoshis, test.txSize, basket, testusers.Alice.ID)
+
+			// then:
+			test.expectations(then.Result(result).WithoutError(err))
+		})
+	}
+
+	testCasesFundWholeTransaction := map[string]struct {
+		havingUTXOsInDB func(testabilities.FunderFixture)
+		targetSatoshis  int64
+		txSize          uint64
+		expectations    func(testabilities.SuccessFundingResultAssertion)
+	}{
+		"target satoshis and fee are equal to the only one utxo satoshis": {
+			havingUTXOsInDB: func(given testabilities.FunderFixture) {
+				given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(101).P2PKH().Stored()
+			},
+
+			targetSatoshis: 100,
+			txSize:         smallTransactionSize,
+
+			expectations: func(thenResult testabilities.SuccessFundingResultAssertion) {
+				thenResult.HasAllocatedUTXOs().RowIndexes(0).
+					HasNoChange().
+					HasFee(1)
+			},
+		},
+		"adding utxo can increase the fee": {
+			havingUTXOsInDB: func(given testabilities.FunderFixture) {
+				given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(102).P2PKH().Stored()
+			},
+
+			targetSatoshis: 100,
+			txSize:         999,
+
+			expectations: func(thenResult testabilities.SuccessFundingResultAssertion) {
+				thenResult.HasAllocatedUTXOs().RowIndexes(0).
+					HasFee(2).
+					HasNoChange()
+			},
+		},
+		"user has a lot of small utxo to they will cover the target sats and fee": {
+			havingUTXOsInDB: func(given testabilities.FunderFixture) {
+				// Funder is collecting utxos by 1000 rows, so we need to have more than 1000 utxos to test this case.
+				for range 1600 {
+					given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(1).P2PKH().Stored()
+				}
+			},
+
+			targetSatoshis: 1363,
+			txSize:         smallTransactionSize,
+
+			expectations: func(thenResult testabilities.SuccessFundingResultAssertion) {
+				thenResult.HasAllocatedUTXOs().ForTotalAmount(1600).
+					HasNoChange()
+			},
+		},
+		"user has single big utxo and basket is aiming for smallest number of changes": {
+			havingUTXOsInDB: func(given testabilities.FunderFixture) {
+				given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(10101).P2PKH().Stored()
+			},
+
+			targetSatoshis: 100,
+			txSize:         smallTransactionSize,
+
+			expectations: func(thenResult testabilities.SuccessFundingResultAssertion) {
+				thenResult.HasAllocatedUTXOs().RowIndexes(0).
+					HasFee(1).
+					HasChangeCount(1).ForAmount(10000)
+			},
+		},
+		"allocate biggest utxos first": {
+			havingUTXOsInDB: func(given testabilities.FunderFixture) {
+				given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(200).P2PKH().Stored()
+				given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(100).P2PKH().Stored()
+				given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(10101).P2PKH().Stored()
+				given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(1).P2PKH().Stored()
+				given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(300).P2PKH().Stored()
+			},
+
+			targetSatoshis: 100,
+			txSize:         smallTransactionSize,
+
+			expectations: func(thenResult testabilities.SuccessFundingResultAssertion) {
+				thenResult.HasAllocatedUTXOs().RowIndexes(2).
+					HasFee(1).
+					HasChangeCount(1).ForAmount(10000)
+			},
+		},
+		"allocate several utxos and calculate the change from them": {
+			havingUTXOsInDB: func(given testabilities.FunderFixture) {
+				given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(200).P2PKH().Stored()
+				given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(100).P2PKH().Stored()
+				given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(1).P2PKH().Stored()
+				given.UTXO().OwnedBy(testusers.Alice).WithSatoshis(300).P2PKH().Stored()
+			},
+
+			targetSatoshis: 549,
+			txSize:         smallTransactionSize,
+
+			expectations: func(thenResult testabilities.SuccessFundingResultAssertion) {
+				thenResult.HasAllocatedUTXOs().RowIndexes(0, 1, 3).
+					HasFee(1).
+					HasChangeCount(1).ForAmount(50)
+			},
+		},
+	}
+	for name, test := range testCasesFundWholeTransaction {
+		t.Run(name, func(t *testing.T) {
+			// given:
+			given, then, cleanup := testabilities.New(t)
+			defer cleanup()
+
+			// and:
+			funder := given.NewFunderService()
+
+			// and:
+			test.havingUTXOsInDB(given)
+
+			// and:
+			basket := given.BasketFor(testusers.Alice).ThatPrefersSingleChange()
+
+			// when:
+			result, err := funder.Fund(ctx, test.targetSatoshis, test.txSize, basket, testusers.Alice.ID)
+
+			// then:
+			test.expectations(then.Result(result).WithoutError(err))
+
+		})
+	}
+}
+
+func TestFunderSQLFund(t *testing.T) {
+	const smallTransactionSize = 44
+	var ctx = context.Background()
 
 	t.Run("adding change increases the fee", func(t *testing.T) {
 		// given:
@@ -353,7 +293,7 @@ func TestFunderSQLFundSuccessResult(t *testing.T) {
 		funder := given.NewFunderService()
 
 		// when:
-		result, err := funder.Fund(ctx, -102, 990, desiredUTXONumberToPreferSingleChange, testDesiredUTXOValue, testusers.Alice.ID)
+		result, err := funder.Fund(ctx, -102, 990, nil, testusers.Alice.ID)
 
 		// then:
 		then.Result(result).WithoutError(err).
@@ -370,7 +310,7 @@ func TestFunderSQLFundSuccessResult(t *testing.T) {
 		funder := given.NewFunderService()
 
 		// when:
-		result, err := funder.Fund(ctx, -2, 999, desiredUTXONumberToPreferSingleChange, testDesiredUTXOValue, testusers.Alice.ID)
+		result, err := funder.Fund(ctx, -2, 999, nil, testusers.Alice.ID)
 
 		// then:
 		then.Result(result).WithoutError(err).
@@ -447,11 +387,12 @@ func TestFunderSQLFundSuccessResult(t *testing.T) {
 			funder := given.NewFunderService()
 
 			// when:
-			result, err := funder.Fund(ctx, targetSatoshis, smallTransactionSize, numberOfDesiredUTXOs, testDesiredUTXOValue, testusers.Alice.ID)
+			result, err := funder.Fund(ctx, targetSatoshis, smallTransactionSize, nil, testusers.Alice.ID)
 
 			// then:
 			then.Result(result).WithoutError(err).
 				HasChangeCount(test.expectedNumberOfChangeOutputs).ForAmount(test.expectedChangeValue)
 		})
 	}
+
 }

--- a/pkg/storage/internal/actions/funder/sql_test.go
+++ b/pkg/storage/internal/actions/funder/sql_test.go
@@ -319,6 +319,44 @@ func TestFunderSQLFund(t *testing.T) {
 			HasNoChange()
 	})
 
+	t.Run("produce single change when basket NumberOfDesiredUTXOs is 0", func(t *testing.T) {
+		// given:
+		given, then, cleanup := testabilities.New(t)
+		defer cleanup()
+
+		// and:
+		funder := given.NewFunderService()
+
+		// and:
+		basket := given.BasketFor(testusers.Alice).WithNumberOfDesiredUTXOs(0)
+
+		// when:
+		result, err := funder.Fund(ctx, -5001, smallTransactionSize, basket, testusers.Alice.ID)
+
+		// then:
+		then.Result(result).WithoutError(err).
+			HasChangeCount(1).ForAmount(5000)
+	})
+
+	t.Run("produce single change when basket NumberOfDesiredUTXOs is negative (value: -5)", func(t *testing.T) {
+		// given:
+		given, then, cleanup := testabilities.New(t)
+		defer cleanup()
+
+		// and:
+		funder := given.NewFunderService()
+
+		// and:
+		basket := given.BasketFor(testusers.Alice).WithNumberOfDesiredUTXOs(-5)
+
+		// when:
+		result, err := funder.Fund(ctx, -5001, smallTransactionSize, basket, testusers.Alice.ID)
+
+		// then:
+		then.Result(result).WithoutError(err).
+			HasChangeCount(1).ForAmount(5000)
+	})
+
 	testCasesSplitUserProvidedInputIntoChanges := map[string]struct {
 		expectedChangeValue           int
 		expectedNumberOfChangeOutputs int

--- a/pkg/storage/internal/actions/funder/sql_test.go
+++ b/pkg/storage/internal/actions/funder/sql_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-softwarelab/common/pkg/must"
 )
 
-func TestRefactoring(t *testing.T) {
+func TestFunderSQLFund(t *testing.T) {
 	const smallTransactionSize = 44
 	const transactionSizeForHigherFee = 1001
 	var ctx = context.Background()
@@ -278,11 +278,6 @@ func TestRefactoring(t *testing.T) {
 
 		})
 	}
-}
-
-func TestFunderSQLFund(t *testing.T) {
-	const smallTransactionSize = 44
-	var ctx = context.Background()
 
 	t.Run("adding change increases the fee", func(t *testing.T) {
 		// given:

--- a/pkg/storage/internal/actions/funder/sql_test.go
+++ b/pkg/storage/internal/actions/funder/sql_test.go
@@ -287,8 +287,11 @@ func TestFunderSQLFund(t *testing.T) {
 		// and:
 		funder := given.NewFunderService()
 
+		// and:
+		basket := given.BasketFor(testusers.Alice).ThatPrefersSingleChange()
+
 		// when:
-		result, err := funder.Fund(ctx, -102, 990, nil, testusers.Alice.ID)
+		result, err := funder.Fund(ctx, -102, 990, basket, testusers.Alice.ID)
 
 		// then:
 		then.Result(result).WithoutError(err).
@@ -304,8 +307,11 @@ func TestFunderSQLFund(t *testing.T) {
 		// and:
 		funder := given.NewFunderService()
 
+		// and:
+		basket := given.BasketFor(testusers.Alice).ThatPrefersSingleChange()
+
 		// when:
-		result, err := funder.Fund(ctx, -2, 999, nil, testusers.Alice.ID)
+		result, err := funder.Fund(ctx, -2, 999, basket, testusers.Alice.ID)
 
 		// then:
 		then.Result(result).WithoutError(err).
@@ -371,9 +377,6 @@ func TestFunderSQLFund(t *testing.T) {
 			// and it must be negative to simulate that user provides by himself the inputs to cover those values.
 			targetSatoshis := must.ConvertToInt64(-(test.expectedChangeValue + fee))
 
-			// and: this is the limit for number of changes we don't want to exceed (in those test cases)
-			const numberOfDesiredUTXOs = 3
-
 			// and:
 			given, then, cleanup := testabilities.New(t)
 			defer cleanup()
@@ -381,8 +384,11 @@ func TestFunderSQLFund(t *testing.T) {
 			// and:
 			funder := given.NewFunderService()
 
+			// and: basket with limit of 3 outputs
+			basket := given.BasketFor(testusers.Alice).WithNumberOfDesiredUTXOs(3)
+
 			// when:
-			result, err := funder.Fund(ctx, targetSatoshis, smallTransactionSize, nil, testusers.Alice.ID)
+			result, err := funder.Fund(ctx, targetSatoshis, smallTransactionSize, basket, testusers.Alice.ID)
 
 			// then:
 			then.Result(result).WithoutError(err).

--- a/pkg/storage/internal/actions/funder/testabilities/fixture_basket.go
+++ b/pkg/storage/internal/actions/funder/testabilities/fixture_basket.go
@@ -1,0 +1,44 @@
+package testabilities
+
+import (
+	"testing"
+
+	"github.com/4chain-ag/go-wallet-toolbox/pkg/storage/internal/testabilities/testusers"
+	"github.com/4chain-ag/go-wallet-toolbox/pkg/wdk"
+)
+
+const (
+	desiredUTXONumberToPreferSingleChange = 1
+	testDesiredUTXOValue                  = 1000
+)
+
+type BasketFixture interface {
+	ThatPrefersSingleChange() *wdk.TableOutputBasket
+}
+
+type basketFixture struct {
+	testing.TB
+	user testusers.User
+}
+
+func newBasketFixture(t testing.TB, user testusers.User) *basketFixture {
+	return &basketFixture{
+		TB:   t,
+		user: user,
+	}
+}
+
+func (f *basketFixture) ThatPrefersSingleChange() *wdk.TableOutputBasket {
+	return &wdk.TableOutputBasket{
+		BasketID: 1,
+		UserID:   f.user.ID,
+		BasketConfiguration: wdk.BasketConfiguration{
+			Name:                    "default",
+			NumberOfDesiredUTXOs:    desiredUTXONumberToPreferSingleChange,
+			MinimumDesiredUTXOValue: testDesiredUTXOValue,
+		},
+		CreatedAt: exampleDate,
+		UpdatedAt: exampleDate,
+		IsDeleted: false,
+	}
+}

--- a/pkg/storage/internal/actions/funder/testabilities/fixture_basket.go
+++ b/pkg/storage/internal/actions/funder/testabilities/fixture_basket.go
@@ -14,6 +14,7 @@ const (
 
 type BasketFixture interface {
 	ThatPrefersSingleChange() *wdk.TableOutputBasket
+	WithNumberOfDesiredUTXOs(i int) *wdk.TableOutputBasket
 }
 
 type basketFixture struct {
@@ -29,12 +30,16 @@ func newBasketFixture(t testing.TB, user testusers.User) *basketFixture {
 }
 
 func (f *basketFixture) ThatPrefersSingleChange() *wdk.TableOutputBasket {
+	return f.WithNumberOfDesiredUTXOs(desiredUTXONumberToPreferSingleChange)
+}
+
+func (f *basketFixture) WithNumberOfDesiredUTXOs(number int) *wdk.TableOutputBasket {
 	return &wdk.TableOutputBasket{
 		BasketID: 1,
 		UserID:   f.user.ID,
 		BasketConfiguration: wdk.BasketConfiguration{
 			Name:                    "default",
-			NumberOfDesiredUTXOs:    desiredUTXONumberToPreferSingleChange,
+			NumberOfDesiredUTXOs:    number,
 			MinimumDesiredUTXOValue: testDesiredUTXOValue,
 		},
 		CreatedAt: exampleDate,

--- a/pkg/storage/internal/actions/funder/testabilities/fixture_funder_sql.go
+++ b/pkg/storage/internal/actions/funder/testabilities/fixture_funder_sql.go
@@ -2,6 +2,7 @@ package testabilities
 
 import (
 	"testing"
+	"time"
 
 	"github.com/4chain-ag/go-wallet-toolbox/pkg/defs"
 	"github.com/4chain-ag/go-wallet-toolbox/pkg/internal/logging"
@@ -9,12 +10,16 @@ import (
 	"github.com/4chain-ag/go-wallet-toolbox/pkg/storage/internal/database"
 	"github.com/4chain-ag/go-wallet-toolbox/pkg/storage/internal/database/models"
 	"github.com/4chain-ag/go-wallet-toolbox/pkg/storage/internal/testabilities/dbfixtures"
+	"github.com/4chain-ag/go-wallet-toolbox/pkg/storage/internal/testabilities/testusers"
 	"github.com/stretchr/testify/require"
 )
+
+var exampleDate = time.Date(2006, 02, 01, 15, 4, 5, 7, time.UTC)
 
 type FunderFixture interface {
 	NewFunderService() *funder.SQL
 	UTXO() UserUTXOFixture
+	BasketFor(user testusers.User) BasketFixture
 }
 
 var feeModel = defs.FeeModel{
@@ -51,4 +56,8 @@ func (f *funderFixture) Save(utxo *models.UserUTXO) {
 	err := f.db.DB.Create(&utxo).Error
 	require.NoError(f.t, err)
 	f.createdUTXOs = append(f.createdUTXOs, utxo)
+}
+
+func (f *funderFixture) BasketFor(user testusers.User) BasketFixture {
+	return newBasketFixture(f.t, user)
 }

--- a/pkg/storage/internal/actions/funder/testabilities/fixture_utxo.go
+++ b/pkg/storage/internal/actions/funder/testabilities/fixture_utxo.go
@@ -70,6 +70,10 @@ func (f *userUtxoFixture) WithSatoshis(satoshis int64) UserUTXOFixture {
 }
 
 func (f *userUtxoFixture) Stored() {
+	if f.satoshis == 0 {
+		return
+	}
+
 	utxo := &models.UserUTXO{
 		UserID:             f.userID,
 		TxID:               f.txID,

--- a/pkg/storage/testabilities/mock_funder.go
+++ b/pkg/storage/testabilities/mock_funder.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/4chain-ag/go-wallet-toolbox/pkg/storage/internal/actions"
+	"github.com/4chain-ag/go-wallet-toolbox/pkg/wdk"
 )
 
 type MockFunder struct {
 }
 
-func (m *MockFunder) Fund(ctx context.Context, targetSat int64, currentTxSize uint64, numberOfDesiredUTXOs int, minimumDesiredUTXOValue uint64, userID int) (*actions.FundingResult, error) {
+func (m *MockFunder) Fund(ctx context.Context, targetSat int64, currentTxSize uint64, basket *wdk.TableOutputBasket, userID int) (*actions.FundingResult, error) {
 	return &actions.FundingResult{}, nil
 }


### PR DESCRIPTION
Next part of funder implementation.

Feature: change funder interface to use basket struct instead of plain numbers from it.

Additionally: refactoring of tests - grouping them into table tests.