### PR TITLE
feat: add function to run all services from queue in parallel.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/bsv-blockchain/universal-test-vectors v0.5.0
 	github.com/filecoin-project/go-jsonrpc v0.8.0
 	github.com/go-resty/resty/v2 v2.16.5
-	github.com/go-softwarelab/common v0.22.0
+	github.com/go-softwarelab/common v0.23.0
 	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/jarcoal/httpmock v1.4.0
 	github.com/mattn/go-sqlite3 v1.14.28

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/bsv-blockchain/universal-test-vectors v0.5.0
 	github.com/filecoin-project/go-jsonrpc v0.8.0
 	github.com/go-resty/resty/v2 v2.16.5
-	github.com/go-softwarelab/common v0.23.0
+	github.com/go-softwarelab/common v0.26.0
 	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/jarcoal/httpmock v1.4.0
 	github.com/mattn/go-sqlite3 v1.14.28

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-resty/resty/v2 v2.16.5 h1:hBKqmWrr7uRc3euHVqmh1HTHcKn99Smr7o5spptdhTM=
 github.com/go-resty/resty/v2 v2.16.5/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
-github.com/go-softwarelab/common v0.22.0 h1:/NH5kqB75J9w1KuQ2zZKA4q6ihCzJr3SkTNTjWb+RN0=
-github.com/go-softwarelab/common v0.22.0/go.mod h1:OBlpZUPWzz+YhTt+fQgHGTxgJBq3IDESJSIyOKC0/6Y=
+github.com/go-softwarelab/common v0.23.0 h1:NIorVZjwQ2EdmOsqy0ak23vDzq3RokIlpeZ+ufUxiSU=
+github.com/go-softwarelab/common v0.23.0/go.mod h1:OBlpZUPWzz+YhTt+fQgHGTxgJBq3IDESJSIyOKC0/6Y=
 github.com/go-sql-driver/mysql v1.7.0 h1:ueSltNNllEqE3qcWBTD0iQd3IpL/6U+mJxLkazJ7YPc=
 github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-resty/resty/v2 v2.16.5 h1:hBKqmWrr7uRc3euHVqmh1HTHcKn99Smr7o5spptdhTM=
 github.com/go-resty/resty/v2 v2.16.5/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
-github.com/go-softwarelab/common v0.23.0 h1:NIorVZjwQ2EdmOsqy0ak23vDzq3RokIlpeZ+ufUxiSU=
-github.com/go-softwarelab/common v0.23.0/go.mod h1:OBlpZUPWzz+YhTt+fQgHGTxgJBq3IDESJSIyOKC0/6Y=
+github.com/go-softwarelab/common v0.26.0 h1:tZJ3L+CshaAm/iBYmpIrgV8IcqPTOOGtJv9LPsUv4mw=
+github.com/go-softwarelab/common v0.26.0/go.mod h1:OBlpZUPWzz+YhTt+fQgHGTxgJBq3IDESJSIyOKC0/6Y=
 github.com/go-sql-driver/mysql v1.7.0 h1:ueSltNNllEqE3qcWBTD0iQd3IpL/6U+mJxLkazJ7YPc=
 github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=

--- a/pkg/internal/satoshi/satoshi.go
+++ b/pkg/internal/satoshi/satoshi.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 
 	"github.com/4chain-ag/go-wallet-toolbox/pkg/wdk/primitives"
-	"github.com/go-softwarelab/common/types"
+	"github.com/go-softwarelab/common/pkg/types"
 )
 
 type Value int64

--- a/pkg/services/internal/named_result.go
+++ b/pkg/services/internal/named_result.go
@@ -1,0 +1,16 @@
+package internal
+
+import "github.com/go-softwarelab/common/pkg/types"
+
+type NamedResult[V any] struct {
+	name string
+	types.Result[V]
+}
+
+func NewNamedResult[V any](name string, result *types.Result[V]) *NamedResult[V] {
+	return &NamedResult[V]{name: name, Result: *result}
+}
+
+func (i *NamedResult[V]) Name() string {
+	return i.name
+}

--- a/pkg/services/internal/parallel.go
+++ b/pkg/services/internal/parallel.go
@@ -20,10 +20,11 @@ func MapParallel[E any, R any](ctx context.Context, sequence iter.Seq[E], runner
 
 		ctx, cancel := context.WithCancel(ctx)
 
+	startGoRoutines:
 		for v := range sequence {
 			select {
 			case <-ctx.Done():
-				break
+				break startGoRoutines
 			default:
 				wg.Add(1)
 				go func(v E) {

--- a/pkg/services/internal/parallel.go
+++ b/pkg/services/internal/parallel.go
@@ -1,0 +1,69 @@
+package internal
+
+import (
+	"context"
+	"iter"
+	"sync"
+)
+
+func MapParallel[E any, R any](ctx context.Context, sequence iter.Seq[E], runner func(context.Context, E) R) iter.Seq[R] {
+	if sequence == nil {
+		return func(yield func(R) bool) {}
+	}
+
+	return func(yield func(R) bool) {
+		wg := &sync.WaitGroup{}
+
+		results := make(chan R, 100)
+
+		ctx, cancel := context.WithCancel(ctx)
+
+		for v := range sequence {
+			wg.Add(1)
+			go func(v E) {
+				defer wg.Done()
+
+				var result R
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					result = runner(ctx, v)
+				}
+
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					results <- result
+				}
+
+			}(v)
+		}
+
+		go func() {
+			wg.Wait()
+			close(results)
+		}()
+
+		for {
+			select {
+			case <-ctx.Done():
+				cancel()
+				return
+			case res, ok := <-results:
+				if !ok {
+					cancel()
+					return
+				}
+				if !yield(res) {
+					cancel()
+					for range results {
+						// drain the channel to avoid memory leaks
+					}
+					return
+				}
+			}
+		}
+	}
+}

--- a/pkg/services/internal/parallel_test.go
+++ b/pkg/services/internal/parallel_test.go
@@ -1,0 +1,182 @@
+package internal_test
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"testing"
+	"time"
+
+	"github.com/4chain-ag/go-wallet-toolbox/pkg/services/internal"
+	"github.com/go-softwarelab/common/pkg/seq"
+	"github.com/go-softwarelab/common/pkg/to"
+	"github.com/go-softwarelab/common/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapParallel(t *testing.T) {
+	namesOfBigNumberTaskResults := seq.Map(seq.RangeTo(1000), to.StringFromInteger)
+	bigNumberOfTasksResults := seq.Collect(seq.Map(namesOfBigNumberTaskResults, types.SuccessResult))
+
+	testCases := map[string]struct {
+		expectedResults []*types.Result[string]
+		typeOfTask      func(result *types.Result[string]) *Task
+	}{
+		"handle empty sequence in input": {
+			expectedResults: nil,
+			typeOfTask:      FastTask,
+		},
+		"runs fast tasks in parallel": {
+			expectedResults: []*types.Result[string]{
+				types.SuccessResult("task-success"),
+				types.SuccessResult("task-ok"),
+				types.SuccessResult("task-done"),
+			},
+			typeOfTask: FastTask,
+		},
+		"runs tasks of various duration in parallel": {
+			expectedResults: []*types.Result[string]{
+				types.SuccessResult("task-success"),
+				types.SuccessResult("task-ok"),
+				types.SuccessResult("task-done"),
+			},
+			typeOfTask: SlowTask,
+		},
+		"handle single error in task": {
+			expectedResults: []*types.Result[string]{
+				types.SuccessResult("task-success"),
+				types.FailureResult[string](errors.New("failure")),
+				types.SuccessResult("task-done"),
+			},
+			typeOfTask: FastTask,
+		},
+		"handle all errors in tasks": {
+			expectedResults: []*types.Result[string]{
+				types.FailureResult[string](errors.New("failure")),
+				types.FailureResult[string](errors.New("not-ok")),
+				types.FailureResult[string](errors.New("bad thing happened")),
+			},
+			typeOfTask: FastTask,
+		},
+		"handle run big number of tasks short tasks in parallel": {
+			expectedResults: bigNumberOfTasksResults,
+			typeOfTask:      FastTask,
+		},
+		"handle run big number of tasks of various duration in parallel": {
+			expectedResults: bigNumberOfTasksResults,
+			typeOfTask:      SlowTask,
+		},
+	}
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// and:
+			tasks := seq.Map(seq.FromSlice(test.expectedResults), test.typeOfTask)
+
+			// when:
+			taskResults := internal.MapParallel(context.Background(), tasks, func(_ context.Context, task *Task) *types.Result[string] {
+				return task.Run(t)
+			})
+
+			results := seq.Collect(taskResults)
+
+			// and:
+			assert.ElementsMatch(t, results, test.expectedResults)
+		})
+	}
+
+	t.Run("handle nil sequence", func(t *testing.T) {
+
+		// when:
+		taskResults := internal.MapParallel(context.Background(), nil, func(_ context.Context, task *Task) *types.Result[string] {
+			return task.Run(t)
+		})
+
+		results := seq.Collect(taskResults)
+
+		// and:
+		assert.Empty(t, results, "result should be empty")
+	})
+
+	t.Run("handle finishing sequence earlier", func(t *testing.T) {
+		// given:
+		expectedResults := []*types.Result[string]{
+			types.SuccessResult("task-success"),
+			types.SuccessResult("task-ok"),
+			types.SuccessResult("task-done"),
+		}
+
+		// and:
+		tasks := seq.Map(seq.FromSlice(expectedResults), FastTask)
+
+		// when:
+		taskResults := internal.MapParallel(context.Background(), tasks, func(_ context.Context, task *Task) *types.Result[string] {
+			return task.Run(t)
+		})
+
+		taskResults = seq.Take(taskResults, 1)
+
+		results := seq.Collect(taskResults)
+
+		// and:
+		assert.Len(t, results, 1)
+		assert.Contains(t, expectedResults, results[0], "result should be one of the expected results")
+	})
+
+	t.Run("handle context closed earlier", func(t *testing.T) {
+		// given:
+		expectedResults := bigNumberOfTasksResults
+
+		// and:
+		tasks := seq.Map(seq.FromSlice(expectedResults), SlowTask)
+
+		// when: the context is closed
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		// and:
+		taskResults := internal.MapParallel(ctx, tasks, func(_ context.Context, task *Task) *types.Result[string] {
+			return task.Run(t)
+		})
+
+		results := seq.Collect(taskResults)
+
+		// and:
+		assert.Empty(t, results)
+	})
+}
+
+type Task struct {
+	name    string
+	process func(tb testing.TB) types.Result[string]
+}
+
+func (t *Task) Run(tb testing.TB) *types.Result[string] {
+	tb.Logf("Task %s started", t.name)
+	res := t.process(tb)
+	tb.Logf("Task %s finished", t.name)
+	return &res
+}
+
+func FastTask(result *types.Result[string]) *Task {
+	return &Task{
+		name: result.OrElseGet(func() string {
+			return result.GetError().Error()
+		}),
+		process: func(t testing.TB) types.Result[string] {
+			return *result
+		},
+	}
+}
+
+func SlowTask(result *types.Result[string]) *Task {
+	return &Task{
+		name: result.OrElseGet(func() string {
+			return result.GetError().Error()
+		}),
+		process: func(t testing.TB) types.Result[string] {
+			delay := rand.IntN(500)
+			time.Sleep(time.Duration(delay) * time.Millisecond)
+			return *result
+		},
+	}
+}

--- a/pkg/services/internal/servicequeue/queues_test.go
+++ b/pkg/services/internal/servicequeue/queues_test.go
@@ -3,7 +3,6 @@ package servicequeue_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/4chain-ag/go-wallet-toolbox/pkg/internal/logging"
@@ -139,7 +138,7 @@ func TestQueueOneByOne(t *testing.T) {
 		},
 		"handle panic from service": {
 			services: []TestService{
-				TestService{Name: "panicing"}.Panicking(),
+				TestService{Name: "panicking"}.Panicking(),
 			},
 			expectedResult: nil,
 			errorExpectation: func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
@@ -148,7 +147,7 @@ func TestQueueOneByOne(t *testing.T) {
 		},
 		"return result of second service if first service would panic": {
 			services: []TestService{
-				TestService{Name: "panicing"}.Panicking(),
+				TestService{Name: "panicking"}.Panicking(),
 				TestService{Name: "ok"}.Successful(),
 			},
 			expectedResult:   &TestServiceResult{200, "success"},
@@ -210,7 +209,7 @@ func TestQueueOneByOne(t *testing.T) {
 			// and:
 			queue := servicequeue.NewQueue2(
 				logging.NewTestLogger(t),
-				"Do3",
+				"Do2",
 				services...,
 			)
 
@@ -361,7 +360,7 @@ func TestQueueParallel(t *testing.T) {
 			// and:
 			queue := servicequeue.NewQueue2(
 				logging.NewTestLogger(t),
-				"Do3",
+				"Do2",
 				services...,
 			)
 
@@ -405,23 +404,23 @@ func TestQueueParallel(t *testing.T) {
 	}{
 		"handle panic from service": {
 			services: []TestService{
-				TestService{Name: "panicing"}.Panicking(),
+				TestService{Name: "panicking"}.Panicking(),
 			},
 			expectedResults: []*servicequeue.NamedResult[*TestServiceResult]{
 				// Error is not exactly the same, because it contains more context about the source of the panic, but ErrorIs should be the same.
-				servicequeue.NewNamedResult("panicing", types.FailureResult[*TestServiceResult](errorFromPanic)),
+				servicequeue.NewNamedResult("panicking", types.FailureResult[*TestServiceResult](errorFromPanic)),
 			},
 			errorExpectation: assert.NoError,
 		},
 		"handle panic of one service between multiple services": {
 			services: []TestService{
 				TestService{Name: "successful"}.Successful(),
-				TestService{Name: "panicing"}.Panicking(),
+				TestService{Name: "panicking"}.Panicking(),
 				TestService{Name: "ok"}.Successful(),
 			},
 			expectedResults: []*servicequeue.NamedResult[*TestServiceResult]{
 				servicequeue.NewNamedResult("successful", types.SuccessResult(&TestServiceResult{200, "success"})),
-				servicequeue.NewNamedResult("panicing", types.FailureResult[*TestServiceResult](errorFromPanic)),
+				servicequeue.NewNamedResult("panicking", types.FailureResult[*TestServiceResult](errorFromPanic)),
 				servicequeue.NewNamedResult("ok", types.SuccessResult(&TestServiceResult{200, "success"})),
 			},
 			errorExpectation: assert.NoError,
@@ -445,10 +444,10 @@ func TestQueueParallel(t *testing.T) {
 			// when:
 			results, err := queue.All(context.Background())
 
-			// debug: show example of error from panicing service
+			// debug: show example of error from panicking service
 			slices.ForEach(results, func(result *servicequeue.NamedResult[*TestServiceResult]) {
 				if result.IsError() {
-					fmt.Println(result.GetError())
+					t.Log(result.GetError())
 				}
 			})
 
@@ -525,7 +524,7 @@ func TestQueueParallel(t *testing.T) {
 			// and:
 			queue := servicequeue.NewQueue2(
 				logging.NewTestLogger(t),
-				"Do3",
+				"Do2",
 				services...,
 			)
 

--- a/pkg/services/internal/servicequeue/queues_test.go
+++ b/pkg/services/internal/servicequeue/queues_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/4chain-ag/go-wallet-toolbox/pkg/internal/logging"
 	"github.com/4chain-ag/go-wallet-toolbox/pkg/services/internal/servicequeue"
 	"github.com/go-softwarelab/common/pkg/slices"
+	"github.com/go-softwarelab/common/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,17 +16,17 @@ const secondArgument = "test"
 const thirdArgument = 1
 const fourthArgument = true
 
-func TestQueue(t *testing.T) {
+func TestQueueOneByOne(t *testing.T) {
 	tests := map[string]struct {
 		services         []TestService
-		expectedResult   *Result
+		expectedResult   *TestServiceResult
 		errorExpectation func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool
 	}{
 		"single service returning success should return success": {
 			services: []TestService{
 				TestService{Name: "successful"}.Successful(),
 			},
-			expectedResult:   &Result{200, "success"},
+			expectedResult:   &TestServiceResult{200, "success"},
 			errorExpectation: assert.NoError,
 		},
 		"single service returning error should return error": {
@@ -66,7 +67,7 @@ func TestQueue(t *testing.T) {
 				TestService{Name: "should-not-be-called-1"}.ShouldNotBeCalled(),
 				TestService{Name: "should-not-be-called-2"}.ShouldNotBeCalled(),
 			},
-			expectedResult:   &Result{200, "success"},
+			expectedResult:   &TestServiceResult{200, "success"},
 			errorExpectation: assert.NoError,
 		},
 		"first service returning error but second returning success should return second result": {
@@ -75,7 +76,7 @@ func TestQueue(t *testing.T) {
 				TestService{Name: "success-service"}.Successful(),
 				TestService{Name: "should-not-be-called"}.ShouldNotBeCalled(),
 			},
-			expectedResult:   &Result{200, "success"},
+			expectedResult:   &TestServiceResult{200, "success"},
 			errorExpectation: assert.NoError,
 		},
 		"first service returning nil but second returning success should return second result": {
@@ -84,7 +85,7 @@ func TestQueue(t *testing.T) {
 				TestService{Name: "success-service"}.Successful(),
 				TestService{Name: "should-not-be-called"}.ShouldNotBeCalled(),
 			},
-			expectedResult:   &Result{200, "success"},
+			expectedResult:   &TestServiceResult{200, "success"},
 			errorExpectation: assert.NoError,
 		},
 		"first and second services returning error but third returning success should return third result": {
@@ -94,7 +95,7 @@ func TestQueue(t *testing.T) {
 				TestService{Name: "success-service"}.Successful(),
 				TestService{Name: "should-not-be-called"}.ShouldNotBeCalled(),
 			},
-			expectedResult:   &Result{200, "success"},
+			expectedResult:   &TestServiceResult{200, "success"},
 			errorExpectation: assert.NoError,
 		},
 		"first and second services returning nil but third returning success should return third result": {
@@ -104,7 +105,7 @@ func TestQueue(t *testing.T) {
 				TestService{Name: "success-service"}.Successful(),
 				TestService{Name: "should-not-be-called"}.ShouldNotBeCalled(),
 			},
-			expectedResult:   &Result{200, "success"},
+			expectedResult:   &TestServiceResult{200, "success"},
 			errorExpectation: assert.NoError,
 		},
 		"first service returning error, second returning nil, third returning success should return third result": {
@@ -114,7 +115,7 @@ func TestQueue(t *testing.T) {
 				TestService{Name: "success-service"}.Successful(),
 				TestService{Name: "should-not-be-called"}.ShouldNotBeCalled(),
 			},
-			expectedResult:   &Result{200, "success"},
+			expectedResult:   &TestServiceResult{200, "success"},
 			errorExpectation: assert.NoError,
 		},
 		"first service returning nil, second returning error, third returning success should return third result": {
@@ -124,7 +125,7 @@ func TestQueue(t *testing.T) {
 				TestService{Name: "success-service"}.Successful(),
 				TestService{Name: "should-not-be-called"}.ShouldNotBeCalled(),
 			},
-			expectedResult:   &Result{200, "success"},
+			expectedResult:   &TestServiceResult{200, "success"},
 			errorExpectation: assert.NoError,
 		},
 		"empty queue should return error": {
@@ -137,7 +138,7 @@ func TestQueue(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name+": Queue", func(t *testing.T) {
 			// given:
-			services := slices.Map(test.services, func(s TestService) *servicequeue.Service[*Result] {
+			services := slices.Map(test.services, func(s TestService) *servicequeue.Service[*TestServiceResult] {
 				service := s.NewTest(t)
 				return servicequeue.NewService(service.Name, service.Do)
 			})
@@ -159,7 +160,7 @@ func TestQueue(t *testing.T) {
 
 		t.Run(name+": Queue1", func(t *testing.T) {
 			// given:
-			services := slices.Map(test.services, func(s TestService) *servicequeue.Service1[string, *Result] {
+			services := slices.Map(test.services, func(s TestService) *servicequeue.Service1[string, *TestServiceResult] {
 				service := s.NewTest(t)
 				return servicequeue.NewService1(service.Name, service.Do1)
 			})
@@ -181,7 +182,7 @@ func TestQueue(t *testing.T) {
 
 		t.Run(name+": Queue2", func(t *testing.T) {
 			// given:
-			services := slices.Map(test.services, func(s TestService) *servicequeue.Service2[string, int, *Result] {
+			services := slices.Map(test.services, func(s TestService) *servicequeue.Service2[string, int, *TestServiceResult] {
 				service := s.NewTest(t)
 				return servicequeue.NewService2(service.Name, service.Do2)
 			})
@@ -203,7 +204,7 @@ func TestQueue(t *testing.T) {
 
 		t.Run(name+": Queue3", func(t *testing.T) {
 			// given:
-			services := slices.Map(test.services, func(s TestService) *servicequeue.Service3[string, int, bool, *Result] {
+			services := slices.Map(test.services, func(s TestService) *servicequeue.Service3[string, int, bool, *TestServiceResult] {
 				service := s.NewTest(t)
 				return servicequeue.NewService3(service.Name, service.Do3)
 			})
@@ -225,7 +226,172 @@ func TestQueue(t *testing.T) {
 	}
 }
 
-type Result struct {
+func TestQueueParallel(t *testing.T) {
+	testCases := map[string]struct {
+		services         []TestService
+		expectedResults  []*servicequeue.NamedResult[*TestServiceResult]
+		errorExpectation func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool
+	}{
+		"empty queue should return error": {
+			services:         []TestService{},
+			expectedResults:  nil,
+			errorExpectation: assert.Error,
+		},
+		"single service successful result": {
+			services: []TestService{
+				TestService{Name: "successful"}.Successful(),
+			},
+			expectedResults: []*servicequeue.NamedResult[*TestServiceResult]{
+				servicequeue.NewNamedResult("successful", types.SuccessResult(&TestServiceResult{200, "success"})),
+			},
+			errorExpectation: assert.NoError,
+		},
+		"single service failure result": {
+			services: []TestService{
+				TestService{Name: "failing"}.Failing(),
+			},
+			expectedResults: []*servicequeue.NamedResult[*TestServiceResult]{
+				servicequeue.NewNamedResult("failing", types.FailureResult[*TestServiceResult](errors.New("some error occurred"))),
+			},
+			errorExpectation: assert.NoError,
+		},
+		"single service nil result": {
+			services: []TestService{
+				TestService{Name: "nil-service"}.ReturningNilResult(),
+			},
+			expectedResults: []*servicequeue.NamedResult[*TestServiceResult]{
+				servicequeue.NewNamedResult("nil-service", types.FailureResult[*TestServiceResult](servicequeue.ErrEmptyResult)),
+			},
+			errorExpectation: assert.NoError,
+		},
+		"handle panic from service": {
+			services: []TestService{
+				TestService{Name: "panicing"}.Panicking(),
+			},
+			expectedResults: []*servicequeue.NamedResult[*TestServiceResult]{
+				servicequeue.NewNamedResult("panicing", types.FailureResult[*TestServiceResult](errors.New("some panic occurred"))),
+			},
+			errorExpectation: assert.NoError,
+		},
+		"multiple services with different results": {
+			services: []TestService{
+				TestService{Name: "successful"}.Successful(),
+				TestService{Name: "failing"}.Failing(),
+				TestService{Name: "ok"}.Successful(),
+				TestService{Name: "nil-service"}.ReturningNilResult(),
+				TestService{Name: "bad-thing-happened"}.Failing(),
+				TestService{Name: "good-job"}.Successful(),
+				TestService{Name: "panicing"}.Panicking(),
+			},
+			expectedResults: []*servicequeue.NamedResult[*TestServiceResult]{
+				servicequeue.NewNamedResult("successful", types.SuccessResult(&TestServiceResult{200, "success"})),
+				servicequeue.NewNamedResult("failing", types.FailureResult[*TestServiceResult](errors.New("some error occurred"))),
+				servicequeue.NewNamedResult("ok", types.SuccessResult(&TestServiceResult{200, "success"})),
+				servicequeue.NewNamedResult("nil-service", types.FailureResult[*TestServiceResult](servicequeue.ErrEmptyResult)),
+				servicequeue.NewNamedResult("bad-thing-happened", types.FailureResult[*TestServiceResult](errors.New("some error occurred"))),
+				servicequeue.NewNamedResult("good-job", types.SuccessResult(&TestServiceResult{200, "success"})),
+				servicequeue.NewNamedResult("panicing", types.FailureResult[*TestServiceResult](errors.New("some panic occurred"))),
+			},
+			errorExpectation: assert.NoError,
+		},
+	}
+	for name, test := range testCases {
+		t.Run(name+": Queue", func(t *testing.T) {
+			// given:
+			services := slices.Map(test.services, func(s TestService) *servicequeue.Service[*TestServiceResult] {
+				service := s.NewTest(t)
+				return servicequeue.NewService(service.Name, service.Do)
+			})
+
+			// and:
+			queue := servicequeue.NewQueue(
+				logging.NewTestLogger(t),
+				"Do",
+				services...,
+			)
+
+			// when:
+			results, err := queue.All(context.Background())
+
+			// then:
+			test.errorExpectation(t, err)
+			assert.Len(t, results, len(test.expectedResults))
+			assert.ElementsMatch(t, test.expectedResults, results)
+		})
+
+		t.Run(name+": Queue1", func(t *testing.T) {
+			// given:
+			services := slices.Map(test.services, func(s TestService) *servicequeue.Service1[string, *TestServiceResult] {
+				service := s.NewTest(t)
+				return servicequeue.NewService1(service.Name, service.Do1)
+			})
+
+			// and:
+			queue := servicequeue.NewQueue1(
+				logging.NewTestLogger(t),
+				"Do1",
+				services...,
+			)
+
+			// when:
+			results, err := queue.All(context.Background(), secondArgument)
+
+			// then:
+			test.errorExpectation(t, err)
+			assert.Len(t, results, len(test.expectedResults))
+			assert.ElementsMatch(t, test.expectedResults, results)
+		})
+
+		t.Run(name+": Queue2", func(t *testing.T) {
+			// given:
+			services := slices.Map(test.services, func(s TestService) *servicequeue.Service2[string, int, *TestServiceResult] {
+				service := s.NewTest(t)
+				return servicequeue.NewService2(service.Name, service.Do2)
+			})
+
+			// and:
+			queue := servicequeue.NewQueue2(
+				logging.NewTestLogger(t),
+				"Do3",
+				services...,
+			)
+
+			// when:
+			results, err := queue.All(context.Background(), secondArgument, thirdArgument)
+
+			// then:
+			test.errorExpectation(t, err)
+			assert.Len(t, results, len(test.expectedResults))
+			assert.ElementsMatch(t, test.expectedResults, results)
+		})
+
+		t.Run(name+": Queue3", func(t *testing.T) {
+			// given:
+			services := slices.Map(test.services, func(s TestService) *servicequeue.Service3[string, int, bool, *TestServiceResult] {
+				service := s.NewTest(t)
+				return servicequeue.NewService3(service.Name, service.Do3)
+			})
+
+			// and:
+			queue := servicequeue.NewQueue3(
+				logging.NewTestLogger(t),
+				"Do3",
+				services...,
+			)
+
+			// when:
+			results, err := queue.All(context.Background(), secondArgument, thirdArgument, fourthArgument)
+
+			// then:
+			test.errorExpectation(t, err)
+			assert.Len(t, results, len(test.expectedResults))
+			assert.ElementsMatch(t, test.expectedResults, results)
+		})
+	}
+
+}
+
+type TestServiceResult struct {
 	StatusCode int
 	Status     string
 }
@@ -233,39 +399,39 @@ type Result struct {
 type TestService struct {
 	Name         string
 	t            testing.TB
-	createResult func() (*Result, error)
+	createResult func() (*TestServiceResult, error)
 }
 
 func (s TestService) Successful() TestService {
-	s.createResult = func() (*Result, error) {
-		return &Result{200, "success"}, nil
+	s.createResult = func() (*TestServiceResult, error) {
+		return &TestServiceResult{200, "success"}, nil
 	}
 	return s
 }
 
 func (s TestService) Failing() TestService {
-	s.createResult = func() (*Result, error) {
+	s.createResult = func() (*TestServiceResult, error) {
 		return nil, errors.New("some error occurred")
 	}
 	return s
 }
 
 func (s TestService) ReturningNilResult() TestService {
-	s.createResult = func() (*Result, error) {
+	s.createResult = func() (*TestServiceResult, error) {
 		return nil, nil
 	}
 	return s
 }
 
 func (s TestService) Panicking() TestService {
-	s.createResult = func() (*Result, error) {
+	s.createResult = func() (*TestServiceResult, error) {
 		panic("some panic occurred")
 	}
 	return s
 }
 
 func (s TestService) ShouldNotBeCalled() TestService {
-	s.createResult = func() (*Result, error) {
+	s.createResult = func() (*TestServiceResult, error) {
 		s.t.Fatalf("service %s shouldn't be called, but was.", s.Name)
 		return nil, nil
 	}
@@ -277,22 +443,22 @@ func (s TestService) NewTest(t testing.TB) *TestService {
 	return &s
 }
 
-func (s *TestService) Do(ctx context.Context) (*Result, error) {
+func (s *TestService) Do(ctx context.Context) (*TestServiceResult, error) {
 	assert.NotNil(s.t, ctx, "expect to receive non-nil context as 1st argument")
 	return s.createResult()
 }
 
-func (s *TestService) Do1(ctx context.Context, str string) (*Result, error) {
+func (s *TestService) Do1(ctx context.Context, str string) (*TestServiceResult, error) {
 	assert.Equal(s.t, secondArgument, str, "expect to receive %#v as 2nd argument", secondArgument)
 	return s.Do(ctx)
 }
 
-func (s *TestService) Do2(ctx context.Context, str string, i int) (*Result, error) {
+func (s *TestService) Do2(ctx context.Context, str string, i int) (*TestServiceResult, error) {
 	assert.Equal(s.t, thirdArgument, i, "expect to receive %#v as 3rd argument", thirdArgument)
 	return s.Do1(ctx, str)
 }
 
-func (s *TestService) Do3(ctx context.Context, str string, i int, boolean bool) (*Result, error) {
+func (s *TestService) Do3(ctx context.Context, str string, i int, boolean bool) (*TestServiceResult, error) {
 	assert.Equal(s.t, fourthArgument, boolean, "expect to receive %#v as 4th argument", fourthArgument)
 	return s.Do2(ctx, str, i)
 }

--- a/pkg/services/internal/servicequeue/result.go
+++ b/pkg/services/internal/servicequeue/result.go
@@ -1,0 +1,13 @@
+package servicequeue
+
+import (
+	"github.com/4chain-ag/go-wallet-toolbox/pkg/services/internal"
+	"github.com/go-softwarelab/common/pkg/types"
+)
+
+type NamedResult[R any] = internal.NamedResult[R]
+
+func NewNamedResult[R any](name string, result *types.Result[R]) *NamedResult[R] {
+	//nolint:unconvert // cannot skip the conversion, because compiler is failing
+	return (*NamedResult[R])(internal.NewNamedResult(name, result))
+}


### PR DESCRIPTION
The goal of this PR is to prepare a method on servicequeue that would allow to call all the services in parallel and receive their results. This will be used in Wallet Services to broadcast transaction to all registered services.