### PR TITLE
feat: create arc service to broadcast through arc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/bsv-blockchain/universal-test-vectors v0.5.0
 	github.com/filecoin-project/go-jsonrpc v0.8.0
 	github.com/go-resty/resty/v2 v2.16.5
-	github.com/go-softwarelab/common v0.29.0
+	github.com/go-softwarelab/common v0.29.1
 	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/jarcoal/httpmock v1.4.0
 	github.com/mattn/go-sqlite3 v1.14.28

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-resty/resty/v2 v2.16.5 h1:hBKqmWrr7uRc3euHVqmh1HTHcKn99Smr7o5spptdhTM=
 github.com/go-resty/resty/v2 v2.16.5/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
-github.com/go-softwarelab/common v0.29.0 h1:2+OGjeIkGyN8poHm+yI/hFYZ12jrf7UXgR919AS2vAc=
-github.com/go-softwarelab/common v0.29.0/go.mod h1:OBlpZUPWzz+YhTt+fQgHGTxgJBq3IDESJSIyOKC0/6Y=
+github.com/go-softwarelab/common v0.29.1 h1:IbnXw4qzKinMqeEB8aD3N9bzmMAxcpXFDRVqlvZObCQ=
+github.com/go-softwarelab/common v0.29.1/go.mod h1:OBlpZUPWzz+YhTt+fQgHGTxgJBq3IDESJSIyOKC0/6Y=
 github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=

--- a/pkg/services/internal/arc/arc_config.go
+++ b/pkg/services/internal/arc/arc_config.go
@@ -1,0 +1,10 @@
+package arc
+
+type Config struct {
+	URL           string
+	Token         string
+	DeploymentID  string
+	WaitFor       string
+	CallbackURL   string
+	CallbackToken string
+}

--- a/pkg/services/internal/arc/arc_error.go
+++ b/pkg/services/internal/arc/arc_error.go
@@ -1,0 +1,27 @@
+package arc
+
+import "fmt"
+
+// APIError represents an error returned by the ARC API when status code is 4xx.
+type APIError struct {
+	Type      string `json:"type"`
+	Title     string `json:"title"`
+	Status    int    `json:"status"`
+	Detail    string `json:"detail"`
+	Instance  string `json:"instance"`
+	TxID      string `json:"txid"`
+	ExtraInfo string `json:"extraInfo"`
+}
+
+// Error returns the error string it's the implementation of the error interface.
+func (a *APIError) Error() string {
+	if a.IsEmpty() {
+		return "ARC error: empty (or not in json) response"
+	}
+	return fmt.Sprintf("ARC error: %s <txID: %s> %s", a.Title, a.TxID, a.Detail)
+}
+
+// IsEmpty checks if the error is empty indicating that we could not parse the error response.
+func (a *APIError) IsEmpty() bool {
+	return a == nil || a.Status == 0
+}

--- a/pkg/services/internal/arc/arc_service.go
+++ b/pkg/services/internal/arc/arc_service.go
@@ -64,11 +64,11 @@ func NewARCService(logger *slog.Logger, httpClient *resty.Client, config Config)
 // PostBeef attempts to post beef with given txIDs
 func (s *Service) PostBeef(ctx context.Context, beef *transaction.Beef, txids []string) (*results.PostBEEF, error) {
 	beefTxs := seq2.Values(seq2.FromMap(beef.Transactions))
-	canBeV1 := seq.Every(beefTxs, func(tx *transaction.BeefTx) bool {
+	canBeSerializedToBEEFV1 := seq.Every(beefTxs, func(tx *transaction.BeefTx) bool {
 		return tx.DataFormat != transaction.TxIDOnly && tx.Transaction != nil
 	})
 
-	if !canBeV1 {
+	if !canBeSerializedToBEEFV1 {
 		return nil, fmt.Errorf("arc is not supporting beef v2 and provided beef cannot be converted to v1")
 	}
 
@@ -98,8 +98,9 @@ func (s *Service) PostBeef(ctx context.Context, beef *transaction.Beef, txids []
 }
 
 func toHex(beef *transaction.Beef) (string, error) {
-	// this is a temporary solution until go-sdk would implement correctly BEEF serialization
-	// We want to search for the subject transaction and convert it to BEEF hex.
+	// This is a temporary solution until go-sdk properly implements BEEF serialization
+	// It searches for the subject transaction in transaction.Beef and serializes this one to BEEF hex.
+	// For now, it's not supporting more than one subject transaction.
 	idToTx := seq2.FromMap(beef.Transactions)
 
 	// inDegree will contain the number of transactions for which the given tx is a parent

--- a/pkg/services/internal/arc/arc_service.go
+++ b/pkg/services/internal/arc/arc_service.go
@@ -1,0 +1,198 @@
+package arc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/4chain-ag/go-wallet-toolbox/pkg/internal/logging"
+	"github.com/4chain-ag/go-wallet-toolbox/pkg/services/internal/httpx"
+	"github.com/4chain-ag/go-wallet-toolbox/pkg/services/results"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/go-resty/resty/v2"
+	"github.com/go-softwarelab/common/pkg/is"
+	"github.com/go-softwarelab/common/pkg/seq"
+	"github.com/go-softwarelab/common/pkg/seq2"
+)
+
+// Custom ARC defined http status codes
+const (
+	StatusNotExtendedFormat             = 460
+	StatusFeeTooLow                     = 465
+	StatusCumulativeFeeValidationFailed = 473
+)
+
+var ErrProblematicStatus = errors.New("arc returned problematic status")
+
+type Service struct {
+	logger       *slog.Logger
+	httpClient   *resty.Client
+	config       Config
+	broadcastURL string
+}
+
+// NewARCService creates a new arc service.
+func NewARCService(logger *slog.Logger, httpClient *resty.Client, config Config) *Service {
+	if httpClient == nil {
+		httpClient = resty.New()
+	}
+
+	headers := httpx.NewHeaders().
+		AcceptJSON().
+		ContentTypeJSON().
+		UserAgent().Value("go-wallet-toolbox").
+		Authorization().IfNotEmpty(config.Token).
+		Set("XDeployment-ID").OrDefault(config.DeploymentID, "go-wallet-toolbox#"+time.Now().Format("20060102150405"))
+
+	httpClient = httpClient.Clone().
+		SetHeaders(headers)
+
+	service := &Service{
+		logger:       logging.Child(logger, "arc"),
+		httpClient:   httpClient,
+		config:       config,
+		broadcastURL: config.URL + "/v1/tx",
+	}
+
+	return service
+}
+
+// PostBeef attempts to post beef with given txIDs
+func (s *Service) PostBeef(ctx context.Context, beef *transaction.Beef, txids []string) (*results.PostBEEF, error) {
+	beefTxs := seq2.Values(seq2.FromMap(beef.Transactions))
+	canBeV1 := seq.Every(beefTxs, func(tx *transaction.BeefTx) bool {
+		return tx.DataFormat != transaction.TxIDOnly && tx.Transaction != nil
+	})
+
+	if !canBeV1 {
+		return nil, fmt.Errorf("arc is not supporting beef v2 and provided beef cannot be converted to v1")
+	}
+
+	beefHex, err := toHex(beef)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := s.broadcast(ctx, beefHex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to broadcast beef: %w", err)
+	}
+
+	return &results.PostBEEF{
+		TxIDResults: []results.PostTxID{
+			{
+				TxID: res.TxID,
+			},
+		},
+	}, nil
+
+	// TODO:
+	// for each txids
+	// 	if txid == broadcasted tx.ID
+	// 		get tx
+
+}
+
+func toHex(beef *transaction.Beef) (string, error) {
+	// this is a temporary solution until go-sdk would implement correctly BEEF serialization
+	// We want to search for the subject transaction and convert it to BEEF hex.
+	idToTx := seq2.FromMap(beef.Transactions)
+
+	// inDegree will contain the number of transactions for which the given tx is a parent
+	inDegree := seq2.CollectToMap(seq2.MapValues(idToTx, func(tx *transaction.BeefTx) int { return 0 }))
+
+	// txsNotMined we are not interested in inputs of mined transactions
+	txsNotMined := seq.Filter(seq2.Values(idToTx), func(tx *transaction.BeefTx) bool {
+		return tx.Transaction.MerklePath == nil
+	})
+
+	inputs := seq.FlattenSlices(seq.Map(txsNotMined, func(tx *transaction.BeefTx) []*transaction.TransactionInput {
+		return tx.Transaction.Inputs
+	}))
+
+	inputsIds := seq.Map(inputs, func(input *transaction.TransactionInput) string {
+		return input.SourceTXID.String()
+	})
+
+	seq.ForEach(inputsIds, func(inputTxID string) {
+		if _, ok := inDegree[inputTxID]; !ok {
+			panic(fmt.Sprintf("unexpected input txid %s, this shouldn't ever happen", inputTxID))
+		}
+		inDegree[inputTxID]++
+	})
+
+	txIDsWithoutChildren := seq2.FilterByValue(seq2.FromMap(inDegree), is.Zero)
+
+	subjectTxs := seq.Collect(seq2.Keys(txIDsWithoutChildren))
+	if len(subjectTxs) != 1 {
+		return "", fmt.Errorf("expected only one subject tx, but got %d", len(subjectTxs))
+	}
+
+	subjectTx, ok := beef.Transactions[subjectTxs[0]]
+	if !ok {
+		return "", fmt.Errorf("expected to find subject tx %s in beef, but it was not found, this shouldn't ever happen", subjectTxs[0])
+	}
+
+	beefHex, err := subjectTx.Transaction.BEEFHex()
+	if err != nil {
+		return "", fmt.Errorf("failed to convert subject tx into BEEF hex: %w", err)
+	}
+	return beefHex, nil
+}
+
+func (s *Service) broadcast(ctx context.Context, txHex string) (*TXInfo, error) {
+	result := &TXInfo{}
+	arcErr := &APIError{}
+
+	headers := httpx.NewHeaders().
+		Set("X-CallbackUrl").IfNotEmpty(s.config.CallbackURL).
+		Set("X-CallbackToken").IfNotEmpty(s.config.CallbackToken).
+		Set("X-WaitFor").IfNotEmpty(s.config.WaitFor)
+
+	req := s.httpClient.R().
+		SetContext(ctx).
+		SetHeaders(headers).
+		SetResult(result).
+		SetError(arcErr)
+
+	req.SetBody(requestBody{
+		RawTx: txHex,
+	})
+
+	response, err := req.Post(s.broadcastURL)
+
+	if err != nil {
+		var netError net.Error
+		if errors.As(err, &netError) {
+			return nil, fmt.Errorf("arc is unreachable: %w", netError)
+		}
+		return nil, fmt.Errorf("failed to send request to arc: %w", err)
+	}
+
+	switch response.StatusCode() {
+	case http.StatusOK:
+		if result.TXStatus.IsProblematic() {
+			return nil, fmt.Errorf("%w: tx status: %s", ErrProblematicStatus, result.TXStatus)
+		}
+		return result, nil
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+		return nil, fmt.Errorf("arc returned unauthorized: %w", arcErr)
+	case StatusNotExtendedFormat:
+		return nil, fmt.Errorf("arc expects transaction in extended format: %w", arcErr)
+	case StatusFeeTooLow, StatusCumulativeFeeValidationFailed:
+		return nil, fmt.Errorf("arc rejected transaction because of wrong fee: %w", arcErr)
+	default:
+		return nil, fmt.Errorf("arc cannot process provided transaction: %w", arcErr)
+	}
+}
+
+type requestBody struct {
+	// Even though the name suggests that it is a raw transaction,
+	// it is actually a hex encoded transaction
+	// and can be in Raw, Extended Format or BEEF format.
+	RawTx string `json:"rawTx"`
+}

--- a/pkg/services/internal/arc/arc_service_test.go
+++ b/pkg/services/internal/arc/arc_service_test.go
@@ -1,0 +1,52 @@
+package arc_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/4chain-ag/go-wallet-toolbox/pkg/services/internal/testabilities"
+	"github.com/4chain-ag/go-wallet-toolbox/pkg/services/results"
+	sdk "github.com/bsv-blockchain/go-sdk/transaction"
+	txtestabilities "github.com/bsv-blockchain/universal-test-vectors/pkg/testabilities"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostBEEFWithARCService(t *testing.T) {
+
+	t.Run("broadcasting happy path", func(t *testing.T) {
+		// given:
+		given := testabilities.Given(t)
+
+		// setup arc server
+		given.ARC().IsUpAndRunning()
+
+		// and:
+		service := given.Services().NewArcService()
+
+		// and:
+		tx := txtestabilities.GivenTX().WithInput(100).WithP2PKHOutput(99).TX()
+		beef, err := sdk.NewBeefFromTransaction(tx)
+		require.NoError(t, err)
+
+		var txids = []string{tx.TxID().String()}
+
+		// when:
+		res, err := service.PostBeef(context.Background(), beef, txids)
+
+		// then:
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+
+		exp := []results.PostTxID{
+			{
+				TxID: tx.TxID().String(),
+				Data: nil, // TODO
+			},
+		}
+
+		require.ElementsMatch(t, exp, res.TxIDResults)
+
+	})
+
+}

--- a/pkg/services/internal/arc/tx_info.go
+++ b/pkg/services/internal/arc/tx_info.go
@@ -1,0 +1,19 @@
+package arc
+
+import "time"
+
+// TXInfo is the struct that represents the transaction information from ARC
+type TXInfo struct {
+	BlockHash   string    `json:"blockHash,omitempty"`
+	BlockHeight int64     `json:"blockHeight,omitempty"`
+	ExtraInfo   string    `json:"extraInfo,omitempty"`
+	MerklePath  string    `json:"merklePath,omitempty"`
+	Timestamp   time.Time `json:"timestamp,omitempty"`
+	TXStatus    TXStatus  `json:"txStatus,omitempty"`
+	TxID        string    `json:"txid,omitempty"`
+}
+
+// Found presents a convention to indicate that the transaction is known by ARC
+func (t *TXInfo) Found() bool {
+	return t != nil
+}

--- a/pkg/services/internal/arc/tx_status.go
+++ b/pkg/services/internal/arc/tx_status.go
@@ -1,0 +1,44 @@
+package arc
+
+// TXStatus is the status of the transaction
+type TXStatus string
+
+// List of statuses available here: https://github.com/bitcoin-sv/arc
+const (
+	// Unknown status means that transaction has been sent to metamorph, but no processing has taken place. This should never be the case, unless something goes wrong.
+	Unknown TXStatus = "UNKNOWN" // 0
+	// Queued status means that transaction has been queued for processing.
+	Queued TXStatus = "QUEUED" // 1
+	// Received status means that transaction has been properly received by the metamorph processor.
+	Received TXStatus = "RECEIVED" // 2
+	// Stored status means that transaction has been stored in the metamorph store. This should ensure the transaction will be processed and retried if not picked up immediately by a mining node.
+	Stored TXStatus = "STORED" // 3
+	// AnnouncedToNetwork status means that transaction has been announced (INV message) to the Bitcoin network.
+	AnnouncedToNetwork TXStatus = "ANNOUNCED_TO_NETWORK" // 4
+	// RequestedByNetwork status means that transaction has been requested from metamorph by a Bitcoin node.
+	RequestedByNetwork TXStatus = "REQUESTED_BY_NETWORK" // 5
+	// SentToNetwork status means that transaction has been sent to at least 1 Bitcoin node.
+	SentToNetwork TXStatus = "SENT_TO_NETWORK" // 6
+	// AcceptedByNetwork status means that transaction has been accepted by a connected Bitcoin node on the ZMQ interface. If metamorph is not connected to ZQM, this status will never by set.
+	AcceptedByNetwork TXStatus = "ACCEPTED_BY_NETWORK" // 7
+	// SeenInOrphanMempool means that transaction has been sent to at least 1 Bitcoin node but parent transaction was not found.
+	SeenInOrphanMempool TXStatus = "SEEN_IN_ORPHAN_MEMPOOL" // 10
+	// SeenOnNetwork status means that transaction has been seen on the Bitcoin network and propagated to other nodes. This status is set when metamorph receives an INV message for the transaction from another node than it was sent to.
+	SeenOnNetwork TXStatus = "SEEN_ON_NETWORK" // 8
+	// DoubleSpendAttempted status means that transaction has been attempted to be double spent.
+	DoubleSpendAttempted = "DOUBLE_SPEND_ATTEMPTED"
+	// Rejected status means that transaction has been rejected by the Bitcoin network.
+	Rejected TXStatus = "REJECTED" // 109
+	// Mined status means that transaction has been mined into a block by a mining node.
+	Mined TXStatus = "MINED" // 9
+)
+
+// IsMined returns true if the transaction has been mined
+func (t TXStatus) IsMined() bool {
+	return t == Mined
+}
+
+// IsProblematic returns true if the transaction is problematic (e.g rejected, double spend, unknown)
+func (t TXStatus) IsProblematic() bool {
+	return t == Rejected || t == DoubleSpendAttempted || t == Unknown || t == SeenInOrphanMempool
+}

--- a/pkg/services/internal/httpx/headers.go
+++ b/pkg/services/internal/httpx/headers.go
@@ -1,0 +1,88 @@
+package httpx
+
+type Headers map[string]string
+
+type HeaderValueSetter interface {
+	Value(value string) Headers
+	IfNotEmpty(value string) Headers
+	OrDefault(value string, defaultValue string) Headers
+}
+
+func NewHeaders() Headers {
+	return make(Headers)
+}
+
+func (h Headers) All() map[string]string {
+	return h
+}
+
+func (h Headers) Accept() HeaderValueSetter {
+	return h.Set("Accept")
+}
+
+func (h Headers) AcceptJSON() Headers {
+	return h.Accept().Value("application/json")
+}
+
+func (h Headers) Authorization() HeaderValueSetter {
+	return h.Set("Authorization")
+}
+
+func (h Headers) AuthorizationBearer() HeaderValueSetter {
+	return setter(h, "Authorization").withValuePrefix("Bearer ")
+}
+
+func (h Headers) ContentType() HeaderValueSetter {
+	return h.Set("Content-Type")
+}
+
+func (h Headers) ContentTypeJSON() Headers {
+	return h.ContentType().Value("application/json")
+}
+
+func (h Headers) UserAgent() HeaderValueSetter {
+	return h.Set("User-Agent")
+}
+
+func (h Headers) Set(key string) HeaderValueSetter {
+	return setter(h, key)
+}
+
+type headersSetter struct {
+	key         string
+	headers     Headers
+	valuePrefix string
+}
+
+func setter(headers Headers, key string) *headersSetter {
+	return &headersSetter{
+		key:     key,
+		headers: headers,
+	}
+}
+
+func (s *headersSetter) Value(value string) Headers {
+	s.headers[s.key] = s.valuePrefix + value
+	return s.headers
+}
+
+func (s *headersSetter) IfNotEmpty(value string) Headers {
+	if value != "" {
+		s.headers[s.key] = s.valuePrefix + value
+	}
+	return s.headers
+}
+
+func (s *headersSetter) OrDefault(value string, defaultValue string) Headers {
+	if value == "" {
+		s.headers[s.key] = s.valuePrefix + defaultValue
+	} else {
+		s.headers[s.key] = s.valuePrefix + value
+	}
+	return s.headers
+}
+
+func (s *headersSetter) withValuePrefix(valuePrefix string) *headersSetter {
+	s.valuePrefix = valuePrefix
+	return s
+}

--- a/pkg/services/internal/httpx/headers_test.go
+++ b/pkg/services/internal/httpx/headers_test.go
@@ -1,0 +1,141 @@
+package httpx_test
+
+import (
+	"testing"
+
+	"github.com/4chain-ag/go-wallet-toolbox/pkg/services/internal/httpx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewHeaders(t *testing.T) {
+	headers := httpx.NewHeaders()
+	assert.NotNil(t, headers)
+	assert.Empty(t, headers.All())
+}
+
+func TestHeaders(t *testing.T) {
+	testCases := map[string]struct {
+		getHeaderSetter func(headers httpx.Headers) httpx.HeaderValueSetter
+		key             string
+		value           string
+	}{
+		"Accept": {
+			getHeaderSetter: func(headers httpx.Headers) httpx.HeaderValueSetter {
+				return headers.Accept()
+			},
+			key:   "Accept",
+			value: "text/plain",
+		},
+		"Authorization": {
+			getHeaderSetter: func(headers httpx.Headers) httpx.HeaderValueSetter {
+				return headers.Authorization()
+			},
+			key:   "Authorization",
+			value: "some_token",
+		},
+		"Content-Type": {
+			getHeaderSetter: func(headers httpx.Headers) httpx.HeaderValueSetter {
+				return headers.ContentType()
+			},
+			key:   "Content-Type",
+			value: "application/json",
+		},
+		"User-Agent": {
+			getHeaderSetter: func(headers httpx.Headers) httpx.HeaderValueSetter {
+				return headers.UserAgent()
+			},
+			key:   "User-Agent",
+			value: "MyApp/1.0",
+		},
+		"Custom-Header": {
+			getHeaderSetter: func(headers httpx.Headers) httpx.HeaderValueSetter {
+				return headers.Set("X-Custom-Header")
+			},
+			key:   "X-Custom-Header",
+			value: "custom-value",
+		},
+	}
+	for name, test := range testCases {
+		t.Run(name+" set value", func(t *testing.T) {
+			headers := httpx.NewHeaders()
+			headers = test.getHeaderSetter(headers).Value(test.value)
+			assert.Equal(t, map[string]string{test.key: test.value}, headers.All())
+		})
+
+		t.Run(name+" set if not empty (use value)", func(t *testing.T) {
+			headers := httpx.NewHeaders()
+			headers = test.getHeaderSetter(headers).IfNotEmpty(test.value)
+			assert.Equal(t, map[string]string{test.key: test.value}, headers.All())
+		})
+
+		t.Run(name+" set if not empty (empty value)", func(t *testing.T) {
+			headers := httpx.NewHeaders()
+			headers = test.getHeaderSetter(headers).IfNotEmpty("")
+			assert.Empty(t, headers.All())
+		})
+
+		t.Run(name+" set or default (use value)", func(t *testing.T) {
+			headers := httpx.NewHeaders()
+			headers = test.getHeaderSetter(headers).OrDefault(test.value, "default")
+			assert.Equal(t, map[string]string{test.key: test.value}, headers.All())
+		})
+
+		t.Run(name+" set or default (use default)", func(t *testing.T) {
+			headers := httpx.NewHeaders()
+			headers = test.getHeaderSetter(headers).OrDefault("", "default")
+			assert.Equal(t, map[string]string{test.key: "default"}, headers.All())
+		})
+	}
+
+	shortSetters := map[string]struct {
+		getHeaderSetter func(headers httpx.Headers) httpx.Headers
+		expectedKey     string
+		expectedValue   string
+	}{
+		"AcceptJSON": {
+			getHeaderSetter: func(headers httpx.Headers) httpx.Headers {
+				return headers.AcceptJSON()
+			},
+			expectedKey:   "Accept",
+			expectedValue: "application/json",
+		},
+		"ContentTypeJSON": {
+			getHeaderSetter: func(headers httpx.Headers) httpx.Headers {
+				return headers.ContentTypeJSON()
+			},
+			expectedKey:   "Content-Type",
+			expectedValue: "application/json",
+		},
+		"AuthorizationBearer": {
+			getHeaderSetter: func(headers httpx.Headers) httpx.Headers {
+				return headers.AuthorizationBearer().Value("token123")
+			},
+			expectedKey:   "Authorization",
+			expectedValue: "Bearer token123",
+		},
+	}
+	for name, test := range shortSetters {
+		t.Run(name, func(t *testing.T) {
+			headers := httpx.NewHeaders()
+			headers = test.getHeaderSetter(headers)
+			assert.Equal(t, map[string]string{test.expectedKey: test.expectedValue}, headers.All())
+		})
+	}
+
+	t.Run("Set multiple headers", func(t *testing.T) {
+		headers := httpx.NewHeaders()
+		headers.AcceptJSON().
+			AuthorizationBearer().Value("token123").
+			UserAgent().Value("TestApp/1.0").
+			Set("X-Custom-Header").Value("custom-value")
+
+		expected := map[string]string{
+			"Accept":          "application/json",
+			"Authorization":   "Bearer token123",
+			"User-Agent":      "TestApp/1.0",
+			"X-Custom-Header": "custom-value",
+		}
+
+		assert.Equal(t, expected, headers.All())
+	})
+}

--- a/pkg/services/internal/testabilities/fixture_arc.go
+++ b/pkg/services/internal/testabilities/fixture_arc.go
@@ -1,0 +1,110 @@
+package testabilities
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	sdk "github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/go-resty/resty/v2"
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const ArcURL = "https://api.taal.com/arc"
+const ArcToken = "mainnet_9596de07e92300c6287e4393594ae39c"
+const DeploymentID = "go-wallet-toolbox-test"
+
+type ArcFixture interface {
+	IsUpAndRunning()
+	HttpClient() *resty.Client
+}
+
+type arcFixture struct {
+	testing.TB
+	transport *httpmock.MockTransport
+}
+
+func NewArcFixture(t testing.TB) ArcFixture {
+	transport := httpmock.NewMockTransport()
+	return NewArcFixtureWithTransport(t, transport)
+}
+
+func NewArcFixtureWithTransport(t testing.TB, transport *httpmock.MockTransport) ArcFixture {
+	require.NotNil(t, transport, "http.RoundTripper must be provided")
+
+	return &arcFixture{
+		TB:        t,
+		transport: transport,
+	}
+}
+
+func (f *arcFixture) HttpClient() *resty.Client {
+	client := resty.New()
+	client.SetTransport(f.transport)
+	return client
+}
+
+func (f *arcFixture) IsUpAndRunning() {
+	f.transport.RegisterResponder("POST", ArcURL+"/v1/tx", func(req *http.Request) (*http.Response, error) {
+		b, err := io.ReadAll(req.Body)
+		if !assert.NoError(f, err) {
+			return nil, err
+		}
+
+		var body map[string]any
+		err = json.Unmarshal(b, &body)
+		if !assert.NoError(f, err) {
+			return nil, err
+		}
+
+		rawTx := body["rawTx"]
+		if !assert.NotNil(f, rawTx) {
+			return httpmock.NewJsonResponse(400, map[string]any{
+				"detail":    "The request seems to be malformed and cannot be processed",
+				"extraInfo": "error parsing transactions from request: no transaction found - empty request body",
+				"instance":  nil,
+				"status":    400,
+				"title":     "Bad request",
+				"txid":      nil,
+				"type":      "https://bitcoin-sv.github.io/arc/#/errors?id=_400",
+			})
+		}
+		txHex := rawTx.(string)
+
+		tx, err := sdk.NewTransactionFromBEEFHex(txHex)
+		if !assert.NoError(f, err) {
+			return httpmock.NewJsonResponse(463, map[string]any{
+				"detail":    "Transaction is malformed and cannot be processed",
+				"extraInfo": err.Error(),
+				"instance":  nil,
+				"status":    463,
+				"title":     "Malformed transaction",
+				"txid":      nil,
+				"type":      "https://bitcoin-sv.github.io/arc/#/errors?id=_463",
+			})
+		}
+
+		id := tx.TxID()
+
+		content := map[string]any{
+			"blockHash":    "",
+			"blockHeight":  0,
+			"competingTxs": nil,
+			"extraInfo":    "",
+			"merklePath":   "",
+			"timestamp":    time.Now().Format("2006-01-02T15:04:05.999999999Z"),
+			"txStatus":     "SEEN_ON_NETWORK",
+			"txid":         id,
+		}
+
+		responder, err := httpmock.NewJsonResponder(200, content)
+		require.NoError(f, err)
+
+		f.transport.RegisterResponder("GET", ArcURL+"/v1/tx/"+id.String(), responder)
+		return responder(req)
+	})
+}

--- a/pkg/services/internal/testabilities/fixture_woc.go
+++ b/pkg/services/internal/testabilities/fixture_woc.go
@@ -1,0 +1,65 @@
+package testabilities
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/require"
+)
+
+type WhatsOnChainFixture interface {
+	WillRespondWithRates(status int, content string, err error)
+
+	WillRespondWithRawTx(status int, txID, rawTx string, err error)
+}
+
+type wocFixture struct {
+	testing.TB
+	transport *httpmock.MockTransport
+}
+
+func NewWoCFixture(t testing.TB) WhatsOnChainFixture {
+	return NewWoCFixtureWithTransport(t, httpmock.NewMockTransport())
+}
+
+func NewWoCFixtureWithTransport(t testing.TB, transport *httpmock.MockTransport) WhatsOnChainFixture {
+	require.NotNil(t, transport, "transport must be provided")
+	return &wocFixture{
+		TB:        t,
+		transport: transport,
+	}
+
+}
+
+func (f *wocFixture) WillRespondWithRates(status int, content string, err error) {
+	responder := func(status int, content string) func(req *http.Request) (*http.Response, error) {
+		return func(req *http.Request) (*http.Response, error) {
+			if err != nil {
+				return nil, err
+			}
+			res := httpmock.NewStringResponse(status, content)
+			res.Header.Set("Content-Type", "application/json")
+			return res, nil
+		}
+	}
+
+	f.transport.RegisterResponder("GET", "https://api.whatsonchain.com/v1/bsv/test/exchangerate", responder(status, content))
+}
+
+func (f *wocFixture) WillRespondWithRawTx(status int, txID, rawTx string, err error) {
+	responder := func(status int, content string) func(req *http.Request) (*http.Response, error) {
+		return func(req *http.Request) (*http.Response, error) {
+			if err != nil {
+				return nil, err
+			}
+			res := httpmock.NewStringResponse(status, content)
+			res.Header.Set("Content-Type", "text/plain")
+			return res, nil
+		}
+	}
+
+	url := fmt.Sprintf("https://api.whatsonchain.com/v1/bsv/test/tx/%s/hex", txID)
+	f.transport.RegisterResponder("GET", url, responder(status, rawTx))
+}

--- a/pkg/services/results/history_notes.go
+++ b/pkg/services/results/history_notes.go
@@ -1,0 +1,6 @@
+package results
+
+import "github.com/4chain-ag/go-wallet-toolbox/pkg/wdk"
+
+// Notes represents a list of ReqHistoryNote
+type Notes []wdk.ReqHistoryNote

--- a/pkg/services/results/postbeef.go
+++ b/pkg/services/results/postbeef.go
@@ -1,0 +1,40 @@
+package results
+
+import (
+	"github.com/bsv-blockchain/go-sdk/transaction"
+)
+
+// PostBEEF is the success result of the single service PostBEEF method.
+type PostBEEF struct {
+	Notes
+	TxIDResults []PostTxID
+}
+
+// PostBEEFError is the error result of the single service PostBEEF method.
+type PostBEEFError struct {
+	Cause error
+	Notes
+	TxIDResults []PostTxID
+}
+
+func (p *PostBEEFError) Error() string {
+	return p.Cause.Error()
+}
+
+// PostTxID is the struct representing postTX result for particular TxID
+type PostTxID struct {
+	TxID string
+	// AlreadyKnown if true, the transaction was already known to this service. Usually treat as a success.
+	// Potentially stop posting to additional transaction processors.
+	AlreadyKnown bool
+	// DoubleSpend is when service indicated this broadcast double spends at least one input
+	// `competingTxs` may be an array of txids that were first seen spends of at least one input.
+	DoubleSpend  bool
+	BlockHash    *string
+	BlockHeight  *int64
+	MerklePath   *transaction.MerklePath
+	CompetingTxs []string
+	// TODO: Data type is object | string | PostTxResultForTxidError
+	Data any
+	Notes
+}

--- a/pkg/wdk/request.go
+++ b/pkg/wdk/request.go
@@ -6,5 +6,5 @@ import "time"
 type ReqHistoryNote struct {
 	When *time.Time `json:"when"`
 	What string     `json:"what"`
-	Args map[string]interface{}
+	Args map[string]any
 }

--- a/pkg/wdk/request.go
+++ b/pkg/wdk/request.go
@@ -1,8 +1,10 @@
 package wdk
 
+import "time"
+
 // ReqHistoryNote is the history representation of the request
 type ReqHistoryNote struct {
-	When        *string
-	What        string
-	ExtraFields map[string]interface{}
+	When *time.Time `json:"when"`
+	What string     `json:"what"`
+	Args map[string]interface{}
 }


### PR DESCRIPTION
It is a first part of the implementation of PostBEEF method in ArcService.
It is focusing on sending request to ARC.
Things that are still missing:
- getting a result for each txid provided
- better errors handling with PostBEEFError