### PR TITLE
feat(#373): log errors from storage server

### DIFF
--- a/pkg/internal/logging/test_writer.go
+++ b/pkg/internal/logging/test_writer.go
@@ -1,6 +1,10 @@
 package logging
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/go-softwarelab/common/pkg/seq"
+)
 
 // TestWriter is a simple io.Writer implementation that writes to a string builder.
 // It is useful for testing purposes - to check what was written by the logger.
@@ -16,6 +20,10 @@ func (w *TestWriter) Write(p []byte) (n int, err error) {
 // String returns the content written to the writer.
 func (w *TestWriter) String() string {
 	return w.builder.String()
+}
+
+func (w *TestWriter) Lines() []string {
+	return seq.Collect(strings.Lines(w.builder.String()))
 }
 
 func (w *TestWriter) Clear() {

--- a/pkg/storage/internal/server/rpc_server.go
+++ b/pkg/storage/internal/server/rpc_server.go
@@ -20,7 +20,7 @@ func NewRPCHandler(parentLogger *slog.Logger, name string, handler any) *RPCServ
 
 	rpcServer := jsonrpc.NewServer(
 		jsonrpc.WithServerMethodNameFormatter(jsonrpc.NewMethodNameFormatter(false, jsonrpc.LowerFirstCharCase)),
-		jsonrpc.WithTracer(tracer(logger)),
+		jsonrpc.WithTracer(newTracer(logger)),
 	)
 
 	rpcServer.Register(name, handler)

--- a/pkg/storage/internal/server/tracer.go
+++ b/pkg/storage/internal/server/tracer.go
@@ -9,37 +9,109 @@ import (
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/logging"
 	"github.com/filecoin-project/go-jsonrpc"
+	"github.com/go-softwarelab/common/pkg/to"
 )
 
-func tracer(logger *slog.Logger) jsonrpc.Tracer {
+type rpcCallTracer struct {
+	debug   bool
+	logger  *slog.Logger
+	method  string
+	params  []reflect.Value
+	results []reflect.Value
+	err     error
+}
+
+func newTracer(logger *slog.Logger) jsonrpc.Tracer {
 	return func(method string, params []reflect.Value, results []reflect.Value, err error) {
-		level := slog.LevelInfo
-		args := []slog.Attr{
-			slog.String("method", method),
+		tracer := rpcCallTracer{
+			debug:   logging.IsDebug(logger),
+			logger:  logger,
+			method:  method,
+			params:  params,
+			results: results,
+			err:     err,
 		}
 
-		if err != nil {
-			level = slog.LevelError
-			args = append(args, slog.String("error", err.Error()))
-		}
+		tracer.LogRequest()
 
-		if logging.IsDebug(logger) {
-			args = append(args, slog.String("handler", params[0].Type().String()))
-
-			for i, param := range params[1:] {
-				args = append(args, slog.Any(fmt.Sprintf("param_%d", i), reflectValueToLoggable(param)))
-			}
-
-			for i, result := range results {
-				args = append(args, slog.Any(fmt.Sprintf("result_%d", i), reflectValueToLoggable(result)))
-			}
-		}
-
-		logger.LogAttrs(context.Background(), level, "Handling RPC call", args...)
+		tracer.LogResult()
 	}
 }
 
-func reflectValueToLoggable(v reflect.Value) string {
+func (t *rpcCallTracer) LogRequest() {
+	args := []slog.Attr{
+		slog.String("method", t.method),
+	}
+	if t.debug {
+		args = append(args, slog.String("handler", t.handlerName()))
+		// params contains all the method arguments (it treats method receiver also as a param and put it in index 0)
+		for i, param := range t.params[1:] {
+			args = append(args, slog.Any(fmt.Sprintf("param_%d", i), t.reflectValueToLoggable(param)))
+		}
+	}
+
+	t.logger.LogAttrs(t.context(), slog.LevelInfo, "RPC request", args...)
+}
+
+func (t *rpcCallTracer) LogResult() {
+	err := t.checkError()
+	level := to.IfThen(err != nil, slog.LevelError).ElseThen(slog.LevelInfo)
+
+	args := []slog.Attr{
+		slog.String("method", t.method),
+	}
+
+	if err != nil {
+		args = append(args, logging.Error(err))
+	}
+
+	if t.debug {
+		args = append(args, slog.String("handler", t.handlerName()))
+		for i, result := range t.results {
+			args = append(args, slog.Any(fmt.Sprintf("result_%d", i), t.reflectValueToLoggable(result)))
+		}
+	}
+
+	t.logger.LogAttrs(t.context(), level, "RPC result", args...)
+}
+
+func (t *rpcCallTracer) checkError() error {
+	if t.err != nil {
+		return t.err
+	}
+
+	if len(t.results) == 0 {
+		return nil
+	}
+
+	lastRes := t.results[len(t.results)-1]
+	err, ok := lastRes.Interface().(error)
+	if ok {
+		return err
+	}
+	return nil
+}
+
+func (t *rpcCallTracer) handlerName() string {
+	return t.params[0].Type().String()
+}
+
+func (t *rpcCallTracer) context() context.Context {
+	// param[0] is a method receiver - which is our storage.
+	// We're assuming that context will be the first argument of the method,
+	// therefore we need to check if there are 2 params (1 for storage struct - method receiver, 2 for context)
+	// and if the first argument is really the context.
+	if len(t.params) < 2 {
+		return context.Background()
+	}
+	ctx, ok := t.params[1].Interface().(context.Context)
+	if !ok {
+		return context.Background()
+	}
+	return ctx
+}
+
+func (t *rpcCallTracer) reflectValueToLoggable(v reflect.Value) string {
 	if !v.IsValid() {
 		return "<invalid>"
 	}

--- a/pkg/storage/internal/server/tracer_test.go
+++ b/pkg/storage/internal/server/tracer_test.go
@@ -15,6 +15,12 @@ import (
 )
 
 func TestTracer(t *testing.T) {
+	const expectedTimeMessage = "time="
+	const expectedLevelInfoMessage = "level=INFO"
+	const expectedRequestMessage = `msg="RPC request"`
+	const expectedResultMessage = `msg="RPC result"`
+	const expectedHandlerArgMessage = `handler=`
+
 	// given:
 	testWriter := logging.TestWriter{}
 	logger := logging.New().WithLevel(defs.LogLevelDebug).WithHandler(defs.TextHandler, &testWriter).Logger()
@@ -49,13 +55,22 @@ func TestTracer(t *testing.T) {
 		client.Get()
 
 		// then:
-		msg := testWriter.String()
-		assert.Contains(t, msg, "time=")
-		assert.Contains(t, msg, "level=INFO")
-		assert.Contains(t, msg, `msg="Handling RPC call"`)
+		lines := testWriter.Lines()
+
+		msg := lines[0]
+		assert.Contains(t, msg, expectedTimeMessage)
+		assert.Contains(t, msg, expectedLevelInfoMessage)
+		assert.Contains(t, msg, expectedRequestMessage)
 		assert.Contains(t, msg, `method=get`)
-		assert.Contains(t, msg, `handler=`)
-		assert.Contains(t, msg, `result_0=10`)
+		assert.Contains(t, msg, expectedHandlerArgMessage)
+
+		msg2 := lines[1]
+		assert.Contains(t, msg2, expectedTimeMessage)
+		assert.Contains(t, msg2, expectedLevelInfoMessage)
+		assert.Contains(t, msg2, expectedResultMessage)
+		assert.Contains(t, msg2, `method=get`)
+		assert.Contains(t, msg2, expectedHandlerArgMessage)
+		assert.Contains(t, msg2, `result_0=10`)
 	})
 
 	t.Run("method with arguments and no result", func(t *testing.T) {
@@ -65,14 +80,24 @@ func TestTracer(t *testing.T) {
 		client.Set(t.Context(), 10)
 
 		// then:
-		msg := testWriter.String()
-		assert.Contains(t, msg, "time=")
-		assert.Contains(t, msg, "level=INFO")
-		assert.Contains(t, msg, `msg="Handling RPC call"`)
+		lines := testWriter.Lines()
+
+		msg := lines[0]
+		assert.Contains(t, msg, expectedTimeMessage)
+		assert.Contains(t, msg, expectedLevelInfoMessage)
+		assert.Contains(t, msg, expectedRequestMessage)
 		assert.Contains(t, msg, `method=set`)
-		assert.Contains(t, msg, `handler=`)
+		assert.Contains(t, msg, expectedHandlerArgMessage)
 		assert.Contains(t, msg, `param_0="<context: `)
 		assert.Contains(t, msg, `param_1=10`)
+
+		msg2 := lines[1]
+		assert.Contains(t, msg2, expectedTimeMessage)
+		assert.Contains(t, msg2, expectedLevelInfoMessage)
+		assert.Contains(t, msg2, expectedResultMessage)
+		assert.Contains(t, msg2, `method=set`)
+		assert.Contains(t, msg2, expectedHandlerArgMessage)
+
 	})
 }
 
@@ -83,6 +108,7 @@ func (h *mockHandler) Get() int {
 }
 
 func (h *mockHandler) Set(context.Context, int) {
+	// nothing to do, it's just for test case purposes
 }
 
 // mockClient matches the mockHandler (but on the client side)


### PR DESCRIPTION
Improvement of logging in storage server RPC request handling

Example logging output for success:
```bash
    handler.go:313: time=2025-07-18T15:44:53.100+02:00 level=INFO msg="RPC request" service=storage_server service=rpc_server method=makeAvailable handler=*mocks.MockWalletStorageProvider param_0="<context: context.Background.WithValue(net/http context value http-server, *http.Server).WithValue(net/http context value local-addr, 127.0.0.1:61338).WithCancel.WithCancel.WithValue(*struct { name string }, jsonrpc.ConnectionType).WithValue(trace.contextKey, span 7ef3412b22fe24a1).WithValue(tag.ctxKey, { {method {makeAvailable {{-1}}}} })>"
        
    handler.go:313: time=2025-07-18T15:44:53.100+02:00 level=INFO msg="RPC result" service=storage_server service=rpc_server method=makeAvailable handler=*mocks.MockWalletStorageProvider result_0="{\"storageIdentityKey\":\"028f2daab7808b79368d99eef1ebc2d35cdafe3932cafe3d83cf17837af034ec29\",\"storageName\":\"test-storage\",\"created_at\":\"0001-01-01T00:00:00Z\",\"updated_at\":\"0001-01-01T00:00:00Z\",\"chain\":\"test\",\"dbtype\":\"\",\"maxOutputScript\":1024}" result_1=null
```

Example logging output for error:
```bash
    handler.go:313: time=2025-07-18T15:44:10.695+02:00 level=INFO msg="RPC request" service=storage_server service=rpc_server method=findOrInsertUser handler=*mocks.MockWalletStorageProvider param_0="<context: context.Background.WithValue(net/http context value http-server, *http.Server).WithValue(net/http context value local-addr, 127.0.0.1:61334).WithCancel.WithCancel.WithValue(*struct { name string }, jsonrpc.ConnectionType).WithValue(trace.contextKey, span 86a7fb8908211d71).WithValue(tag.ctxKey, { {method {findOrInsertUser {{-1}}}} })>" param_1="\"028f2daab7808b79368d99eef1ebc2d35cdafe3932cafe3d83cf17837af034ec29\""
        
    handler.go:313: time=2025-07-18T15:44:10.695+02:00 level=ERROR msg="RPC result" service=storage_server service=rpc_server method=findOrInsertUser error="some error have happened: internally generated error: bum - the error" handler=*mocks.MockWalletStorageProvider result_0=null result_1="<error: some error have happened: internally generated error: bum - the error>"
```