### PR TITLE
feat(#464): implement WaitForAuthentication method in Wallet

### DIFF
--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -365,9 +365,14 @@ func (w *Wallet) IsAuthenticated(_ context.Context, _ any, originator string) (*
 }
 
 // WaitForAuthentication continuously waits until the user is authenticated, returning the result once confirmed.
-func (w *Wallet) WaitForAuthentication(ctx context.Context, args any, originator string) (*sdk.AuthenticatedResult, error) {
-	// TODO implement me
-	panic("implement me")
+func (w *Wallet) WaitForAuthentication(_ context.Context, _ any, originator string) (*sdk.AuthenticatedResult, error) {
+	if err := validate.Originator(originator); err != nil {
+		return nil, fmt.Errorf("invalid originator: %w", err)
+	}
+
+	return &sdk.AuthenticatedResult{
+		Authenticated: true,
+	}, nil
 }
 
 // GetHeight retrieves the current height of the blockchain.

--- a/pkg/wallet/wallet_wait_for_authentication_test.go
+++ b/pkg/wallet/wallet_wait_for_authentication_test.go
@@ -1,0 +1,115 @@
+package wallet_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/internal/testabilities"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWalletWaitForAuthenticationArgsValidation(t *testing.T) {
+	errorTestCases := map[string]struct {
+		originator string
+		args       any
+	}{
+		"too long originator": {
+			originator: strings.Repeat("a", 251),
+			args:       nil,
+		},
+		"too long originator part": {
+			originator: "a." + strings.Repeat("b", 64) + ".c",
+			args:       nil,
+		},
+		"empty part in originator": {
+			originator: "a..c",
+			args:       nil,
+		},
+	}
+
+	for name, test := range errorTestCases {
+		t.Run(name, func(t *testing.T) {
+			// given:
+			given, then, cleanup := testabilities.New(t)
+			defer cleanup()
+			aliceWallet := given.AliceWalletWithStorage(testabilities.StorageTypeMocked)
+
+			// when:
+			result, err := aliceWallet.WaitForAuthentication(t.Context(), test.args, test.originator)
+
+			// then:
+			then.Result(result).HasError(err)
+
+			then.Storage().HadNoInteraction()
+		})
+	}
+}
+
+func (s *WalletTestSuite) TestWalletWaitForAuthentication() {
+	successTestCases := map[string]struct {
+		args       any
+		originator string
+	}{
+		"nil args with default originator": {
+			args:       nil,
+			originator: fixtures.DefaultOriginator,
+		},
+		"empty struct args with default originator": {
+			args:       struct{}{},
+			originator: fixtures.DefaultOriginator,
+		},
+		"map args with default originator": {
+			args:       map[string]string{"key": "value"},
+			originator: fixtures.DefaultOriginator,
+		},
+		"nil args with simple originator": {
+			args:       nil,
+			originator: "testoriginator",
+		},
+		"nil args with multi-part originator": {
+			args:       nil,
+			originator: "subdomain.example.com",
+		},
+		"max single label length (63) across multiple parts": {
+			originator: strings.Repeat("a", 63) + "." + strings.Repeat("b", 63) + "." + strings.Repeat("c", 63),
+			args:       map[string]any{"k": "v"},
+		},
+		"max total length (250 chars) should pass": {
+			originator: strings.Repeat("a", 250),
+			args:       struct{ Foo string }{Foo: "bar"},
+		},
+		"default originator still passes": {
+			originator: fixtures.DefaultOriginator,
+			args:       nil,
+		},
+		"case-insensitive originator (if normalization is supported)": {
+			originator: strings.ToUpper(fixtures.DefaultOriginator),
+			args:       nil,
+		},
+		"originator with 2 labels and simple map args": {
+			originator: "example.com",
+			args:       map[string]string{"key": "value"},
+		},
+	}
+
+	for name, test := range successTestCases {
+		s.Run(name, func() {
+			t := s.T()
+
+			// given:
+			given, cleanup := testabilities.Given(t)
+			defer cleanup()
+			aliceWallet := given.AliceWalletWithStorage(s.StorageType)
+
+			// when:
+			result, err := aliceWallet.WaitForAuthentication(t.Context(), test.args, test.originator)
+
+			// then:
+			assert.NoError(t, err)
+			require.NotNil(t, result)
+			assert.True(t, result.Authenticated, "Should return authenticated as true")
+		})
+	}
+}


### PR DESCRIPTION
Closes #464
This pull request implements the `WaitForAuthentication` method for the `Wallet` type, adding input validation and returning a fixed authenticated result. It also introduces comprehensive unit tests to verify correct behavior for both valid and invalid originator values.

**Implementation of authentication waiting and validation:**

* [`pkg/wallet/wallet.go`](diffhunk://#diff-ea88400ee9978d3861f790f89a8efae2e437c92fa450cf110dbde7a2a0fcbc42L368-R375): Implements `WaitForAuthentication`, which validates the `originator` argument and returns an authenticated result if valid, or an error if invalid.

**Testing enhancements:**

* [`pkg/wallet/wallet_wait_for_authentication_test.go`](diffhunk://#diff-23bbbd6babc430f73e81842cfaf26dfd8de3495446f7e130ae098c8d1eeeb5bbR1-R115): Adds tests to ensure `WaitForAuthentication` correctly handles various valid and invalid `originator` inputs, checking both error and success scenarios.