### PR TITLE
feat: add wallet services integration and GetHeight method implementation

### DIFF
--- a/pkg/wallet/internal/testabilities/fixture_wallet_builder.go
+++ b/pkg/wallet/internal/testabilities/fixture_wallet_builder.go
@@ -1,13 +1,16 @@
 package testabilities
 
 import (
+	"log/slog"
 	"testing"
 
 	sdk "github.com/bsv-blockchain/go-sdk/wallet"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/services"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/internal/wallet_opts"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 	"github.com/stretchr/testify/require"
 )
@@ -27,6 +30,7 @@ type WalletBuilder interface {
 	WithActiveStorage(storageType StorageType) WalletBuilder
 	WithRemoteStorage() WalletBuilder
 	WithSQLiteStorage() WalletBuilder
+	WithServices() WalletBuilder
 	ForUser(user testusers.User) *wallet.Wallet
 }
 
@@ -34,11 +38,17 @@ type walletBuilder struct {
 	testing.TB
 	walletFixture *walletFixture
 	storageType   StorageType
+	withServices  bool
 	givenStorage  testabilities.StorageFixture
 }
 
 func (w *walletBuilder) WithActiveStorage(storageType StorageType) WalletBuilder {
 	w.storageType = storageType
+	return w
+}
+
+func (w *walletBuilder) WithServices() WalletBuilder {
+	w.withServices = true
 	return w
 }
 
@@ -59,7 +69,14 @@ func (w *walletBuilder) ForUser(user testusers.User) *wallet.Wallet {
 	keyDeriver := sdk.NewKeyDeriver(privKey)
 	activeStorage, cleanup := w.storage()
 
-	userWallet, err := wallet.New(defs.NetworkTestnet, keyDeriver, activeStorage)
+	var opts []func(*wallet_opts.Opts)
+	if w.withServices {
+		serviceCfg := defs.DefaultServicesConfig(defs.NetworkTestnet)
+		walletServices := services.New(slog.Default(), serviceCfg)
+		opts = append(opts, wallet.WithServices(walletServices))
+	}
+
+	userWallet, err := wallet.New(defs.NetworkTestnet, keyDeriver, activeStorage, opts...)
 	require.NoErrorf(w, err, "Couldn't create wallet for user %s - invalid test setup", user.Name)
 
 	w.walletFixture.addUserWalletSetup(&userWalletSetup{

--- a/pkg/wallet/internal/wallet_opts/wallet_opts.go
+++ b/pkg/wallet/internal/wallet_opts/wallet_opts.go
@@ -1,9 +1,13 @@
 package wallet_opts
 
-import sdk "github.com/bsv-blockchain/go-sdk/wallet"
+import (
+	sdk "github.com/bsv-blockchain/go-sdk/wallet"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/services"
+)
 
 type Opts struct {
 	Flags
+	Services *services.WalletServices
 }
 
 type Flags struct {

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/bsv-blockchain/go-sdk/wallet"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/validate"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/services"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/storage"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/internal/actions"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/internal/mapping"
@@ -23,6 +24,7 @@ type Wallet struct {
 	storage    wdk.WalletStorage
 	keyDeriver *sdk.KeyDeriver
 	flags      *wallet_opts.Flags
+	services   *services.WalletServices
 }
 
 // WithIncludeAllSourceTransactions - default: `true`
@@ -53,6 +55,13 @@ func WithTrustSelf(value sdk.TrustSelf) func(*wallet_opts.Opts) {
 		} else {
 			opts.TrustSelf = &value
 		}
+	}
+}
+
+// WithServices allows to set the wallet services that will be used by the wallet.
+func WithServices(services *services.WalletServices) func(*wallet_opts.Opts) {
+	return func(opts *wallet_opts.Opts) {
+		opts.Services = services
 	}
 }
 
@@ -87,6 +96,7 @@ func New[KeySource PrivateKeySource](chain defs.BSVNetwork, keySource KeySource,
 			AutoKnownTxids:               false,
 			TrustSelf:                    to.Ptr(sdk.TrustSelfKnown),
 		},
+		Services: nil,
 	}, opts...)
 
 	return &Wallet{
@@ -94,6 +104,7 @@ func New[KeySource PrivateKeySource](chain defs.BSVNetwork, keySource KeySource,
 		storage:    storageManager,
 		keyDeriver: keyDeriver,
 		flags:      &options.Flags,
+		services:   options.Services,
 	}, nil
 }
 
@@ -376,9 +387,23 @@ func (w *Wallet) WaitForAuthentication(_ context.Context, _ any, originator stri
 }
 
 // GetHeight retrieves the current height of the blockchain.
-func (w *Wallet) GetHeight(ctx context.Context, args any, originator string) (*sdk.GetHeightResult, error) {
-	// TODO implement me
-	panic("implement me")
+func (w *Wallet) GetHeight(ctx context.Context, _ any, originator string) (*sdk.GetHeightResult, error) {
+	if err := validate.Originator(originator); err != nil {
+		return nil, fmt.Errorf("invalid originator: %w", err)
+	}
+
+	if w.services == nil {
+		return nil, fmt.Errorf("services are not configured for this wallet")
+	}
+
+	currentHeight, err := w.services.CurrentHeight(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current height: %w", err)
+	}
+
+	return &sdk.GetHeightResult{
+		Height: currentHeight,
+	}, nil
 }
 
 // GetHeaderForHeight retrieves the block header of a block at a specified height.

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -390,12 +390,12 @@ func (w *Wallet) WaitForAuthentication(_ context.Context, _ any, originator stri
 
 // GetHeight retrieves the current height of the blockchain.
 func (w *Wallet) GetHeight(ctx context.Context, _ any, originator string) (*sdk.GetHeightResult, error) {
-	if err := validate.Originator(originator); err != nil {
-		return nil, fmt.Errorf("invalid originator: %w", err)
-	}
-
 	if w.services == nil {
 		return nil, fmt.Errorf("services are not configured for this wallet")
+	}
+
+	if err := validate.Originator(originator); err != nil {
+		return nil, fmt.Errorf("invalid originator: %w", err)
 	}
 
 	currentHeight, err := w.services.CurrentHeight(ctx)

--- a/pkg/wallet/wallet_get_height_test.go
+++ b/pkg/wallet/wallet_get_height_test.go
@@ -1,7 +1,6 @@
 package wallet_test
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -19,7 +18,7 @@ func TestWallet_GetHeight(t *testing.T) {
 	validOriginator := "example.com"
 
 	// when:
-	result, err := w.GetHeight(context.Background(), struct{}{}, validOriginator)
+	result, err := w.GetHeight(t.Context(), struct{}{}, validOriginator)
 
 	// then:
 	require.NoError(t, err)
@@ -47,7 +46,7 @@ func TestWallet_GetHeight_InvalidOriginator(t *testing.T) {
 			w := given.Wallet().WithSQLiteStorage().WithServices().ForUser(testusers.Alice)
 
 			// when:
-			result, err := w.GetHeight(context.Background(), struct{}{}, tc.originator)
+			result, err := w.GetHeight(t.Context(), struct{}{}, tc.originator)
 
 			// then:
 			require.Error(t, err)
@@ -77,7 +76,7 @@ func TestWallet_GetHeight_ValidOriginators(t *testing.T) {
 			w := given.Wallet().WithSQLiteStorage().WithServices().ForUser(testusers.Alice)
 
 			// when:
-			result, err := w.GetHeight(context.Background(), struct{}{}, tc.originator)
+			result, err := w.GetHeight(t.Context(), struct{}{}, tc.originator)
 
 			// then:
 			require.NoError(t, err)
@@ -98,7 +97,7 @@ func TestWallet_GetHeight_WalletWithoutServices(t *testing.T) {
 		ForUser(testusers.Alice)
 
 	// When
-	result, err := wallet.GetHeight(context.Background(), nil, "test-originator")
+	result, err := wallet.GetHeight(t.Context(), nil, "test-originator")
 
 	// Then
 	require.Error(t, err)

--- a/pkg/wallet/wallet_get_height_test.go
+++ b/pkg/wallet/wallet_get_height_test.go
@@ -28,17 +28,14 @@ func TestWallet_GetHeight(t *testing.T) {
 }
 
 func TestWallet_GetHeight_InvalidOriginator(t *testing.T) {
-	tests := []struct {
-		name       string
-		originator string
-	}{
-		{"too long", strings.Repeat("a", 251)},
-		{"empty part", "invalid..originator"},
-		{"part too long", "part1." + strings.Repeat("a", 64) + ".part3"},
+	tests := map[string]string{
+		"too long":      strings.Repeat("a", 251),
+		"empty part":    "invalid..originator",
+		"part too long": "part1." + strings.Repeat("a", 64) + ".part3",
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, originator := range tests {
+		t.Run(name, func(t *testing.T) {
 			// given:
 			given, cleanup := testabilities.Given(t)
 			defer cleanup()
@@ -46,7 +43,7 @@ func TestWallet_GetHeight_InvalidOriginator(t *testing.T) {
 			w := given.Wallet().WithSQLiteStorage().WithServices().ForUser(testusers.Alice)
 
 			// when:
-			result, err := w.GetHeight(t.Context(), struct{}{}, tc.originator)
+			result, err := w.GetHeight(t.Context(), struct{}{}, originator)
 
 			// then:
 			require.Error(t, err)
@@ -57,18 +54,15 @@ func TestWallet_GetHeight_InvalidOriginator(t *testing.T) {
 }
 
 func TestWallet_GetHeight_ValidOriginators(t *testing.T) {
-	tests := []struct {
-		name       string
-		originator string
-	}{
-		{"empty", ""},
-		{"simple domain", "example.com"},
-		{"subdomain", "api.example.com"},
-		{"short", "a.b"},
+	tests := map[string]string{
+		"empty":         "",
+		"simple domain": "example.com",
+		"subdomain":     "api.example.com",
+		"short":         "a.b",
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, originator := range tests {
+		t.Run(name, func(t *testing.T) {
 			// given:
 			given, cleanup := testabilities.Given(t)
 			defer cleanup()
@@ -76,7 +70,7 @@ func TestWallet_GetHeight_ValidOriginators(t *testing.T) {
 			w := given.Wallet().WithSQLiteStorage().WithServices().ForUser(testusers.Alice)
 
 			// when:
-			result, err := w.GetHeight(t.Context(), struct{}{}, tc.originator)
+			result, err := w.GetHeight(t.Context(), struct{}{}, originator)
 
 			// then:
 			require.NoError(t, err)

--- a/pkg/wallet/wallet_get_height_test.go
+++ b/pkg/wallet/wallet_get_height_test.go
@@ -1,0 +1,107 @@
+package wallet_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/internal/testabilities"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWallet_GetHeight(t *testing.T) {
+	// given:
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+
+	w := given.Wallet().WithSQLiteStorage().WithServices().ForUser(testusers.Alice)
+	validOriginator := "example.com"
+
+	// when:
+	result, err := w.GetHeight(context.Background(), struct{}{}, validOriginator)
+
+	// then:
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Greater(t, result.Height, uint32(0))
+	t.Logf("Successfully got height: %d", result.Height)
+}
+
+func TestWallet_GetHeight_InvalidOriginator(t *testing.T) {
+	tests := []struct {
+		name       string
+		originator string
+	}{
+		{"too long", strings.Repeat("a", 251)},
+		{"empty part", "invalid..originator"},
+		{"part too long", "part1." + strings.Repeat("a", 64) + ".part3"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// given:
+			given, cleanup := testabilities.Given(t)
+			defer cleanup()
+
+			w := given.Wallet().WithSQLiteStorage().WithServices().ForUser(testusers.Alice)
+
+			// when:
+			result, err := w.GetHeight(context.Background(), struct{}{}, tc.originator)
+
+			// then:
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid originator")
+			require.Nil(t, result)
+		})
+	}
+}
+
+func TestWallet_GetHeight_ValidOriginators(t *testing.T) {
+	tests := []struct {
+		name       string
+		originator string
+	}{
+		{"empty", ""},
+		{"simple domain", "example.com"},
+		{"subdomain", "api.example.com"},
+		{"short", "a.b"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// given:
+			given, cleanup := testabilities.Given(t)
+			defer cleanup()
+
+			w := given.Wallet().WithSQLiteStorage().WithServices().ForUser(testusers.Alice)
+
+			// when:
+			result, err := w.GetHeight(context.Background(), struct{}{}, tc.originator)
+
+			// then:
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Greater(t, result.Height, uint32(0))
+		})
+	}
+}
+
+func TestWallet_GetHeight_WalletWithoutServices(t *testing.T) {
+	// Given
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+
+	wallet := given.Wallet().
+		WithSQLiteStorage().
+		// NOT calling WithServices()
+		ForUser(testusers.Alice)
+
+	// When
+	result, err := wallet.GetHeight(context.Background(), nil, "test-originator")
+
+	// Then
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "services are not configured for this wallet")
+	require.Nil(t, result)
+}


### PR DESCRIPTION
Closes #475
This pull request introduces support for wallet services in the wallet creation and usage flow, and implements the `GetHeight` method to retrieve the current blockchain height. It also adds comprehensive tests for the new functionality and originator validation. The changes are grouped into three main themes: wallet service integration, new feature implementation, and testing.

**Wallet service integration:**

* Added an optional `services` field to the `Wallet` struct and support for injecting wallet services via the new `WithServices` option in both the wallet builder and the wallet constructor. (`pkg/wallet/internal/testabilities/fixture_wallet_builder.go`, `pkg/wallet/internal/wallet_opts/wallet_opts.go`, `pkg/wallet/wallet.go`) [[1]](diffhunk://#diff-46c9ad57016c699e7246a8becb512f71d90028724a9ff56c9e0136e52df4c3caR4-R13) [[2]](diffhunk://#diff-46c9ad57016c699e7246a8becb512f71d90028724a9ff56c9e0136e52df4c3caR33-R41) [[3]](diffhunk://#diff-46c9ad57016c699e7246a8becb512f71d90028724a9ff56c9e0136e52df4c3caR50-R54) [[4]](diffhunk://#diff-46c9ad57016c699e7246a8becb512f71d90028724a9ff56c9e0136e52df4c3caL62-R79) [[5]](diffhunk://#diff-72c23512e5a524b79bc536aa7aa09765e9f27e5ebb2ce5b24860cd6827ad627dL3-R10) [[6]](diffhunk://#diff-ea88400ee9978d3861f790f89a8efae2e437c92fa450cf110dbde7a2a0fcbc42R10) [[7]](diffhunk://#diff-ea88400ee9978d3861f790f89a8efae2e437c92fa450cf110dbde7a2a0fcbc42R27) [[8]](diffhunk://#diff-ea88400ee9978d3861f790f89a8efae2e437c92fa450cf110dbde7a2a0fcbc42R61-R67) [[9]](diffhunk://#diff-ea88400ee9978d3861f790f89a8efae2e437c92fa450cf110dbde7a2a0fcbc42R99-R107)

**New feature implementation:**

* Implemented the `GetHeight` method on the `Wallet` struct to return the current blockchain height using the configured wallet services, with validation for the `originator` parameter and error handling if services are not configured. (`pkg/wallet/wallet.go`)

**Testing:**

* Added a new test file `wallet_get_height_test.go` with tests for successful height retrieval, originator validation (both valid and invalid cases), and handling of wallets without configured services. (`pkg/wallet/wallet_get_height_test.go`)
