### PR TITLE
feat: implement nLockTime finality check in transaction processing

### DIFF
--- a/pkg/storage/internal/actions/process.go
+++ b/pkg/storage/internal/actions/process.go
@@ -117,7 +117,13 @@ func (p *process) processNewTx(ctx context.Context, userID int, args *wdk.Proces
 		return fmt.Errorf("txID mismatch: provided %s, calculated from raw tx: %s", *args.TxID, txID)
 	}
 
-	// TODO: Services::nLockTimeIsFinal(tx)
+	isFinal, err := p.services.NLockTimeIsFinal(ctx, tx)
+	if err != nil {
+		return fmt.Errorf("failed to check nLockTime finality: %w", err)
+	}
+	if !isFinal {
+		return fmt.Errorf("transaction nLockTime is not final")
+	}
 
 	txEntity, err := p.txRepo.FindTransactionByReference(ctx, userID, *args.Reference)
 	if err != nil {

--- a/pkg/storage/provider_process_action_test.go
+++ b/pkg/storage/provider_process_action_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const nLockTimeThreshold = uint32(500_000_000)
+
 func TestProcessActionHappyPath(t *testing.T) {
 	// given:
 	given, cleanup := testabilities.Given(t)
@@ -673,7 +675,7 @@ func TestProcessActionNLockTimeIsFinalThresholdBoundary(t *testing.T) {
 
 	createActionResult, originalTx := given.Action(activeStorage).Created()
 
-	const nLockTimeThreshold = uint32(500_000_000)
+	const nLockTimeThreshold = nLockTimeThreshold
 	modifiedTx := *originalTx
 	modifiedTx.LockTime = nLockTimeThreshold
 	if len(modifiedTx.Inputs) > 0 {

--- a/pkg/storage/provider_process_action_test.go
+++ b/pkg/storage/provider_process_action_test.go
@@ -1,11 +1,13 @@
 package storage_test
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/bsv-blockchain/go-sdk/transaction"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/testutils"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/randomizer"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/storage/internal/testabilities"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
@@ -448,4 +450,253 @@ func TestProcessActionARCReturnNoBody(t *testing.T) {
 	assert.Equal(t, txID, string(reviewActionResult.TxID))
 	assert.Equal(t, wdk.ReviewActionResultStatusServiceError, reviewActionResult.Status)
 	assert.Empty(t, reviewActionResult.CompetingTxs)
+}
+
+func TestProcessActionNLockTimeIsFinalSuccess(t *testing.T) {
+	tests := map[string]struct {
+		setupService func(given testabilities.StorageFixture)
+		lockTime     uint32
+		sequences    []uint32
+		description  string
+	}{
+		"zero locktime is always final": {
+			setupService: func(given testabilities.StorageFixture) {
+				// No special setup needed for zero locktime
+			},
+			lockTime:    0,
+			sequences:   []uint32{0, 1, 2},
+			description: "zero locktime should always be final",
+		},
+		"all inputs max sequence shortcut": {
+			setupService: func(given testabilities.StorageFixture) {
+				// No height check needed when all inputs have max sequence
+			},
+			lockTime:    700_000,
+			sequences:   []uint32{testutils.MaxSeq, testutils.MaxSeq, testutils.MaxSeq},
+			description: "all max sequence inputs should be final regardless of locktime",
+		},
+		"block height locktime final": {
+			setupService: func(given testabilities.StorageFixture) {
+				const currentHeight = uint32(800_000)
+				given.Provider().WhatsOnChain().WillRespondWithChainInfo(http.StatusOK, currentHeight)
+			},
+			lockTime:    799_999,
+			sequences:   []uint32{0},
+			description: "locktime less than current height should be final",
+		},
+		"timestamp locktime final": {
+			setupService: func(given testabilities.StorageFixture) {
+				// No special setup needed for timestamp validation
+			},
+			lockTime:    uint32(time.Now().Unix() - 3600),
+			sequences:   []uint32{0},
+			description: "past timestamp locktime should be final",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// given:
+			given, cleanup := testabilities.Given(t)
+			defer cleanup()
+
+			test.setupService(given)
+
+			activeStorage := given.Provider().
+				WithRandomizer(randomizer.NewTestRandomizer()).
+				GORM()
+
+			createActionResult, originalTx := given.Action(activeStorage).Created()
+
+			modifiedTx := *originalTx
+			modifiedTx.LockTime = test.lockTime
+			for i, seq := range test.sequences {
+				if i < len(modifiedTx.Inputs) {
+					modifiedTx.Inputs[i].SequenceNumber = seq
+				}
+			}
+
+			txID := modifiedTx.TxID().String()
+
+			args := wdk.ProcessActionArgs{
+				IsNewTx:    true,
+				IsSendWith: false,
+				IsNoSend:   false,
+				IsDelayed:  false,
+				Reference:  to.Ptr(createActionResult.Reference),
+				TxID:       to.Ptr(primitives.TXIDHexString(txID)),
+				RawTx:      modifiedTx.Bytes(),
+				SendWith:   []primitives.TXIDHexString{},
+			}
+
+			// when:
+			result, err := activeStorage.ProcessAction(t.Context(), testusers.Alice.AuthID(), args)
+
+			// then:
+			require.NoError(t, err)
+			require.NotNil(t, result)
+		})
+	}
+}
+
+func TestProcessActionNLockTimeIsFinalFailure(t *testing.T) {
+	tests := map[string]struct {
+		setupService func(given testabilities.StorageFixture)
+		lockTime     uint32
+		sequences    []uint32
+	}{
+		"block height locktime not final": {
+			setupService: func(given testabilities.StorageFixture) {
+				const currentHeight = uint32(800_000)
+				given.Provider().WhatsOnChain().WillRespondWithChainInfo(http.StatusOK, currentHeight)
+			},
+			lockTime:  800_001,
+			sequences: []uint32{0},
+		},
+		"timestamp locktime not final": {
+			setupService: func(given testabilities.StorageFixture) {
+				// No special setup needed for timestamp validation
+			},
+			lockTime:  uint32(time.Now().Unix() + 7200),
+			sequences: []uint32{0},
+		},
+		"mixed sequences with future block height": {
+			setupService: func(given testabilities.StorageFixture) {
+				const currentHeight = uint32(500_000)
+				given.Provider().WhatsOnChain().WillRespondWithChainInfo(http.StatusOK, currentHeight)
+			},
+			lockTime:  500_001,
+			sequences: []uint32{testutils.MaxSeq - 1, 0, testutils.MaxSeq},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// given:
+			given, cleanup := testabilities.Given(t)
+			defer cleanup()
+
+			test.setupService(given)
+
+			activeStorage := given.Provider().
+				WithRandomizer(randomizer.NewTestRandomizer()).
+				GORM()
+
+			// and:
+			createActionResult, originalTx := given.Action(activeStorage).Created()
+
+			modifiedTx := *originalTx
+			modifiedTx.LockTime = test.lockTime
+			for i, seq := range test.sequences {
+				if i < len(modifiedTx.Inputs) {
+					modifiedTx.Inputs[i].SequenceNumber = seq
+				}
+			}
+
+			txID := modifiedTx.TxID().String()
+
+			args := wdk.ProcessActionArgs{
+				IsNewTx:    true,
+				IsSendWith: false,
+				IsNoSend:   false,
+				IsDelayed:  false,
+				Reference:  to.Ptr(createActionResult.Reference),
+				TxID:       to.Ptr(primitives.TXIDHexString(txID)),
+				RawTx:      modifiedTx.Bytes(),
+				SendWith:   []primitives.TXIDHexString{},
+			}
+
+			// when:
+			_, err := activeStorage.ProcessAction(t.Context(), testusers.Alice.AuthID(), args)
+
+			// then:
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "transaction nLockTime is not final")
+		})
+	}
+}
+
+func TestProcessActionNLockTimeIsFinalServiceError(t *testing.T) {
+	// given:
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+
+	givenProvider := given.Provider()
+
+	err := givenProvider.WhatsOnChain().WillBeUnreachable()
+	require.Error(t, err)
+	givenProvider.Bitails().WillReturnNetworkInfo(http.StatusBadGateway, 0)
+	err = givenProvider.BHS().WillBeUnreachable()
+	require.Error(t, err)
+
+	activeStorage := givenProvider.
+		WithRandomizer(randomizer.NewTestRandomizer()).
+		GORM()
+
+	createActionResult, originalTx := given.Action(activeStorage).Created()
+
+	modifiedTx := *originalTx
+	modifiedTx.LockTime = 400_000
+	if len(modifiedTx.Inputs) > 0 {
+		modifiedTx.Inputs[0].SequenceNumber = 0
+	}
+
+	txID := modifiedTx.TxID().String()
+
+	args := wdk.ProcessActionArgs{
+		IsNewTx:    true,
+		IsSendWith: false,
+		IsNoSend:   false,
+		IsDelayed:  false,
+		Reference:  to.Ptr(createActionResult.Reference),
+		TxID:       to.Ptr(primitives.TXIDHexString(txID)),
+		RawTx:      modifiedTx.Bytes(),
+		SendWith:   []primitives.TXIDHexString{},
+	}
+
+	// when:
+	_, err = activeStorage.ProcessAction(t.Context(), testusers.Alice.AuthID(), args)
+
+	// then:
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to check nLockTime finality")
+}
+
+func TestProcessActionNLockTimeIsFinalThresholdBoundary(t *testing.T) {
+	// given:
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+
+	activeStorage := given.Provider().
+		WithRandomizer(randomizer.NewTestRandomizer()).
+		GORM()
+
+	createActionResult, originalTx := given.Action(activeStorage).Created()
+
+	const nLockTimeThreshold = uint32(500_000_000)
+	modifiedTx := *originalTx
+	modifiedTx.LockTime = nLockTimeThreshold
+	if len(modifiedTx.Inputs) > 0 {
+		modifiedTx.Inputs[0].SequenceNumber = 0
+	}
+
+	txID := modifiedTx.TxID().String()
+
+	args := wdk.ProcessActionArgs{
+		IsNewTx:    true,
+		IsSendWith: false,
+		IsNoSend:   false,
+		IsDelayed:  false,
+		Reference:  to.Ptr(createActionResult.Reference),
+		TxID:       to.Ptr(primitives.TXIDHexString(txID)),
+		RawTx:      modifiedTx.Bytes(),
+		SendWith:   []primitives.TXIDHexString{},
+	}
+
+	// when:
+	result, err := activeStorage.ProcessAction(t.Context(), testusers.Alice.AuthID(), args)
+
+	// then:
+	require.NoError(t, err)
+	require.NotNil(t, result)
 }

--- a/pkg/wdk/services.interface.go
+++ b/pkg/wdk/services.interface.go
@@ -16,6 +16,7 @@ type Services interface {
 	FindChainTipHeader(ctx context.Context) (*ChainBlockHeader, error)
 	RawTx(txID string) (RawTxResult, error)
 	GetBEEF(ctx context.Context, txID string, knownTxIDs []string) (*transaction.Beef, error)
+	NLockTimeIsFinal(ctx context.Context, txOrLockTime any) (bool, error)
 }
 
 // HeightProvider is an interface that provides the current blockchain height.


### PR DESCRIPTION
Closes: #490
This pull request introduces comprehensive validation and testing for transaction `nLockTime` finality in the transaction processing logic. It ensures that transactions are only processed if their `nLockTime` is considered final, improving the correctness and security of transaction handling. The most important changes are grouped below:

**Transaction finality enforcement:**

* Added a call to the new `NLockTimeIsFinal` service method in the `processNewTx` function to check transaction finality before processing. If the check fails or the transaction is not final, an error is returned.
* Extended the `Services` interface to include the new `NLockTimeIsFinal` method, which determines if a transaction or locktime is final.

**Testing for nLockTime finality:**

* Added extensive tests in `provider_process_action_test.go` to verify correct handling of various `nLockTime` scenarios, including successful finality, failure cases, service errors, and threshold boundary conditions. These tests ensure that the new logic is robust and correctly integrated.
* Updated test imports to include necessary dependencies for the new tests.## Description of Changes