### PR TITLE
feat: provide the functions in brc29 package to generate Address for recipient from sender side and or himself

### DIFF
--- a/examples/internal/example_setup/faucet_address.go
+++ b/examples/internal/example_setup/faucet_address.go
@@ -18,10 +18,10 @@ func FaucetAddress(wallet *Setup) {
 		DerivationSuffix: base64.StdEncoding.EncodeToString(parts.DerivationSuffix),
 	}
 
-	address, err := brc29.Address(
-		wallet.PrivateKey,
+	address, err := brc29.MyAddress(
+		parts.SenderIdentityKey,
 		keyID,
-		wallet.IdentityKey,
+		wallet.PrivateKey,
 		brc29.WithTestNet(),
 	)
 	if err != nil {

--- a/examples/internal/example_setup/faucet_address.go
+++ b/examples/internal/example_setup/faucet_address.go
@@ -18,7 +18,7 @@ func FaucetAddress(wallet *Setup) {
 		DerivationSuffix: base64.StdEncoding.EncodeToString(parts.DerivationSuffix),
 	}
 
-	address, err := brc29.MyAddress(
+	address, err := brc29.AddressForSelf(
 		parts.SenderIdentityKey,
 		keyID,
 		wallet.PrivateKey,

--- a/examples/internal/example_setup/internalize_tx.go
+++ b/examples/internal/example_setup/internalize_tx.go
@@ -2,27 +2,23 @@ package example_setup
 
 import (
 	"context"
-	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
 	sdk "github.com/bsv-blockchain/go-sdk/wallet"
 	"github.com/bsv-blockchain/go-wallet-toolbox/examples/internal/show"
 	"github.com/bsv-blockchain/go-wallet-toolbox/examples/internal/utils"
 )
 
 // InternalizeFromFaucet is a helper function to internalize a transaction from the faucet
-func InternalizeFromFaucet(ctx context.Context, atomicBeefBytes []byte, wallet sdk.Interface, identityKey *ec.PublicKey) error {
+func InternalizeFromFaucet(ctx context.Context, atomicBeefBytes []byte, wallet sdk.Interface) error {
 	paymentRemittance := utils.DerivationParts()
 
 	internalizeArgs := sdk.InternalizeActionArgs{
 		Tx: atomicBeefBytes,
 		Outputs: []sdk.InternalizeOutput{
 			{
-				OutputIndex: 0,
-				Protocol:    "wallet payment",
-				PaymentRemittance: &sdk.Payment{
-					DerivationPrefix:  paymentRemittance.DerivationPrefix,
-					DerivationSuffix:  paymentRemittance.DerivationSuffix,
-					SenderIdentityKey: identityKey,
-				},
+				OutputIndex:       0,
+				Protocol:          "wallet payment",
+				PaymentRemittance: paymentRemittance,
 			},
 		},
 		Description: "internalize from faucet",

--- a/examples/internal/utils/key_derivation.go
+++ b/examples/internal/utils/key_derivation.go
@@ -25,22 +25,20 @@ type DerivationBytesResult struct {
 }
 
 // DerivationParts creates derivation parts with default prefix and suffix
-func DerivationParts() PaymentRemittance {
+func DerivationParts() *sdk.Payment {
 	prefix := "" // empty string will use default base64 prefix
 	suffix := "" // empty string will use default base64 suffix
 	bytes := derivationBytes(prefix, suffix)
 
-	var identityKey string
 	_, publicKey := sdk.AnyoneKey()
-	identityKey = publicKey.ToDERHex()
 
-	paymentRemittance := &PaymentRemittance{
+	paymentRemittance := &sdk.Payment{
 		DerivationPrefix:  bytes.DerivationPrefix,
 		DerivationSuffix:  bytes.DerivationSuffix,
-		SenderIdentityKey: identityKey,
+		SenderIdentityKey: publicKey,
 	}
 
-	return *paymentRemittance
+	return paymentRemittance
 }
 
 func derivationBytes(prefix string, suffix string) DerivationBytesResult {

--- a/examples/wallet_examples/internalize_tx_from_faucet/internalize_tx_from_faucet.go
+++ b/examples/wallet_examples/internalize_tx_from_faucet/internalize_tx_from_faucet.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
+
 	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/services"
-	"log/slog"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/examples/internal/example_setup"
 	"github.com/bsv-blockchain/go-wallet-toolbox/examples/internal/show"
@@ -14,7 +15,7 @@ import (
 
 // The txID is the transaction ID of the transaction to internalize
 // Pass in your txID from the faucet_address example
-var txID = "" //example: 15f47f2db5f26469c081e8d80d91a4b0f06e4a97abcc022b0b5163ac5f6cc0c8
+var txID = "" // example: 15f47f2db5f26469c081e8d80d91a4b0f06e4a97abcc022b0b5163ac5f6cc0c8
 
 // To internalize a transaction from the faucet, you need to pass the txid of the transaction to internalize
 // Use the faucet_address example to get the user address and follow the instructions to fund the address from the faucet
@@ -57,7 +58,7 @@ func main() {
 	show.Step("Alice", "Internalizing transaction from faucet")
 
 	// This method will internalize the transaction from the faucet into the wallet database
-	err = example_setup.InternalizeFromFaucet(ctx, atomicBeef, aliceWallet, alice.IdentityKey)
+	err = example_setup.InternalizeFromFaucet(ctx, atomicBeef, aliceWallet)
 	if err != nil {
 		panic(fmt.Errorf("failed to internalize tx: %w", err))
 	}

--- a/manual_tests/internal/tui/internalize_form.go
+++ b/manual_tests/internal/tui/internalize_form.go
@@ -240,7 +240,7 @@ func calculateAddressForInternalize(derivationPrefix, derivationSuffix string, u
 	}
 
 	networkOption := to.IfThen(bsvNetwork == defs.NetworkMainnet, brc29.WithMainNet()).ElseThen(brc29.WithTestNet())
-	address, err := brc29.YourAddress(anyonePriv, keyID, user.PublicKey(), networkOption)
+	address, err := brc29.AddressForCounterparty(anyonePriv, keyID, user.PublicKey(), networkOption)
 	if err != nil {
 		return "", fmt.Errorf("failed to calculate address: %w", err)
 	}

--- a/manual_tests/internal/tui/internalize_form.go
+++ b/manual_tests/internal/tui/internalize_form.go
@@ -240,7 +240,7 @@ func calculateAddressForInternalize(derivationPrefix, derivationSuffix string, u
 	}
 
 	networkOption := to.IfThen(bsvNetwork == defs.NetworkMainnet, brc29.WithMainNet()).ElseThen(brc29.WithTestNet())
-	address, err := brc29.Address(anyonePriv, keyID, user.PublicKey(), networkOption)
+	address, err := brc29.YourAddress(anyonePriv, keyID, user.PublicKey(), networkOption)
 	if err != nil {
 		return "", fmt.Errorf("failed to calculate address: %w", err)
 	}

--- a/pkg/brc29/brc29_address.go
+++ b/pkg/brc29/brc29_address.go
@@ -33,7 +33,7 @@ import (
 // var pub *ec.PublicKey = ...
 // var priv *ec.PrivateKey = ...
 //
-// address, err := brc29.AddressForSelf(brc29.PubHex("ab..."), keyID, brc29.PrivHex("cd..."))
+// address, err := brc29.AddressForSelf(pub, keyID, priv)
 // ```
 // 4. Use WIF string to generate an address
 // ```go
@@ -43,7 +43,7 @@ import (
 // ```go
 // address, err := brc29.AddressForSelf(brc29.PubHex("ab..."), keyID, brc29.PrivHex("cd..."), brc29.WithTestNet())
 // ```
-func AddressForSelf[S CounterpartyPublicKey, R CounterpartyPrivateKey](senderPublicKey S, keyID KeyID, myPrivateKey R, opts ...func(*lockOptions)) (*script.Address, error) {
+func AddressForSelf[S CounterpartyPublicKey, R CounterpartyPrivateKey](senderPublicKey S, keyID KeyID, selfPrivateKey R, opts ...func(*lockOptions)) (*script.Address, error) {
 	options := &lockOptions{
 		mainNet: true,
 	}
@@ -52,7 +52,7 @@ func AddressForSelf[S CounterpartyPublicKey, R CounterpartyPrivateKey](senderPub
 		opt(options)
 	}
 
-	key, err := deriveRecipientPrivateKey(senderPublicKey, keyID, myPrivateKey)
+	key, err := deriveRecipientPrivateKey(senderPublicKey, keyID, selfPrivateKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to derive key for BRC29 address: %w", err)
 	}
@@ -90,7 +90,7 @@ func AddressForSelf[S CounterpartyPublicKey, R CounterpartyPrivateKey](senderPub
 // var priv *ec.PrivateKey = ...
 // var pub *ec.PublicKey = ...
 //
-// address, err := brc29.AddressForCounterparty(brc29.PrivHex("ab..."), keyID, brc29.PubHex("cd..."))
+// address, err := brc29.AddressForCounterparty(priv, keyID, pub)
 // ```
 // 4. Use WIF string to generate an address
 // ```go
@@ -100,7 +100,7 @@ func AddressForSelf[S CounterpartyPublicKey, R CounterpartyPrivateKey](senderPub
 // ```go
 // address, err := brc29.AddressForCounterparty(brc29.PrivHex("ab..."), keyID, brc29.PubHex("cd..."), brc29.WithTestNet())
 // ```
-func AddressForCounterparty[S CounterpartyPrivateKey, R CounterpartyPublicKey](senderPrivateKey S, keyID KeyID, yourPublicKey R, opts ...func(*lockOptions)) (*script.Address, error) {
+func AddressForCounterparty[S CounterpartyPrivateKey, R CounterpartyPublicKey](senderPrivateKey S, keyID KeyID, counterpartyPublicKey R, opts ...func(*lockOptions)) (*script.Address, error) {
 	options := &lockOptions{
 		mainNet: true,
 	}
@@ -118,9 +118,9 @@ func AddressForCounterparty[S CounterpartyPrivateKey, R CounterpartyPublicKey](s
 		return nil, fmt.Errorf("failed to create sender key deriver from %T: %w", senderPrivateKey, err)
 	}
 
-	recipientIdentityKey, err := toIdentityKey(yourPublicKey)
+	recipientIdentityKey, err := toIdentityKey(counterpartyPublicKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create recipient identity key from %T: %w", yourPublicKey, err)
+		return nil, fmt.Errorf("failed to create recipient identity key from %T: %w", counterpartyPublicKey, err)
 	}
 
 	key, err := senderKeyDeriver.DerivePublicKey(Protocol, keyID.String(), sdk.Counterparty{

--- a/pkg/brc29/brc29_address.go
+++ b/pkg/brc29/brc29_address.go
@@ -7,9 +7,9 @@ import (
 	sdk "github.com/bsv-blockchain/go-sdk/wallet"
 )
 
-// MyAddress generates a blockchain address according to BRC29 specification.
+// AddressForSelf generates a blockchain address according to BRC29 specification.
 // It is meant to be used by the recipient to generate a BRC29 address for himself.
-// If you are a sender, and you want to generate an address to send funds for a recipient, use brc29.YourAddress instead.
+// If you are a sender, and you want to generate an address to send funds for a recipient, use brc29.AddressForCounterparty instead.
 //
 // The sender key can be a public key hex or a key deriver or ec.PublicKey.
 // The recipient key can be a private key hex string or a key deriver or ec.PrivateKey.
@@ -19,31 +19,31 @@ import (
 // Examples:
 // 1. Use key hexes to generate an address
 // ```go
-// address, err := brc29.MyAddress(brc29.PubHex("ab..."), keyID, brc29.PrivHex("cd..."))
+// address, err := brc29.AddressForSelf(brc29.PubHex("ab..."), keyID, brc29.PrivHex("cd..."))
 // ```
 // 2. Use key derivers to generate an address
 // ```go
 // var senderDeriver *sdk.KeyDeriver = ...
 // var recipientDeriver *sdk.KeyDeriver = ...
 //
-// address, err := brc29.MyAddress(senderDeriver, keyID, recipientDeriver)
+// address, err := brc29.AddressForSelf(senderDeriver, keyID, recipientDeriver)
 // ```
 // 3. Use ec.PublicKey and ec.PrivateKey to generate an address
 // ```go
 // var pub *ec.PublicKey = ...
 // var priv *ec.PrivateKey = ...
 //
-// address, err := brc29.MyAddress(brc29.PubHex("ab..."), keyID, brc29.PrivHex("cd..."))
+// address, err := brc29.AddressForSelf(brc29.PubHex("ab..."), keyID, brc29.PrivHex("cd..."))
 // ```
 // 4. Use WIF string to generate an address
 // ```go
-// address, err := brc29.MyAddress(pub, keyID, brc29.WIF("ab..."))
+// address, err := brc29.AddressForSelf(pub, keyID, brc29.WIF("ab..."))
 // ```
 // 5. Testnet address
 // ```go
-// address, err := brc29.MyAddress(brc29.PubHex("ab..."), keyID, brc29.PrivHex("cd..."), brc29.WithTestNet())
+// address, err := brc29.AddressForSelf(brc29.PubHex("ab..."), keyID, brc29.PrivHex("cd..."), brc29.WithTestNet())
 // ```
-func MyAddress[S CounterpartyPublicKey, R CounterpartyPrivateKey](senderPublicKey S, keyID KeyID, myPrivateKey R, opts ...func(*lockOptions)) (*script.Address, error) {
+func AddressForSelf[S CounterpartyPublicKey, R CounterpartyPrivateKey](senderPublicKey S, keyID KeyID, myPrivateKey R, opts ...func(*lockOptions)) (*script.Address, error) {
 	options := &lockOptions{
 		mainNet: true,
 	}
@@ -64,9 +64,9 @@ func MyAddress[S CounterpartyPublicKey, R CounterpartyPrivateKey](senderPublicKe
 	return address, nil
 }
 
-// YourAddress generates a blockchain address according to BRC29 specification.
+// AddressForCounterparty generates a blockchain address according to BRC29 specification.
 // It is meant to be used by the sender to generate a BRC29 address for a recipient.
-// If you are a recipient, and you want to generate an address to pass it to a sender, use brc29.MyAddress instead.
+// If you are a recipient, and you want to generate an address to pass it to a sender, use brc29.AddressForSelf instead.
 //
 // The sender key can be a private key hex string or a key deriver or ec.PrivateKey.
 // The recipient key can be a public key hex or a key deriver or ec.PublicKey.
@@ -76,31 +76,31 @@ func MyAddress[S CounterpartyPublicKey, R CounterpartyPrivateKey](senderPublicKe
 // Examples:
 // 1. Use key hexes to generate an address
 // ```go
-// address, err := brc29.YourAddress(brc29.PrivHex("ab..."), keyID, brc29.PubHex("cd..."))
+// address, err := brc29.AddressForCounterparty(brc29.PrivHex("ab..."), keyID, brc29.PubHex("cd..."))
 // ```
 // 2. Use key derivers to generate an address
 // ```go
 // var senderDeriver *sdk.KeyDeriver = ...
 // var recipientDeriver *sdk.KeyDeriver = ...
 //
-// address, err := brc29.YourAddress(senderDeriver, keyID, recipientDeriver)
+// address, err := brc29.AddressForCounterparty(senderDeriver, keyID, recipientDeriver)
 // ```
 // 3. Use ec.PrivateKey and ec.PublicKey to generate an address
 // ```go
 // var priv *ec.PrivateKey = ...
 // var pub *ec.PublicKey = ...
 //
-// address, err := brc29.YourAddress(brc29.PrivHex("ab..."), keyID, brc29.PubHex("cd..."))
+// address, err := brc29.AddressForCounterparty(brc29.PrivHex("ab..."), keyID, brc29.PubHex("cd..."))
 // ```
 // 4. Use WIF string to generate an address
 // ```go
-// address, err := brc29.YourAddress(brc29.WIF("ab..."), keyID, pub)
+// address, err := brc29.AddressForCounterparty(brc29.WIF("ab..."), keyID, pub)
 // ```
 // 5. Testnet address
 // ```go
-// address, err := brc29.YourAddress(brc29.PrivHex("ab..."), keyID, brc29.PubHex("cd..."), brc29.WithTestNet())
+// address, err := brc29.AddressForCounterparty(brc29.PrivHex("ab..."), keyID, brc29.PubHex("cd..."), brc29.WithTestNet())
 // ```
-func YourAddress[S CounterpartyPrivateKey, R CounterpartyPublicKey](senderPrivateKey S, keyID KeyID, yourPublicKey R, opts ...func(*lockOptions)) (*script.Address, error) {
+func AddressForCounterparty[S CounterpartyPrivateKey, R CounterpartyPublicKey](senderPrivateKey S, keyID KeyID, yourPublicKey R, opts ...func(*lockOptions)) (*script.Address, error) {
 	options := &lockOptions{
 		mainNet: true,
 	}

--- a/pkg/brc29/brc29_address.go
+++ b/pkg/brc29/brc29_address.go
@@ -7,15 +7,100 @@ import (
 	sdk "github.com/bsv-blockchain/go-sdk/wallet"
 )
 
-const forSelf = false
+// MyAddress generates a blockchain address according to BRC29 specification.
+// It is meant to be used by the recipient to generate a BRC29 address for himself.
+// If you are a sender, and you want to generate an address to send funds for a recipient, use brc29.YourAddress instead.
+//
+// The sender key can be a public key hex or a key deriver or ec.PublicKey.
+// The recipient key can be a private key hex string or a key deriver or ec.PrivateKey.
+//
+// Additional options allow setting the address network to mainnet or testnet. By default, mainnet address is generated.
+//
+// Examples:
+// 1. Use key hexes to generate an address
+// ```go
+// address, err := brc29.MyAddress(brc29.PubHex("ab..."), keyID, brc29.PrivHex("cd..."))
+// ```
+// 2. Use key derivers to generate an address
+// ```go
+// var senderDeriver *sdk.KeyDeriver = ...
+// var recipientDeriver *sdk.KeyDeriver = ...
+//
+// address, err := brc29.MyAddress(senderDeriver, keyID, recipientDeriver)
+// ```
+// 3. Use ec.PublicKey and ec.PrivateKey to generate an address
+// ```go
+// var pub *ec.PublicKey = ...
+// var priv *ec.PrivateKey = ...
+//
+// address, err := brc29.MyAddress(brc29.PubHex("ab..."), keyID, brc29.PrivHex("cd..."))
+// ```
+// 4. Use WIF string to generate an address
+// ```go
+// address, err := brc29.MyAddress(pub, keyID, brc29.WIF("ab..."))
+// ```
+// 5. Testnet address
+// ```go
+// address, err := brc29.MyAddress(brc29.PubHex("ab..."), keyID, brc29.PrivHex("cd..."), brc29.WithTestNet())
+// ```
+func MyAddress[S CounterpartyPublicKey, R CounterpartyPrivateKey](senderPublicKey S, keyID KeyID, myPrivateKey R, opts ...func(*lockOptions)) (*script.Address, error) {
+	options := &lockOptions{
+		mainNet: true,
+	}
 
-// Address generates a blockchain address according to BRC29 specification.
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	key, err := deriveRecipientPrivateKey(senderPublicKey, keyID, myPrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive key for BRC29 address: %w", err)
+	}
+
+	address, err := script.NewAddressFromPublicKey(key.PubKey(), options.mainNet)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create brc29 address from public key: %w", err)
+	}
+	return address, nil
+}
+
+// YourAddress generates a blockchain address according to BRC29 specification.
+// It is meant to be used by the sender to generate a BRC29 address for a recipient.
+// If you are a recipient, and you want to generate an address to pass it to a sender, use brc29.MyAddress instead.
 //
 // The sender key can be a private key hex string or a key deriver or ec.PrivateKey.
 // The recipient key can be a public key hex or a key deriver or ec.PublicKey.
 //
 // Additional options allow setting the address network to mainnet or testnet.
-func Address[SenderKey CounterpartyPrivateKey, RecipientKey CounterpartyPublicKey](senderPrivateKeySource SenderKey, keyID KeyID, recipientPublicKeySource RecipientKey, opts ...func(*lockOptions)) (*script.Address, error) {
+//
+// Examples:
+// 1. Use key hexes to generate an address
+// ```go
+// address, err := brc29.YourAddress(brc29.PrivHex("ab..."), keyID, brc29.PubHex("cd..."))
+// ```
+// 2. Use key derivers to generate an address
+// ```go
+// var senderDeriver *sdk.KeyDeriver = ...
+// var recipientDeriver *sdk.KeyDeriver = ...
+//
+// address, err := brc29.YourAddress(senderDeriver, keyID, recipientDeriver)
+// ```
+// 3. Use ec.PrivateKey and ec.PublicKey to generate an address
+// ```go
+// var priv *ec.PrivateKey = ...
+// var pub *ec.PublicKey = ...
+//
+// address, err := brc29.YourAddress(brc29.PrivHex("ab..."), keyID, brc29.PubHex("cd..."))
+// ```
+// 4. Use WIF string to generate an address
+// ```go
+// address, err := brc29.YourAddress(brc29.WIF("ab..."), keyID, pub)
+// ```
+// 5. Testnet address
+// ```go
+// address, err := brc29.YourAddress(brc29.PrivHex("ab..."), keyID, brc29.PubHex("cd..."), brc29.WithTestNet())
+// ```
+func YourAddress[S CounterpartyPrivateKey, R CounterpartyPublicKey](senderPrivateKey S, keyID KeyID, yourPublicKey R, opts ...func(*lockOptions)) (*script.Address, error) {
 	options := &lockOptions{
 		mainNet: true,
 	}
@@ -28,27 +113,27 @@ func Address[SenderKey CounterpartyPrivateKey, RecipientKey CounterpartyPublicKe
 		return nil, fmt.Errorf("invalid key ID: %w", err)
 	}
 
-	senderKeyDeriver, err := toKeyDeriver(senderPrivateKeySource)
+	senderKeyDeriver, err := toKeyDeriver(senderPrivateKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create sender key deriver from %T: %w", senderPrivateKeySource, err)
+		return nil, fmt.Errorf("failed to create sender key deriver from %T: %w", senderPrivateKey, err)
 	}
 
-	recipientIdentityKey, err := toIdentityKey(recipientPublicKeySource)
+	recipientIdentityKey, err := toIdentityKey(yourPublicKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create recipient identity key from %T: %w", recipientPublicKeySource, err)
+		return nil, fmt.Errorf("failed to create recipient identity key from %T: %w", yourPublicKey, err)
 	}
 
 	key, err := senderKeyDeriver.DerivePublicKey(Protocol, keyID.String(), sdk.Counterparty{
 		Type:         sdk.CounterpartyTypeOther,
 		Counterparty: recipientIdentityKey,
-	}, forSelf)
+	}, false)
 	if err != nil {
-		return nil, fmt.Errorf("failed to derive public key for BRC29: %w", err)
+		return nil, fmt.Errorf("failed to derive public key for recipient for BRC29 address: %w", err)
 	}
 
 	address, err := script.NewAddressFromPublicKey(key, options.mainNet)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create address from public key: %w", err)
+		return nil, fmt.Errorf("failed to create brc29 address for recipient from public key: %w", err)
 	}
 	return address, nil
 }

--- a/pkg/brc29/brc29_address_test.go
+++ b/pkg/brc29/brc29_address_test.go
@@ -10,10 +10,123 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBRC29AddressByRecipientCreation(t *testing.T) {
+	t.Run("return valid address with hex string as sender public key source", func(t *testing.T) {
+		address, err := brc29.MyAddress(brc29.PubHex(senderPublicKeyHex), keyID, brc29.PrivHex(recipientPrivateKeyHex))
+		assert.NoError(t, err)
+		require.NotNil(t, address)
+		require.Equal(t, expectedAddress, address.AddressString)
+	})
+
+	t.Run("return valid address with ec.PublicKey as sender public key source", func(t *testing.T) {
+		pub, err := ec.PublicKeyFromString(senderPublicKeyHex)
+		require.NoError(t, err)
+		address, err := brc29.MyAddress(pub, keyID, brc29.PrivHex(recipientPrivateKeyHex))
+		assert.NoError(t, err)
+		require.NotNil(t, address)
+		require.Equal(t, expectedAddress, address.AddressString)
+	})
+
+	t.Run("return valid address with sender key deriver as sender public key source", func(t *testing.T) {
+		priv, err := ec.PrivateKeyFromHex(senderPrivateKeyHex)
+		require.NoError(t, err)
+		keyDeriver := sdk.NewKeyDeriver(priv)
+		address, err := brc29.MyAddress(keyDeriver, keyID, brc29.PrivHex(recipientPrivateKeyHex))
+		assert.NoError(t, err)
+		require.NotNil(t, address)
+		require.Equal(t, expectedAddress, address.AddressString)
+	})
+
+	t.Run("return valid address with ec.PrivateKey as recipient private key source", func(t *testing.T) {
+		priv, err := ec.PrivateKeyFromHex(recipientPrivateKeyHex)
+		require.NoError(t, err)
+		address, err := brc29.MyAddress(brc29.PubHex(senderPublicKeyHex), keyID, priv)
+		assert.NoError(t, err)
+		require.NotNil(t, address)
+		require.Equal(t, expectedAddress, address.AddressString)
+	})
+
+	t.Run("return testnet address created with brc29 by recipient", func(t *testing.T) {
+		address, err := brc29.MyAddress(brc29.PubHex(senderPublicKeyHex), keyID, brc29.PrivHex(recipientPrivateKeyHex), brc29.WithTestNet())
+		assert.NoError(t, err)
+		require.NotNil(t, address)
+		require.Equal(t, expectedTestnetAddress, address.AddressString)
+	})
+}
+
+func TestBRC29AddressByRecipientErrors(t *testing.T) {
+	errorTestCases := map[string]struct {
+		sender    string
+		keyID     brc29.KeyID
+		recipient string
+	}{
+		"return error when sender key is empty": {
+			sender:    "",
+			keyID:     keyID,
+			recipient: invalidKeyHex,
+		},
+		"return error when sender key parsing fails": {
+			sender:    invalidKeyHex,
+			keyID:     keyID,
+			recipient: recipientPrivateKeyHex,
+		},
+		"return error when KeyID is invalid": {
+			sender:    senderPublicKeyHex,
+			keyID:     brc29.KeyID{DerivationPrefix: "", DerivationSuffix: ""},
+			recipient: recipientPrivateKeyHex,
+		},
+		"return error when recipient key is empty": {
+			sender:    senderPublicKeyHex,
+			keyID:     keyID,
+			recipient: "",
+		},
+		"return error when recipient key parsing fails": {
+			sender:    senderPublicKeyHex,
+			keyID:     keyID,
+			recipient: invalidKeyHex,
+		},
+	}
+	for name, test := range errorTestCases {
+		t.Run(name, func(t *testing.T) {
+			address, err := brc29.MyAddress(brc29.PubHex(test.sender), test.keyID, brc29.PrivHex(test.recipient))
+			require.Nil(t, address)
+			require.Error(t, err)
+		})
+	}
+
+	t.Run("return error when nil is passed as sender public key deriver", func(t *testing.T) {
+		var keyDeriver *sdk.KeyDeriver
+		address, err := brc29.MyAddress(keyDeriver, keyID, brc29.PrivHex(recipientPrivateKeyHex))
+		assert.Error(t, err)
+		require.Nil(t, address)
+	})
+
+	t.Run("return error when nil is passed as sender public key", func(t *testing.T) {
+		var pub *ec.PublicKey
+		address, err := brc29.MyAddress(pub, keyID, brc29.PrivHex(recipientPrivateKeyHex))
+		assert.Error(t, err)
+		require.Nil(t, address)
+	})
+
+	t.Run("return error when nil is passed as recipient private key deriver", func(t *testing.T) {
+		var keyDeriver *sdk.KeyDeriver
+		address, err := brc29.MyAddress(brc29.PubHex(senderPublicKeyHex), keyID, keyDeriver)
+		assert.Error(t, err)
+		require.Nil(t, address)
+	})
+
+	t.Run("return error when nil is passed as recipient private key", func(t *testing.T) {
+		var priv *ec.PrivateKey
+		address, err := brc29.MyAddress(brc29.PubHex(senderPublicKeyHex), keyID, priv)
+		assert.Error(t, err)
+		require.Nil(t, address)
+	})
+}
+
 func TestBRC29AddressCreation(t *testing.T) {
 	t.Run("return valid address created with brc28 with hex string as sender private key source", func(t *testing.T) {
 		// when:
-		address, err := brc29.Address(senderPrivateKeyHex, keyID, recipientPublicKeyHex)
+		address, err := brc29.YourAddress(brc29.PrivHex(senderPrivateKeyHex), keyID, brc29.PubHex(recipientPublicKeyHex))
 
 		// then:
 		assert.NoError(t, err)
@@ -23,7 +136,7 @@ func TestBRC29AddressCreation(t *testing.T) {
 
 	t.Run("return valid address created with brc28 with wif as sender private key source", func(t *testing.T) {
 		// when:
-		address, err := brc29.Address(brc29.WIF(senderWIFString), keyID, recipientPublicKeyHex)
+		address, err := brc29.YourAddress(brc29.WIF(senderWIFString), keyID, brc29.PubHex(recipientPublicKeyHex))
 
 		// then:
 		assert.NoError(t, err)
@@ -37,7 +150,7 @@ func TestBRC29AddressCreation(t *testing.T) {
 		require.NoError(t, err)
 
 		// when:
-		address, err := brc29.Address(priv, keyID, recipientPublicKeyHex)
+		address, err := brc29.YourAddress(priv, keyID, brc29.PubHex(recipientPublicKeyHex))
 
 		// then:
 		assert.NoError(t, err)
@@ -53,7 +166,7 @@ func TestBRC29AddressCreation(t *testing.T) {
 		keyDeriver := sdk.NewKeyDeriver(priv)
 
 		// when:
-		address, err := brc29.Address(keyDeriver, keyID, recipientPublicKeyHex)
+		address, err := brc29.YourAddress(keyDeriver, keyID, brc29.PubHex(recipientPublicKeyHex))
 
 		// then:
 		assert.NoError(t, err)
@@ -67,7 +180,7 @@ func TestBRC29AddressCreation(t *testing.T) {
 		require.NoError(t, err)
 
 		// when:
-		address, err := brc29.Address(senderPrivateKeyHex, keyID, pub)
+		address, err := brc29.YourAddress(brc29.PrivHex(senderPrivateKeyHex), keyID, pub)
 
 		// then:
 		assert.NoError(t, err)
@@ -81,7 +194,7 @@ func TestBRC29AddressCreation(t *testing.T) {
 		require.NoError(t, err)
 
 		// when:
-		address, err := brc29.Address(senderPrivateKeyHex, keyID, pub, brc29.WithTestNet())
+		address, err := brc29.YourAddress(brc29.PrivHex(senderPrivateKeyHex), keyID, pub, brc29.WithTestNet())
 
 		// then:
 		assert.NoError(t, err)
@@ -125,7 +238,7 @@ func TestBRC29AddressErrors(t *testing.T) {
 	for name, test := range errorTestCases {
 		t.Run(name, func(t *testing.T) {
 			// when:
-			address, err := brc29.Address(test.sender, test.keyID, test.recipient)
+			address, err := brc29.YourAddress(brc29.PrivHex(test.sender), test.keyID, brc29.PubHex(test.recipient))
 
 			// then:
 			require.Nil(t, address)
@@ -138,7 +251,7 @@ func TestBRC29AddressErrors(t *testing.T) {
 		var keyDeriver *sdk.KeyDeriver
 
 		// when:
-		address, err := brc29.Address(keyDeriver, keyID, recipientPublicKeyHex)
+		address, err := brc29.YourAddress(keyDeriver, keyID, brc29.PubHex(recipientPublicKeyHex))
 
 		// then:
 		assert.Error(t, err)
@@ -150,7 +263,7 @@ func TestBRC29AddressErrors(t *testing.T) {
 		var priv *ec.PrivateKey
 
 		// when:
-		address, err := brc29.Address(priv, keyID, recipientPublicKeyHex)
+		address, err := brc29.YourAddress(priv, keyID, brc29.PubHex(recipientPublicKeyHex))
 
 		// then:
 		assert.Error(t, err)
@@ -162,7 +275,7 @@ func TestBRC29AddressErrors(t *testing.T) {
 		var keyDeriver *sdk.KeyDeriver
 
 		// when:
-		address, err := brc29.Address(senderPrivateKeyHex, keyID, keyDeriver)
+		address, err := brc29.YourAddress(brc29.PrivHex(senderPrivateKeyHex), keyID, keyDeriver)
 
 		// then:
 		assert.Error(t, err)
@@ -174,7 +287,7 @@ func TestBRC29AddressErrors(t *testing.T) {
 		var pub *ec.PublicKey
 
 		// when:
-		address, err := brc29.Address(senderPrivateKeyHex, keyID, pub)
+		address, err := brc29.YourAddress(brc29.PrivHex(senderPrivateKeyHex), keyID, pub)
 
 		// then:
 		assert.Error(t, err)

--- a/pkg/brc29/brc29_address_test.go
+++ b/pkg/brc29/brc29_address_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestBRC29AddressByRecipientCreation(t *testing.T) {
 	t.Run("return valid address with hex string as sender public key source", func(t *testing.T) {
-		address, err := brc29.MyAddress(brc29.PubHex(senderPublicKeyHex), keyID, brc29.PrivHex(recipientPrivateKeyHex))
+		address, err := brc29.AddressForSelf(brc29.PubHex(senderPublicKeyHex), keyID, brc29.PrivHex(recipientPrivateKeyHex))
 		assert.NoError(t, err)
 		require.NotNil(t, address)
 		require.Equal(t, expectedAddress, address.AddressString)
@@ -21,7 +21,7 @@ func TestBRC29AddressByRecipientCreation(t *testing.T) {
 	t.Run("return valid address with ec.PublicKey as sender public key source", func(t *testing.T) {
 		pub, err := ec.PublicKeyFromString(senderPublicKeyHex)
 		require.NoError(t, err)
-		address, err := brc29.MyAddress(pub, keyID, brc29.PrivHex(recipientPrivateKeyHex))
+		address, err := brc29.AddressForSelf(pub, keyID, brc29.PrivHex(recipientPrivateKeyHex))
 		assert.NoError(t, err)
 		require.NotNil(t, address)
 		require.Equal(t, expectedAddress, address.AddressString)
@@ -31,7 +31,7 @@ func TestBRC29AddressByRecipientCreation(t *testing.T) {
 		priv, err := ec.PrivateKeyFromHex(senderPrivateKeyHex)
 		require.NoError(t, err)
 		keyDeriver := sdk.NewKeyDeriver(priv)
-		address, err := brc29.MyAddress(keyDeriver, keyID, brc29.PrivHex(recipientPrivateKeyHex))
+		address, err := brc29.AddressForSelf(keyDeriver, keyID, brc29.PrivHex(recipientPrivateKeyHex))
 		assert.NoError(t, err)
 		require.NotNil(t, address)
 		require.Equal(t, expectedAddress, address.AddressString)
@@ -40,14 +40,14 @@ func TestBRC29AddressByRecipientCreation(t *testing.T) {
 	t.Run("return valid address with ec.PrivateKey as recipient private key source", func(t *testing.T) {
 		priv, err := ec.PrivateKeyFromHex(recipientPrivateKeyHex)
 		require.NoError(t, err)
-		address, err := brc29.MyAddress(brc29.PubHex(senderPublicKeyHex), keyID, priv)
+		address, err := brc29.AddressForSelf(brc29.PubHex(senderPublicKeyHex), keyID, priv)
 		assert.NoError(t, err)
 		require.NotNil(t, address)
 		require.Equal(t, expectedAddress, address.AddressString)
 	})
 
 	t.Run("return testnet address created with brc29 by recipient", func(t *testing.T) {
-		address, err := brc29.MyAddress(brc29.PubHex(senderPublicKeyHex), keyID, brc29.PrivHex(recipientPrivateKeyHex), brc29.WithTestNet())
+		address, err := brc29.AddressForSelf(brc29.PubHex(senderPublicKeyHex), keyID, brc29.PrivHex(recipientPrivateKeyHex), brc29.WithTestNet())
 		assert.NoError(t, err)
 		require.NotNil(t, address)
 		require.Equal(t, expectedTestnetAddress, address.AddressString)
@@ -88,7 +88,7 @@ func TestBRC29AddressByRecipientErrors(t *testing.T) {
 	}
 	for name, test := range errorTestCases {
 		t.Run(name, func(t *testing.T) {
-			address, err := brc29.MyAddress(brc29.PubHex(test.sender), test.keyID, brc29.PrivHex(test.recipient))
+			address, err := brc29.AddressForSelf(brc29.PubHex(test.sender), test.keyID, brc29.PrivHex(test.recipient))
 			require.Nil(t, address)
 			require.Error(t, err)
 		})
@@ -96,28 +96,28 @@ func TestBRC29AddressByRecipientErrors(t *testing.T) {
 
 	t.Run("return error when nil is passed as sender public key deriver", func(t *testing.T) {
 		var keyDeriver *sdk.KeyDeriver
-		address, err := brc29.MyAddress(keyDeriver, keyID, brc29.PrivHex(recipientPrivateKeyHex))
+		address, err := brc29.AddressForSelf(keyDeriver, keyID, brc29.PrivHex(recipientPrivateKeyHex))
 		assert.Error(t, err)
 		require.Nil(t, address)
 	})
 
 	t.Run("return error when nil is passed as sender public key", func(t *testing.T) {
 		var pub *ec.PublicKey
-		address, err := brc29.MyAddress(pub, keyID, brc29.PrivHex(recipientPrivateKeyHex))
+		address, err := brc29.AddressForSelf(pub, keyID, brc29.PrivHex(recipientPrivateKeyHex))
 		assert.Error(t, err)
 		require.Nil(t, address)
 	})
 
 	t.Run("return error when nil is passed as recipient private key deriver", func(t *testing.T) {
 		var keyDeriver *sdk.KeyDeriver
-		address, err := brc29.MyAddress(brc29.PubHex(senderPublicKeyHex), keyID, keyDeriver)
+		address, err := brc29.AddressForSelf(brc29.PubHex(senderPublicKeyHex), keyID, keyDeriver)
 		assert.Error(t, err)
 		require.Nil(t, address)
 	})
 
 	t.Run("return error when nil is passed as recipient private key", func(t *testing.T) {
 		var priv *ec.PrivateKey
-		address, err := brc29.MyAddress(brc29.PubHex(senderPublicKeyHex), keyID, priv)
+		address, err := brc29.AddressForSelf(brc29.PubHex(senderPublicKeyHex), keyID, priv)
 		assert.Error(t, err)
 		require.Nil(t, address)
 	})
@@ -126,7 +126,7 @@ func TestBRC29AddressByRecipientErrors(t *testing.T) {
 func TestBRC29AddressCreation(t *testing.T) {
 	t.Run("return valid address created with brc28 with hex string as sender private key source", func(t *testing.T) {
 		// when:
-		address, err := brc29.YourAddress(brc29.PrivHex(senderPrivateKeyHex), keyID, brc29.PubHex(recipientPublicKeyHex))
+		address, err := brc29.AddressForCounterparty(brc29.PrivHex(senderPrivateKeyHex), keyID, brc29.PubHex(recipientPublicKeyHex))
 
 		// then:
 		assert.NoError(t, err)
@@ -136,7 +136,7 @@ func TestBRC29AddressCreation(t *testing.T) {
 
 	t.Run("return valid address created with brc28 with wif as sender private key source", func(t *testing.T) {
 		// when:
-		address, err := brc29.YourAddress(brc29.WIF(senderWIFString), keyID, brc29.PubHex(recipientPublicKeyHex))
+		address, err := brc29.AddressForCounterparty(brc29.WIF(senderWIFString), keyID, brc29.PubHex(recipientPublicKeyHex))
 
 		// then:
 		assert.NoError(t, err)
@@ -150,7 +150,7 @@ func TestBRC29AddressCreation(t *testing.T) {
 		require.NoError(t, err)
 
 		// when:
-		address, err := brc29.YourAddress(priv, keyID, brc29.PubHex(recipientPublicKeyHex))
+		address, err := brc29.AddressForCounterparty(priv, keyID, brc29.PubHex(recipientPublicKeyHex))
 
 		// then:
 		assert.NoError(t, err)
@@ -166,7 +166,7 @@ func TestBRC29AddressCreation(t *testing.T) {
 		keyDeriver := sdk.NewKeyDeriver(priv)
 
 		// when:
-		address, err := brc29.YourAddress(keyDeriver, keyID, brc29.PubHex(recipientPublicKeyHex))
+		address, err := brc29.AddressForCounterparty(keyDeriver, keyID, brc29.PubHex(recipientPublicKeyHex))
 
 		// then:
 		assert.NoError(t, err)
@@ -180,7 +180,7 @@ func TestBRC29AddressCreation(t *testing.T) {
 		require.NoError(t, err)
 
 		// when:
-		address, err := brc29.YourAddress(brc29.PrivHex(senderPrivateKeyHex), keyID, pub)
+		address, err := brc29.AddressForCounterparty(brc29.PrivHex(senderPrivateKeyHex), keyID, pub)
 
 		// then:
 		assert.NoError(t, err)
@@ -194,7 +194,7 @@ func TestBRC29AddressCreation(t *testing.T) {
 		require.NoError(t, err)
 
 		// when:
-		address, err := brc29.YourAddress(brc29.PrivHex(senderPrivateKeyHex), keyID, pub, brc29.WithTestNet())
+		address, err := brc29.AddressForCounterparty(brc29.PrivHex(senderPrivateKeyHex), keyID, pub, brc29.WithTestNet())
 
 		// then:
 		assert.NoError(t, err)
@@ -238,7 +238,7 @@ func TestBRC29AddressErrors(t *testing.T) {
 	for name, test := range errorTestCases {
 		t.Run(name, func(t *testing.T) {
 			// when:
-			address, err := brc29.YourAddress(brc29.PrivHex(test.sender), test.keyID, brc29.PubHex(test.recipient))
+			address, err := brc29.AddressForCounterparty(brc29.PrivHex(test.sender), test.keyID, brc29.PubHex(test.recipient))
 
 			// then:
 			require.Nil(t, address)
@@ -251,7 +251,7 @@ func TestBRC29AddressErrors(t *testing.T) {
 		var keyDeriver *sdk.KeyDeriver
 
 		// when:
-		address, err := brc29.YourAddress(keyDeriver, keyID, brc29.PubHex(recipientPublicKeyHex))
+		address, err := brc29.AddressForCounterparty(keyDeriver, keyID, brc29.PubHex(recipientPublicKeyHex))
 
 		// then:
 		assert.Error(t, err)
@@ -263,7 +263,7 @@ func TestBRC29AddressErrors(t *testing.T) {
 		var priv *ec.PrivateKey
 
 		// when:
-		address, err := brc29.YourAddress(priv, keyID, brc29.PubHex(recipientPublicKeyHex))
+		address, err := brc29.AddressForCounterparty(priv, keyID, brc29.PubHex(recipientPublicKeyHex))
 
 		// then:
 		assert.Error(t, err)
@@ -275,7 +275,7 @@ func TestBRC29AddressErrors(t *testing.T) {
 		var keyDeriver *sdk.KeyDeriver
 
 		// when:
-		address, err := brc29.YourAddress(brc29.PrivHex(senderPrivateKeyHex), keyID, keyDeriver)
+		address, err := brc29.AddressForCounterparty(brc29.PrivHex(senderPrivateKeyHex), keyID, keyDeriver)
 
 		// then:
 		assert.Error(t, err)
@@ -287,7 +287,7 @@ func TestBRC29AddressErrors(t *testing.T) {
 		var pub *ec.PublicKey
 
 		// when:
-		address, err := brc29.YourAddress(brc29.PrivHex(senderPrivateKeyHex), keyID, pub)
+		address, err := brc29.AddressForCounterparty(brc29.PrivHex(senderPrivateKeyHex), keyID, pub)
 
 		// then:
 		assert.Error(t, err)

--- a/pkg/brc29/brc29_template.go
+++ b/pkg/brc29/brc29_template.go
@@ -38,7 +38,7 @@ import (
 // lockingScript, err := Lock(priv, keyID, pub)
 // ```
 func Lock[SenderKey CounterpartyPrivateKey, RecipientKey CounterpartyPublicKey](senderPrivateKeySource SenderKey, keyID KeyID, recipientPublicKeySource RecipientKey, opts ...func(*lockOptions)) (*script.Script, error) {
-	address, err := YourAddress(senderPrivateKeySource, keyID, recipientPublicKeySource, opts...)
+	address, err := AddressForCounterparty(senderPrivateKeySource, keyID, recipientPublicKeySource, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate BRC29 address to lock the output: %w", err)
 	}

--- a/pkg/brc29/brc29_template.go
+++ b/pkg/brc29/brc29_template.go
@@ -6,18 +6,39 @@ import (
 	"github.com/bsv-blockchain/go-sdk/script"
 	"github.com/bsv-blockchain/go-sdk/transaction"
 	"github.com/bsv-blockchain/go-sdk/transaction/template/p2pkh"
-	sdk "github.com/bsv-blockchain/go-sdk/wallet"
 )
 
 // Lock generates a locking script for a BRC29 address derived from the sender, key ID, and recipient public key.
 //
 // Arguments:
-//   - sender: the sender key. Can be a private key hex string or a key deriver or ec.PrivateKey.
+//   - sender: the sender key. Can be a private key hex or wif or a key deriver or ec.PrivateKey.
 //   - keyID: the key ID.
 //   - recipient: the recipient key. This is the public key from private key that will be able to unlock it later. Can be a public key hex or a key deriver or ec.PublicKey.
 //   - opts: additional options.
+//
+// Example:
+// 1. Lock with hexes
+// ```go
+// lockingScript, err := Lock(PrivHex("ab..."), keyID, PubHex("cd..."))
+// ```
+//
+// 2. Lock with key derivers
+// ```go
+// var senderKeyDeriver *sdk.KeyDeriver = ...
+// var recipientKeyDeriver *sdk.KeyDeriver = ...
+//
+// lockingScript, err := Lock(keyDeriver, keyID, keyDeriver)
+// ```
+//
+// 3. Lock with ec private and public keys
+// ```go
+// var priv ec.PrivateKey = ...
+// var pub ec.PublicKey = ...
+//
+// lockingScript, err := Lock(priv, keyID, pub)
+// ```
 func Lock[SenderKey CounterpartyPrivateKey, RecipientKey CounterpartyPublicKey](senderPrivateKeySource SenderKey, keyID KeyID, recipientPublicKeySource RecipientKey, opts ...func(*lockOptions)) (*script.Script, error) {
-	address, err := Address(senderPrivateKeySource, keyID, recipientPublicKeySource, opts...)
+	address, err := YourAddress(senderPrivateKeySource, keyID, recipientPublicKeySource, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate BRC29 address to lock the output: %w", err)
 	}
@@ -39,13 +60,37 @@ type UnlockingScriptTemplate struct {
 // Unlock generates an unlocking script for a BRC29 address derived from the sender, key ID, and recipient private key.
 //
 // Arguments:
-//   - senderPublicKeySource: the sender key. Can be a private key hex string or a key deriver or ec.PrivateKey.
+//   - senderPublicKeySource: the sender key. Can be a public key hex or a key deriver or ec.PublicKey.
 //   - keyID: the key ID.
-//   - recipientPrivateKeySource: the recipient key. This is the private key for which the output was locked for. Can be a private key hex string or a key deriver or ec.PrivateKey.
+//   - recipientPrivateKeySource: the recipient key. This is the private key for which the output was locked for. Can be a private key hex or wif or a key deriver or ec.PrivateKey.
 //   - opts: additional options.
 //
 // Additional options:
 //   - WithSigHash: the sighash type to use for signing.
+//
+// Example:
+// 1. Unlock with hexes
+// ```go
+// unlockingScriptTemplate, err := Unlock(PrivHex("ab..."), keyID, PrivHex("cd..."))
+// ```
+// 2. Unlock with key derivers
+// ```go
+// var senderKeyDeriver *sdk.KeyDeriver = ...
+// var recipientKeyDeriver *sdk.KeyDeriver = ...
+//
+// unlockingScriptTemplate, err := Unlock(keyDeriver, keyID, keyDeriver)
+// ```
+// 3. Unlock with ec private and public keys
+// ```go
+// var priv ec.PrivateKey = ...
+// var pub ec.PublicKey = ...
+//
+// unlockingScriptTemplate, err := Unlock(priv, keyID, pub)
+// ```
+// 4. Unlock with sig hash
+// ```go
+// unlockingScriptTemplate, err := Unlock(PrivHex("ab..."), keyID, PrivHex("cd..."), WithSigHash(SigHashAll))
+// ```
 func Unlock[SenderKey CounterpartyPublicKey, RecipientKey CounterpartyPrivateKey](senderPublicKeySource SenderKey, keyID KeyID, recipientPrivateKeySource RecipientKey, opts ...func(*unlockOptions)) (*UnlockingScriptTemplate, error) {
 	options := &unlockOptions{}
 
@@ -53,27 +98,9 @@ func Unlock[SenderKey CounterpartyPublicKey, RecipientKey CounterpartyPrivateKey
 		opt(options)
 	}
 
-	senderIdentityKey, err := toIdentityKey(senderPublicKeySource)
+	key, err := deriveRecipientPrivateKey(senderPublicKeySource, keyID, recipientPrivateKeySource)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create sender identity key from %T: %w", senderIdentityKey, err)
-	}
-
-	recipientKeyDeriver, err := toKeyDeriver(recipientPrivateKeySource)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create recipient key deriver from %T: %w", recipientPrivateKeySource, err)
-	}
-
-	err = keyID.Validate()
-	if err != nil {
-		return nil, fmt.Errorf("invalid key ID: %w", err)
-	}
-
-	key, err := recipientKeyDeriver.DerivePrivateKey(Protocol, keyID.String(), sdk.Counterparty{
-		Type:         sdk.CounterpartyTypeOther,
-		Counterparty: senderIdentityKey,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to derive BRC29 private key for unlocking: %w", err)
+		return nil, fmt.Errorf("failed to derive recipient private key to unlock the input: %w", err)
 	}
 
 	unlocker, err := p2pkh.Unlock(key, options.sigHash)

--- a/pkg/brc29/brc29_template.go
+++ b/pkg/brc29/brc29_template.go
@@ -27,7 +27,7 @@ import (
 // var senderKeyDeriver *sdk.KeyDeriver = ...
 // var recipientKeyDeriver *sdk.KeyDeriver = ...
 //
-// lockingScript, err := Lock(keyDeriver, keyID, keyDeriver)
+// lockingScript, err := Lock(senderKeyDeriver, keyID, recipientKeyDeriver)
 // ```
 //
 // 3. Lock with ec private and public keys
@@ -71,25 +71,25 @@ type UnlockingScriptTemplate struct {
 // Example:
 // 1. Unlock with hexes
 // ```go
-// unlockingScriptTemplate, err := Unlock(PrivHex("ab..."), keyID, PrivHex("cd..."))
+// unlockingScriptTemplate, err := Unlock(PubHex("ab..."), keyID, PrivHex("cd..."))
 // ```
 // 2. Unlock with key derivers
 // ```go
 // var senderKeyDeriver *sdk.KeyDeriver = ...
 // var recipientKeyDeriver *sdk.KeyDeriver = ...
 //
-// unlockingScriptTemplate, err := Unlock(keyDeriver, keyID, keyDeriver)
+// unlockingScriptTemplate, err := Unlock(senderKeyDeriver, keyID, recipientKeyDeriver)
 // ```
 // 3. Unlock with ec private and public keys
 // ```go
 // var priv ec.PrivateKey = ...
 // var pub ec.PublicKey = ...
 //
-// unlockingScriptTemplate, err := Unlock(priv, keyID, pub)
+// unlockingScriptTemplate, err := Unlock(pub, keyID, priv)
 // ```
 // 4. Unlock with sig hash
 // ```go
-// unlockingScriptTemplate, err := Unlock(PrivHex("ab..."), keyID, PrivHex("cd..."), WithSigHash(SigHashAll))
+// unlockingScriptTemplate, err := Unlock(PubHex("ab..."), keyID, PrivHex("cd..."), WithSigHash(SigHashAll))
 // ```
 func Unlock[SenderKey CounterpartyPublicKey, RecipientKey CounterpartyPrivateKey](senderPublicKeySource SenderKey, keyID KeyID, recipientPrivateKeySource RecipientKey, opts ...func(*unlockOptions)) (*UnlockingScriptTemplate, error) {
 	options := &unlockOptions{}

--- a/pkg/brc29/brc29_template_test.go
+++ b/pkg/brc29/brc29_template_test.go
@@ -16,7 +16,7 @@ import (
 func TestBRC29TemplateLock(t *testing.T) {
 	t.Run("should lock with P2PKH and BRC29 calculated address", func(t *testing.T) {
 		// when:
-		lockingScript, err := brc29.Lock(senderPrivateKeyHex, keyID, recipientPublicKeyHex)
+		lockingScript, err := brc29.Lock(brc29.PrivHex(senderPrivateKeyHex), keyID, brc29.PubHex(recipientPublicKeyHex))
 		// then:
 		assert.NoError(t, err)
 		require.NotNil(t, lockingScript)
@@ -34,7 +34,7 @@ func TestBRC29TemplateLock(t *testing.T) {
 		var keyDeriver *sdk.KeyDeriver
 
 		// when:
-		lockingScript, err := brc29.Lock(keyDeriver, keyID, recipientPublicKeyHex)
+		lockingScript, err := brc29.Lock(keyDeriver, keyID, brc29.PubHex(recipientPublicKeyHex))
 
 		// then:
 		assert.Error(t, err)
@@ -46,7 +46,7 @@ func TestBRC29TemplateLock(t *testing.T) {
 		var priv *ec.PrivateKey
 
 		// when:
-		lockingScript, err := brc29.Lock(priv, keyID, recipientPublicKeyHex)
+		lockingScript, err := brc29.Lock(priv, keyID, brc29.PubHex(recipientPublicKeyHex))
 
 		// then:
 		assert.Error(t, err)
@@ -58,7 +58,7 @@ func TestBRC29TemplateLock(t *testing.T) {
 		var keyDeriver *sdk.KeyDeriver
 
 		// when:
-		lockingScript, err := brc29.Lock(senderPrivateKeyHex, keyID, keyDeriver)
+		lockingScript, err := brc29.Lock(brc29.PrivHex(senderPrivateKeyHex), keyID, keyDeriver)
 
 		// then:
 		assert.Error(t, err)
@@ -70,7 +70,7 @@ func TestBRC29TemplateLock(t *testing.T) {
 		var pub *ec.PublicKey
 
 		// when:
-		lockingScript, err := brc29.Lock(senderPrivateKeyHex, keyID, pub)
+		lockingScript, err := brc29.Lock(brc29.PrivHex(senderPrivateKeyHex), keyID, pub)
 
 		// then:
 		assert.Error(t, err)
@@ -111,7 +111,7 @@ func TestBRC29TemplateLock(t *testing.T) {
 	for name, test := range errorTestCases {
 		t.Run(name, func(t *testing.T) {
 			// when:
-			lockingScript, err := brc29.Lock(test.sender, test.keyID, test.recipient)
+			lockingScript, err := brc29.Lock(brc29.PrivHex(test.sender), test.keyID, brc29.PubHex(test.recipient))
 
 			// then:
 			require.Nil(t, lockingScript)
@@ -132,11 +132,11 @@ func TestBRC29TemplateUnlock(t *testing.T) {
 		require.NoError(t, err)
 
 		// and:
-		lockingScript, err := brc29.Lock(senderPrivateKeyHex, keyID, recipientPublicKeyHex)
+		lockingScript, err := brc29.Lock(brc29.PrivHex(senderPrivateKeyHex), keyID, brc29.PubHex(recipientPublicKeyHex))
 		require.NoError(t, err)
 
 		// when:
-		unlocker, err := brc29.Unlock(senderPublicKeyHex, keyID, recipientPrivateKeyHex)
+		unlocker, err := brc29.Unlock(brc29.PubHex(senderPublicKeyHex), keyID, brc29.PrivHex(recipientPrivateKeyHex))
 		require.NoError(t, err)
 
 		// and:
@@ -164,7 +164,7 @@ func TestBRC29TemplateUnlock(t *testing.T) {
 	})
 
 	t.Run("estimate unlocking script length", func(t *testing.T) {
-		unlocker, err := brc29.Unlock(senderPublicKeyHex, keyID, recipientPrivateKeyHex)
+		unlocker, err := brc29.Unlock(brc29.PubHex(senderPublicKeyHex), keyID, brc29.PrivHex(recipientPrivateKeyHex))
 		require.NoError(t, err)
 
 		length := unlocker.EstimateLength(transaction.NewTransaction(), 0)
@@ -206,7 +206,7 @@ func TestBRC29TemplateUnlock(t *testing.T) {
 	for name, test := range errorTestCases {
 		t.Run(name, func(t *testing.T) {
 			// when:
-			unlocker, err := brc29.Unlock(test.sender, test.keyID, test.recipient)
+			unlocker, err := brc29.Unlock(brc29.PubHex(test.sender), test.keyID, brc29.PrivHex(test.recipient))
 
 			// then:
 			require.Nil(t, unlocker)

--- a/pkg/brc29/brc29_types.go
+++ b/pkg/brc29/brc29_types.go
@@ -31,23 +31,41 @@ func (w WIF) PrivateKey() (*ec.PrivateKey, error) {
 	return ec.PrivateKeyFromWif(string(w)) //nolint:wrapcheck
 }
 
-// CounterpartyPublicKey represents a source of counterparty identity (public) key.
-// Can be used with different types of sources:
-//   - string: a public key in DER HEX format
-//   - *sdk.KeyDeriver: a key deriver that can be used to derive the public key
-//   - *ec.PublicKey: a public key object
-type CounterpartyPublicKey interface {
-	string | *sdk.KeyDeriver | *ec.PublicKey
+// PrivHex represents a string holding private key in HEX format.
+// To pass a string as PrivHex simply wrap it with PrivHex type, like brc29.PrivHex("ab...").
+type PrivHex string
+
+// PrivateKey returns the private key from the PrivHex string.
+func (k PrivHex) PrivateKey() (*ec.PrivateKey, error) {
+	return ec.PrivateKeyFromHex(string(k)) //nolint:wrapcheck
 }
 
 // CounterpartyPrivateKey represents a source of counterparty private key.
 // Can be used with different types of sources:
-//   - string: a private key in DER HEX format
-//   - WIF: a WIF string
-//   - *sdk.KeyDeriver: a key deriver that can be used to derive the private key
+//   - PrivHex: a private key in HEX format - to pass it, you simply wrap string with PrivHex type, like PrivHex("ab...")
+//   - WIF: a private key in WIF format string - to pass it, you simply wrap string with WIF type, like WIF("L1...")
 //   - *ec.PrivateKey: a private key object
+//   - *sdk.KeyDeriver: a key deriver that can be used to derive the private key
 type CounterpartyPrivateKey interface {
-	string | WIF | *sdk.KeyDeriver | *ec.PrivateKey
+	PrivHex | WIF | *ec.PrivateKey | *sdk.KeyDeriver
+}
+
+// PubHex represents a string holding a public key in DER HEX format.
+// To pass a string as PubHex simply wrap it with PubHex type, like PubHex("ab...").
+type PubHex string
+
+// PublicKey returns the public key from the PubHex string.
+func (k PubHex) PublicKey() (*ec.PublicKey, error) {
+	return ec.PublicKeyFromString(string(k)) //nolint:wrapcheck
+}
+
+// CounterpartyPublicKey represents a source of counterparty identity (public) key.
+// Can be used with different types of sources:
+//   - PubHex: a public key in HEX format - to pass it, you simply wrap string with PubHex type, like PubHex("ab...")
+//   - *sdk.KeyDeriver: a key deriver that can be used to derive the public key
+//   - *ec.PublicKey: a public key object
+type CounterpartyPublicKey interface {
+	PubHex | *sdk.KeyDeriver | *ec.PublicKey
 }
 
 // KeyID represents a key ID for BRC29.

--- a/pkg/brc29/brc29_utils.go
+++ b/pkg/brc29/brc29_utils.go
@@ -62,7 +62,7 @@ func toKeyDeriver[KeySource CounterpartyPrivateKey](keySource KeySource) (*sdk.K
 func deriveRecipientPrivateKey[SenderKey CounterpartyPublicKey, RecipientKey CounterpartyPrivateKey](senderPublicKeySource SenderKey, keyID KeyID, recipientPrivateKeySource RecipientKey) (*ec.PrivateKey, error) {
 	senderIdentityKey, err := toIdentityKey(senderPublicKeySource)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create sender identity key from %T: %w", senderIdentityKey, err)
+		return nil, fmt.Errorf("failed to create sender identity key from %T: %w", senderPublicKeySource, err)
 	}
 
 	recipientKeyDeriver, err := toKeyDeriver(recipientPrivateKeySource)

--- a/pkg/brc29/brc29_utils.go
+++ b/pkg/brc29/brc29_utils.go
@@ -9,8 +9,8 @@ import (
 
 func toIdentityKey[KeySource CounterpartyPublicKey](keySource KeySource) (*ec.PublicKey, error) {
 	switch k := any(keySource).(type) {
-	case string:
-		pubKey, err := ec.PublicKeyFromString(k)
+	case PubHex:
+		pubKey, err := k.PublicKey()
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse public key from string: %w", err)
 		}
@@ -32,8 +32,8 @@ func toIdentityKey[KeySource CounterpartyPublicKey](keySource KeySource) (*ec.Pu
 
 func toKeyDeriver[KeySource CounterpartyPrivateKey](keySource KeySource) (*sdk.KeyDeriver, error) {
 	switch k := any(keySource).(type) {
-	case string:
-		priv, err := ec.PrivateKeyFromHex(k)
+	case PrivHex:
+		priv, err := k.PrivateKey()
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse private key from hex: %w", err)
 		}
@@ -57,4 +57,31 @@ func toKeyDeriver[KeySource CounterpartyPrivateKey](keySource KeySource) (*sdk.K
 	default:
 		return nil, fmt.Errorf("unexpected key source type: %T, ensure that all subtypes of key source are handled", k)
 	}
+}
+
+func deriveRecipientPrivateKey[SenderKey CounterpartyPublicKey, RecipientKey CounterpartyPrivateKey](senderPublicKeySource SenderKey, keyID KeyID, recipientPrivateKeySource RecipientKey) (*ec.PrivateKey, error) {
+	senderIdentityKey, err := toIdentityKey(senderPublicKeySource)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create sender identity key from %T: %w", senderIdentityKey, err)
+	}
+
+	recipientKeyDeriver, err := toKeyDeriver(recipientPrivateKeySource)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create recipient key deriver from %T: %w", recipientPrivateKeySource, err)
+	}
+
+	err = keyID.Validate()
+	if err != nil {
+		return nil, fmt.Errorf("invalid key ID: %w", err)
+	}
+
+	key, err := recipientKeyDeriver.DerivePrivateKey(Protocol, keyID.String(), sdk.Counterparty{
+		Type:         sdk.CounterpartyTypeOther,
+		Counterparty: senderIdentityKey,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive BRC29 private key: %w", err)
+	}
+
+	return key, nil
 }

--- a/pkg/internal/assembler/create_action_tx_assembler.go
+++ b/pkg/internal/assembler/create_action_tx_assembler.go
@@ -144,7 +144,7 @@ func (a *CreateActionTransactionAssembler) toTxInputFromManagedInput(it *wdk.Sto
 	//  or need to query for those inputs the storage
 	//  for now (until SignAction is implemented) we create unlocking script template here.
 	input.UnlockingScriptTemplate, err = brc29.Unlock(
-		senderIdentityKey,
+		brc29.PubHex(senderIdentityKey),
 		brc29.KeyID{
 			DerivationPrefix: to.Value(it.DerivationPrefix),
 			DerivationSuffix: to.Value(it.DerivationSuffix),

--- a/pkg/storage/internal/testabilities/assertions_have_funds.go
+++ b/pkg/storage/internal/testabilities/assertions_have_funds.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/bsv-blockchain/go-sdk/transaction/template/p2pkh"
 	sdk "github.com/bsv-blockchain/go-sdk/wallet"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/brc29"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures"
@@ -42,10 +41,8 @@ func (t *thenFundsAssertion) CanReserveSatoshis(amount uint64) bool {
 		DerivationPrefix: fixtures.DerivationPrefix,
 		DerivationSuffix: fixtures.DerivationSuffix,
 	}
-	address, err := brc29.Address(t.sender.PrivateKey(t), keyID, t.sender.IdentityKey(t), brc29.WithTestNet())
-	require.NoError(t.TB, err)
 
-	lockingScript, err := p2pkh.Lock(address)
+	lockingScript, err := brc29.Lock(t.sender.PrivateKey(t), keyID, t.sender.PublicKey(t))
 	require.NoError(t.TB, err)
 
 	args := wdk.ValidCreateActionArgs{

--- a/pkg/storage/internal/testabilities/fixture_tx.go
+++ b/pkg/storage/internal/testabilities/fixture_tx.go
@@ -85,7 +85,7 @@ func (t *txGeneratorFixture) PreInternalized() (internalizeArgs *wdk.Internalize
 
 	anyonePriv, anyonePub := sdk.AnyoneKey()
 
-	address, err := brc29.YourAddress(anyonePriv, keyID, t.sender.PublicKey(t), brc29.WithTestNet())
+	address, err := brc29.AddressForCounterparty(anyonePriv, keyID, t.sender.PublicKey(t), brc29.WithTestNet())
 	require.NoError(t.TB, err)
 
 	lockingScript, err := p2pkh.Lock(address)
@@ -146,7 +146,7 @@ func (t *txGeneratorFixture) Created() (createActionResult *wdk.StorageCreateAct
 		DerivationPrefix: fixtures.DerivationPrefix,
 		DerivationSuffix: fixtures.DerivationSuffix,
 	}
-	address, err := brc29.YourAddress(t.sender.PrivateKey(t), keyID, t.recipient.PublicKey(t), brc29.WithTestNet())
+	address, err := brc29.AddressForCounterparty(t.sender.PrivateKey(t), keyID, t.recipient.PublicKey(t), brc29.WithTestNet())
 	require.NoError(t.TB, err)
 
 	lockingScript, err := p2pkh.Lock(address)

--- a/pkg/storage/internal/testabilities/fixture_tx.go
+++ b/pkg/storage/internal/testabilities/fixture_tx.go
@@ -85,7 +85,7 @@ func (t *txGeneratorFixture) PreInternalized() (internalizeArgs *wdk.Internalize
 
 	anyonePriv, anyonePub := sdk.AnyoneKey()
 
-	address, err := brc29.Address(anyonePriv, keyID, t.sender.PublicKey(t), brc29.WithTestNet())
+	address, err := brc29.YourAddress(anyonePriv, keyID, t.sender.PublicKey(t), brc29.WithTestNet())
 	require.NoError(t.TB, err)
 
 	lockingScript, err := p2pkh.Lock(address)
@@ -146,7 +146,7 @@ func (t *txGeneratorFixture) Created() (createActionResult *wdk.StorageCreateAct
 		DerivationPrefix: fixtures.DerivationPrefix,
 		DerivationSuffix: fixtures.DerivationSuffix,
 	}
-	address, err := brc29.Address(t.sender.PrivateKey(t), keyID, t.recipient.PublicKey(t), brc29.WithTestNet())
+	address, err := brc29.YourAddress(t.sender.PrivateKey(t), keyID, t.recipient.PublicKey(t), brc29.WithTestNet())
 	require.NoError(t.TB, err)
 
 	lockingScript, err := p2pkh.Lock(address)


### PR DESCRIPTION
This is proposition to have 2 functions for address creation.
One `AddressForSelf` that recipient can use to prepare an address and pass it to sender.
Second `AddressForCounterparty` to be used by sender to create an address to send funds to recipient.