### PR TITLE
feat(#377): add logging in RelinquishOutput

### DIFF
--- a/pkg/storage/provider.go
+++ b/pkg/storage/provider.go
@@ -404,6 +404,11 @@ func (p *Provider) ListOutputs(ctx context.Context, auth wdk.AuthID, args wdk.Li
 
 // RelinquishOutput removes a specified output from a basket
 func (p *Provider) RelinquishOutput(ctx context.Context, auth wdk.AuthID, args wdk.RelinquishOutputArgs) error {
+	logger := p.logger.With(logging.UserID(auth.UserID),
+		slog.String("output", args.Output),
+		slog.String("basket", args.Basket),
+	)
+	logger.DebugContext(ctx, "Validating relinquishOutput args")
 	if auth.UserID == nil {
 		return ErrAuthorization
 	}
@@ -412,6 +417,7 @@ func (p *Provider) RelinquishOutput(ctx context.Context, auth wdk.AuthID, args w
 		return fmt.Errorf("invalid relinquishOutput args: %w", err)
 	}
 
+	logger.DebugContext(ctx, "Extracting txID and vout from output")
 	txID, vout := primitives.OutpointString(args.Output).MustGet()
 
 	var basketName *string
@@ -419,10 +425,20 @@ func (p *Provider) RelinquishOutput(ctx context.Context, auth wdk.AuthID, args w
 		basketName = &args.Basket
 	}
 
+	logger.InfoContext(ctx, "Starting RelinquishOutput process",
+		slog.String("txID", txID),
+		slog.Int("vout", int(vout)),
+	)
 	err := p.repo.Outputs.UnlinkOutputFromBasketByOutpoint(ctx, *auth.UserID, basketName, wdk.OutPoint{TxID: txID, Vout: vout})
 	if err != nil {
+		logger.DebugContext(ctx, "RelinquishOutput completed with error")
 		return fmt.Errorf("failed to relinquish output: %w", err)
 	}
+
+	logger.InfoContext(ctx, "RelinquishOutput completed successfully",
+		slog.String("txID", txID),
+		slog.Int("vout", int(vout)),
+	)
 	return nil
 }
 

--- a/pkg/storage/provider.go
+++ b/pkg/storage/provider.go
@@ -431,7 +431,6 @@ func (p *Provider) RelinquishOutput(ctx context.Context, auth wdk.AuthID, args w
 	)
 	err := p.repo.Outputs.UnlinkOutputFromBasketByOutpoint(ctx, *auth.UserID, basketName, wdk.OutPoint{TxID: txID, Vout: vout})
 	if err != nil {
-		logger.DebugContext(ctx, "RelinquishOutput completed with error")
 		return fmt.Errorf("failed to relinquish output: %w", err)
 	}
 


### PR DESCRIPTION
Closes: #377
This pull request adds enhanced logging to the `RelinquishOutput` method in `pkg/storage/provider.go` to improve traceability and debugging of output relinquishment actions. The new log statements provide more detailed context throughout the method's execution.

Logging improvements:

* Added a contextual logger at the start of `RelinquishOutput` with user ID, output, and basket information, and a debug message for argument validation.
* Added debug and info log statements to trace extraction of transaction details, the start of the relinquishment process, error handling, and successful completion.## Description of Changes