### PR TITLE
feat(#376): add logging in AbortAction

### DIFF
--- a/pkg/storage/internal/actions/abort.go
+++ b/pkg/storage/internal/actions/abort.go
@@ -36,7 +36,16 @@ func newAbortAction(logger *slog.Logger, transactions TransactionsRepo, outputsR
 
 func (a *abortAction) AbortAction(ctx context.Context, userID int, args *wdk.AbortActionArgs) (*wdk.AbortActionResult, error) {
 	referenceStr := string(args.Reference)
+	logger := a.logger.With(
+		logging.UserID(userID),
+		slog.String("reference", referenceStr),
+	)
 
+	logger.InfoContext(ctx, "Starting AbortAction process",
+		slog.Bool("isPotentialTxID", a.isPotentiallyTxID(referenceStr)),
+	)
+
+	logger.DebugContext(ctx, "Searching for transaction by reference or txid")
 	txEntity, err := a.transactionsRepo.FindTransactionByReference(ctx, userID, referenceStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find transaction by reference %s: %w", referenceStr, err)
@@ -49,30 +58,53 @@ func (a *abortAction) AbortAction(ctx context.Context, userID int, args *wdk.Abo
 		}
 	}
 
+	logger.DebugContext(ctx, "Checking if transaction was found")
+
 	if txEntity == nil {
 		return nil, fmt.Errorf("no transaction found with reference or txid %q", referenceStr)
 	}
+
+	logger.DebugContext(ctx, "Validating transaction for abort",
+		logging.Number("transactionID", txEntity.ID),
+		slog.String("status", string(txEntity.Status)),
+		slog.Bool("isOutgoing", txEntity.IsOutgoing),
+	)
 
 	if err := a.validateTx(ctx, txEntity); err != nil {
 		return nil, fmt.Errorf("transaction validation failed: %w", err)
 	}
 
+	logger.DebugContext(ctx, "Starting transaction abort process",
+		logging.Number("transactionID", txEntity.ID),
+	)
+
 	if err := a.abortTx(ctx, txEntity.ID); err != nil {
 		return nil, fmt.Errorf("failed to abort transaction: %w", err)
 	}
+
+	logger.InfoContext(ctx, "AbortAction completed successfully",
+		logging.UserID(userID),
+		logging.Number("transactionID", txEntity.ID),
+		slog.String("reference", referenceStr),
+	)
 
 	return &wdk.AbortActionResult{Aborted: true}, nil
 }
 
 func (a *abortAction) abortTx(ctx context.Context, id uint) error {
+	logger := a.logger.With(logging.Number("transactionID", id))
+
+	logger.DebugContext(ctx, "Unreserving UTXOs for transaction")
 	if err := a.utxosRepo.UnreserveUTXOsByTransactionID(ctx, id); err != nil {
 		return fmt.Errorf("failed to unreserve UTXOs for transaction: %w", err)
 	}
 
+	logger.DebugContext(ctx, "Recreating spent outputs for transaction")
 	if err := a.outputsRepo.RecreateSpentOutputs(ctx, id); err != nil {
 		return fmt.Errorf("failed to recreate spent outputs for transaction: %w", err)
 	}
 
+	logger.DebugContext(ctx, "Updating transaction status to 'failed'")
 	if err := a.transactionsRepo.UpdateTransactionStatusByID(ctx, id, wdk.TxStatusFailed); err != nil {
 		return fmt.Errorf("failed to update transaction status: %w", err)
 	}
@@ -84,18 +116,29 @@ func (a *abortAction) abortTx(ctx context.Context, id uint) error {
 }
 
 func (a *abortAction) validateTx(ctx context.Context, txEntity *pkgentity.Transaction) error {
+	logger := a.logger.With(logging.Number("transactionID", txEntity.ID),
+		slog.Bool("isOutgoing", txEntity.IsOutgoing),
+		slog.String("status", string(txEntity.Status)),
+	)
+
+	logger.DebugContext(ctx, "Validating if transaction is outgoing")
 	if !txEntity.IsOutgoing {
 		return fmt.Errorf("%w: must be an outgoing transaction", wdk.ErrNotAbortableAction)
 	}
 
+	logger.DebugContext(ctx, "Validating transaction status")
 	if err := validateTxStatusForAbort(txEntity.Status); err != nil {
 		return err
 	}
 
+	logger.DebugContext(ctx, "Checking if transaction outputs are unspent")
 	if err := a.outputsRepo.ShouldTxOutputsBeUnspent(ctx, txEntity.ID); err != nil {
 		return fmt.Errorf("cannot abort transaction with spent outputs: %w", err)
 	}
 
+	logger.DebugContext(ctx, "Transaction validation passed",
+		logging.Number("transactionID", txEntity.ID),
+	)
 	return nil
 }
 

--- a/pkg/storage/internal/actions/abort.go
+++ b/pkg/storage/internal/actions/abort.go
@@ -114,7 +114,8 @@ func (a *abortAction) abortTx(ctx context.Context, id uint) error {
 }
 
 func (a *abortAction) validateTx(ctx context.Context, txEntity *pkgentity.Transaction) error {
-	logger := a.logger.With(logging.Number("transactionID", txEntity.ID),
+	logger := a.logger.With(
+		logging.Number("transactionID", txEntity.ID),
 		slog.Bool("isOutgoing", txEntity.IsOutgoing),
 		slog.String("status", string(txEntity.Status)),
 	)
@@ -134,9 +135,7 @@ func (a *abortAction) validateTx(ctx context.Context, txEntity *pkgentity.Transa
 		return fmt.Errorf("cannot abort transaction with spent outputs: %w", err)
 	}
 
-	logger.DebugContext(ctx, "Transaction validation passed",
-		logging.Number("transactionID", txEntity.ID),
-	)
+	logger.DebugContext(ctx, "Transaction validation passed")
 	return nil
 }
 

--- a/pkg/storage/internal/actions/abort.go
+++ b/pkg/storage/internal/actions/abort.go
@@ -83,9 +83,7 @@ func (a *abortAction) AbortAction(ctx context.Context, userID int, args *wdk.Abo
 	}
 
 	logger.InfoContext(ctx, "AbortAction completed successfully",
-		logging.UserID(userID),
 		logging.Number("transactionID", txEntity.ID),
-		slog.String("reference", referenceStr),
 	)
 
 	return &wdk.AbortActionResult{Aborted: true}, nil


### PR DESCRIPTION
Closes: #376
This pull request adds detailed logging to the transaction abort workflow in `pkg/storage/internal/actions/abort.go`. The new logs provide better visibility into each step of the abort process, including transaction lookup, validation, UTXO management, and status updates. These changes will help with debugging and monitoring by making it easier to trace the flow and state of transactions during abort operations.

**Logging enhancements for transaction abort workflow:**

* Added contextual info and started logging at each major step in `AbortAction`, including transaction lookup, validation, and abort completion. [[1]](diffhunk://#diff-9cda57e1464cf412f67e91af2cdd3eb6ff2de6f01548d230293df6d9788e0443R39-R48) [[2]](diffhunk://#diff-9cda57e1464cf412f67e91af2cdd3eb6ff2de6f01548d230293df6d9788e0443R61-R107)
* Added debug logs to the `abortTx` method to trace UTXO unreservation, output recreation, and transaction status update steps.
* Enhanced `validateTx` method with debug logs for each validation check: outgoing status, transaction status, and output spend status.