### PR TITLE
feat: more chaintracks client endpoints

### DIFF
--- a/examples/services_examples/chaintracks_examples/call_chaintracks_server/call_chaintracks_server.go
+++ b/examples/services_examples/chaintracks_examples/call_chaintracks_server/call_chaintracks_server.go
@@ -17,18 +17,29 @@ const (
 )
 
 func main() {
-	ctx := context.Background()
-
 	// Set to LevelDebug to see http request logs
 	// slog.SetLogLoggerLevel(slog.LevelDebug)
 
 	chaintr := chaintracks.NewClient(slog.Default(), defs.NetworkMainnet, chaintracksURL)
 
-	info, err := chaintr.GetInfo(ctx)
+	getInfo(chaintr)
+	getPresentHeight(chaintr)
+}
+
+func getInfo(chaintr *chaintracks.Client) {
+	info, err := chaintr.GetInfo(context.Background())
 	if err != nil {
 		panic("failed to get Chaintracks info: " + err.Error())
 	}
 
 	show.Info("Chaintracks Info", info)
+}
 
+func getPresentHeight(chaintr *chaintracks.Client) {
+	height, err := chaintr.GetPresentHeight(context.Background())
+	if err != nil {
+		panic("failed to get Chaintracks present height: " + err.Error())
+	}
+
+	show.Info("Chaintracks Present Height", height)
 }

--- a/examples/services_examples/chaintracks_examples/call_chaintracks_server/call_chaintracks_server.go
+++ b/examples/services_examples/chaintracks_examples/call_chaintracks_server/call_chaintracks_server.go
@@ -24,6 +24,7 @@ func main() {
 
 	getInfo(chaintr)
 	getPresentHeight(chaintr)
+	findChainTipHashHex(chaintr)
 }
 
 func getInfo(chaintr *chaintracks.Client) {
@@ -42,4 +43,13 @@ func getPresentHeight(chaintr *chaintracks.Client) {
 	}
 
 	show.Info("Chaintracks Present Height", height)
+}
+
+func findChainTipHashHex(chaintr *chaintracks.Client) {
+	hashHex, err := chaintr.FindChainTipHashHex(context.Background())
+	if err != nil {
+		panic("failed to get Chaintracks chain tip hash: " + err.Error())
+	}
+
+	show.Info("Chaintracks Chain Tip Hash", hashHex)
 }

--- a/examples/services_examples/chaintracks_examples/call_chaintracks_server/call_chaintracks_server.go
+++ b/examples/services_examples/chaintracks_examples/call_chaintracks_server/call_chaintracks_server.go
@@ -25,6 +25,7 @@ func main() {
 	getInfo(chaintr)
 	getPresentHeight(chaintr)
 	findChainTipHashHex(chaintr)
+	findChainTipHeaderHex(chaintr)
 }
 
 func getInfo(chaintr *chaintracks.Client) {
@@ -52,4 +53,13 @@ func findChainTipHashHex(chaintr *chaintracks.Client) {
 	}
 
 	show.Info("Chaintracks Chain Tip Hash", hashHex)
+}
+
+func findChainTipHeaderHex(chaintr *chaintracks.Client) {
+	header, err := chaintr.FindChainTipHeaderHex(context.Background())
+	if err != nil {
+		panic("failed to get Chaintracks chain tip header: " + err.Error())
+	}
+
+	show.Info("Chaintracks Chain Tip Header", header)
 }

--- a/examples/services_examples/chaintracks_examples/call_chaintracks_server/call_chaintracks_server.go
+++ b/examples/services_examples/chaintracks_examples/call_chaintracks_server/call_chaintracks_server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/examples/internal/show"
@@ -23,9 +24,10 @@ func main() {
 	chaintr := chaintracks.NewClient(slog.Default(), defs.NetworkMainnet, chaintracksURL)
 
 	getInfo(chaintr)
-	getPresentHeight(chaintr)
+	height := getPresentHeight(chaintr)
 	findChainTipHashHex(chaintr)
 	findChainTipHeaderHex(chaintr)
+	findHeaderHexForHeight(chaintr, height-1)
 }
 
 func getInfo(chaintr *chaintracks.Client) {
@@ -37,13 +39,15 @@ func getInfo(chaintr *chaintracks.Client) {
 	show.Info("Chaintracks Info", info)
 }
 
-func getPresentHeight(chaintr *chaintracks.Client) {
+func getPresentHeight(chaintr *chaintracks.Client) uint32 {
 	height, err := chaintr.GetPresentHeight(context.Background())
 	if err != nil {
 		panic("failed to get Chaintracks present height: " + err.Error())
 	}
 
 	show.Info("Chaintracks Present Height", height)
+
+	return height
 }
 
 func findChainTipHashHex(chaintr *chaintracks.Client) {
@@ -62,4 +66,13 @@ func findChainTipHeaderHex(chaintr *chaintracks.Client) {
 	}
 
 	show.Info("Chaintracks Chain Tip Header", header)
+}
+
+func findHeaderHexForHeight(chaintr *chaintracks.Client, height uint32) {
+	header, err := chaintr.FindHeaderHexForHeight(context.Background(), height)
+	if err != nil {
+		panic("failed to get Chaintracks header for height: " + err.Error())
+	}
+
+	show.Info(fmt.Sprintf("Chaintracks Header for Height: %d", height), header)
 }

--- a/examples/services_examples/chaintracks_examples/call_chaintracks_server/call_chaintracks_server.go
+++ b/examples/services_examples/chaintracks_examples/call_chaintracks_server/call_chaintracks_server.go
@@ -25,9 +25,10 @@ func main() {
 
 	getInfo(chaintr)
 	height := getPresentHeight(chaintr)
-	findChainTipHashHex(chaintr)
+	tipHash := findChainTipHashHex(chaintr)
 	findChainTipHeaderHex(chaintr)
 	findHeaderHexForHeight(chaintr, height-1)
+	findHeaderHexForBlockHash(chaintr, tipHash)
 }
 
 func getInfo(chaintr *chaintracks.Client) {
@@ -50,13 +51,15 @@ func getPresentHeight(chaintr *chaintracks.Client) uint32 {
 	return height
 }
 
-func findChainTipHashHex(chaintr *chaintracks.Client) {
+func findChainTipHashHex(chaintr *chaintracks.Client) string {
 	hashHex, err := chaintr.FindChainTipHashHex(context.Background())
 	if err != nil {
 		panic("failed to get Chaintracks chain tip hash: " + err.Error())
 	}
 
 	show.Info("Chaintracks Chain Tip Hash", hashHex)
+
+	return hashHex
 }
 
 func findChainTipHeaderHex(chaintr *chaintracks.Client) {
@@ -75,4 +78,13 @@ func findHeaderHexForHeight(chaintr *chaintracks.Client, height uint32) {
 	}
 
 	show.Info(fmt.Sprintf("Chaintracks Header for Height: %d", height), header)
+}
+
+func findHeaderHexForBlockHash(chaintr *chaintracks.Client, hash string) {
+	header, err := chaintr.FindHeaderHexForBlockHash(context.Background(), hash)
+	if err != nil {
+		panic("failed to get Chaintracks header for block hash: " + err.Error())
+	}
+
+	show.Info(fmt.Sprintf("Chaintracks Header for Block Hash: %s", hash), header)
 }

--- a/examples/services_examples/chaintracks_examples/call_chaintracks_server/call_chaintracks_server.go
+++ b/examples/services_examples/chaintracks_examples/call_chaintracks_server/call_chaintracks_server.go
@@ -29,6 +29,9 @@ func main() {
 	findChainTipHeaderHex(chaintr)
 	findHeaderHexForHeight(chaintr, height-1)
 	findHeaderHexForBlockHash(chaintr, tipHash)
+
+	const numberOfHeadersToGet = 5
+	getHeaders(chaintr, height-numberOfHeadersToGet, numberOfHeadersToGet)
 }
 
 func getInfo(chaintr *chaintracks.Client) {
@@ -87,4 +90,21 @@ func findHeaderHexForBlockHash(chaintr *chaintracks.Client, hash string) {
 	}
 
 	show.Info(fmt.Sprintf("Chaintracks Header for Block Hash: %s", hash), header)
+}
+
+func getHeaders(chaintr *chaintracks.Client, height uint32, count uint32) {
+	hashedHeaders, err := chaintr.GetHeaders(context.Background(), height, count)
+	if err != nil {
+		panic("failed to get Chaintracks headers: " + err.Error())
+	}
+
+	baseHeaders, err := hashedHeaders.ToBaseBlockHeaders()
+	if err != nil {
+		panic("failed to convert hashed headers to base headers: " + err.Error())
+	}
+
+	show.Info(fmt.Sprintf("Got %d Chaintracks Base Headers", len(baseHeaders)), baseHeaders)
+	for i, header := range baseHeaders {
+		show.Info(fmt.Sprintf("Header index: %d", i), *header)
+	}
 }

--- a/pkg/services/chaintracks/chaintracks_client.go
+++ b/pkg/services/chaintracks/chaintracks_client.go
@@ -90,3 +90,20 @@ func (c *Client) GetInfo(ctx context.Context) (*InfoResponse, error) {
 
 	return resp.Value, nil
 }
+
+func (c *Client) GetPresentHeight(ctx context.Context) (uint, error) {
+	var resp ResponseFrame[uint]
+	if result, err := c.resty.R().
+		SetContext(ctx).
+		SetResult(&resp).
+		Get(c.url + "/getPresentHeight"); err != nil {
+		return 0, fmt.Errorf("getPresentHeight request: %w", err)
+	} else if result.StatusCode() != 200 {
+		c.logger.DebugContext(ctx, "chaintracks getPresentHeight non-200 HTTP status", "status", result.StatusCode(), "body", result.String())
+		return 0, fmt.Errorf("getPresentHeight HTTP status: %d", result.StatusCode())
+	} else if !resp.IsSuccess() {
+		return 0, fmt.Errorf("getPresentHeight response not successful: status: %q", resp.Status)
+	}
+
+	return *resp.Value, nil
+}

--- a/pkg/services/chaintracks/chaintracks_client.go
+++ b/pkg/services/chaintracks/chaintracks_client.go
@@ -124,6 +124,8 @@ func (c *Client) FindHeaderHexForHeight(ctx context.Context, height uint32) (*Bl
 	}
 }
 
+// FindHeaderHexForBlockHash retrieves the block header for the specified block hash as a BlockHeader struct.
+// Returns an error if the block hash is invalid, not found, or if the backend request is unsuccessful.
 func (c *Client) FindHeaderHexForBlockHash(ctx context.Context, hash string) (*BlockHeader, error) {
 	if resp, err := getRequest[BlockHeader](c, ctx, fmt.Sprintf("%s/findHeaderHexForBlockHash?hash=%s", c.url, hash)); err != nil {
 		return nil, fmt.Errorf("findHeaderHexForBlockHash: %w", err)
@@ -132,7 +134,10 @@ func (c *Client) FindHeaderHexForBlockHash(ctx context.Context, hash string) (*B
 	}
 }
 
-
+// GetHeaders retrieves a sequence of block headers starting at the specified height, limited to the given count.
+// Returns the headers as a HashedBaseHeaders value or an error if the request fails or the backend response is unsuccessful.
+// NOTE: The returned HashedBaseHeaders is a hex-encoded string of concatenated block headers.
+// To convert to structured headers, call ToBaseBlockHeaders() on the result.
 func (c *Client) GetHeaders(ctx context.Context, height uint32, count uint32) (HashedBaseHeaders, error) {
 	if resp, err := getRequest[HashedBaseHeaders](c, ctx, fmt.Sprintf("%s/getHeaders?height=%d&count=%d", c.url, height, count)); err != nil {
 		return "", fmt.Errorf("getHeaders: %w", err)

--- a/pkg/services/chaintracks/chaintracks_client.go
+++ b/pkg/services/chaintracks/chaintracks_client.go
@@ -102,6 +102,14 @@ func (c *Client) FindChainTipHashHex(ctx context.Context) (string, error) {
 	}
 }
 
+func (c *Client) FindChainTipHeaderHex(ctx context.Context) (*BlockHeader, error) {
+	if resp, err := getRequest[BlockHeader](c, ctx, c.url+"/findChainTipHeaderHex"); err != nil {
+		return nil, fmt.Errorf("findChainTipHeaderHex: %w", err)
+	} else {
+		return resp, nil
+	}
+}
+
 func getRequest[T any](c *Client, ctx context.Context, url string) (*T, error) {
 	var resp ResponseFrame[T]
 	result, err := c.resty.R().

--- a/pkg/services/chaintracks/chaintracks_client.go
+++ b/pkg/services/chaintracks/chaintracks_client.go
@@ -124,6 +124,14 @@ func (c *Client) FindHeaderHexForHeight(ctx context.Context, height uint32) (*Bl
 	}
 }
 
+func (c *Client) FindHeaderHexForBlockHash(ctx context.Context, hash string) (*BlockHeader, error) {
+	if resp, err := getRequest[BlockHeader](c, ctx, fmt.Sprintf("%s/findHeaderHexForBlockHash?hash=%s", c.url, hash)); err != nil {
+		return nil, fmt.Errorf("findHeaderHexForBlockHash: %w", err)
+	} else {
+		return resp, nil
+	}
+}
+
 func getRequest[T any](c *Client, ctx context.Context, url string) (*T, error) {
 	var resp ResponseFrame[T]
 	result, err := c.resty.R().

--- a/pkg/services/chaintracks/chaintracks_client.go
+++ b/pkg/services/chaintracks/chaintracks_client.go
@@ -103,6 +103,8 @@ func (c *Client) FindChainTipHashHex(ctx context.Context) (string, error) {
 	}
 }
 
+// FindChainTipHeaderHex retrieves the current chain tip block header in hex format from the backend service.
+// Returns a BlockHeader struct with header fields, or an error if the request or response is unsuccessful.
 func (c *Client) FindChainTipHeaderHex(ctx context.Context) (*BlockHeader, error) {
 	if resp, err := getRequest[BlockHeader](c, ctx, c.url+"/findChainTipHeaderHex"); err != nil {
 		return nil, fmt.Errorf("findChainTipHeaderHex: %w", err)
@@ -111,6 +113,9 @@ func (c *Client) FindChainTipHeaderHex(ctx context.Context) (*BlockHeader, error
 	}
 }
 
+// FindHeaderHexForHeight queries the backend for the block header at the given height and returns a BlockHeader struct.
+// Returns an error if the request is unsuccessful, the height is not found, or the backend returns a non-200 status.
+// The returned BlockHeader includes header fields, chain height, and block hash, or nil if not found.
 func (c *Client) FindHeaderHexForHeight(ctx context.Context, height uint32) (*BlockHeader, error) {
 	if resp, err := getRequest[BlockHeader](c, ctx, fmt.Sprintf("%s/findHeaderHexForHeight?height=%d", c.url, height)); err != nil {
 		return nil, fmt.Errorf("findHeaderHexForHeight: %w", err)

--- a/pkg/services/chaintracks/chaintracks_client.go
+++ b/pkg/services/chaintracks/chaintracks_client.go
@@ -132,6 +132,15 @@ func (c *Client) FindHeaderHexForBlockHash(ctx context.Context, hash string) (*B
 	}
 }
 
+
+func (c *Client) GetHeaders(ctx context.Context, height uint32, count uint32) (HashedBaseHeaders, error) {
+	if resp, err := getRequest[HashedBaseHeaders](c, ctx, fmt.Sprintf("%s/getHeaders?height=%d&count=%d", c.url, height, count)); err != nil {
+		return "", fmt.Errorf("getHeaders: %w", err)
+	} else {
+		return *resp, nil
+	}
+}
+
 func getRequest[T any](c *Client, ctx context.Context, url string) (*T, error) {
 	var resp ResponseFrame[T]
 	result, err := c.resty.R().

--- a/pkg/services/chaintracks/chaintracks_client.go
+++ b/pkg/services/chaintracks/chaintracks_client.go
@@ -75,54 +75,46 @@ func (c *Client) Chain() defs.BSVNetwork {
 // GetInfo returns an InfoResponse with chain id, block heights, ingest endpoints, and installed package metadata.
 // GetInfo returns an error if the request fails, responds with non-200 status, or response indicates failure.
 func (c *Client) GetInfo(ctx context.Context) (*InfoResponse, error) {
-	var resp ResponseFrame[InfoResponse]
-	if result, err := c.resty.R().
-		SetContext(ctx).
-		SetResult(&resp).
-		Get(c.url + "/getInfo"); err != nil {
-		return nil, fmt.Errorf("getinfo request: %w", err)
-	} else if result.StatusCode() != 200 {
-		c.logger.DebugContext(ctx, "chaintracks getinfo non-200 HTTP status", "status", result.StatusCode(), "body", result.String())
-		return nil, fmt.Errorf("getinfo HTTP status: %d", result.StatusCode())
-	} else if !resp.IsSuccess() {
-		return nil, fmt.Errorf("getinfo response not successful: status: %q", resp.Status)
+	if resp, err := getRequest[InfoResponse](c, ctx, c.url+"/getInfo"); err != nil {
+		return nil, fmt.Errorf("getinfo: %w", err)
+	} else {
+		return resp, nil
 	}
-
-	return resp.Value, nil
 }
 
 // GetPresentHeight queries the backend for the current blockchain height and returns it as a uint value.
 // Returns an error if the request fails, the HTTP status is not 200, or the response indicates failure.
 func (c *Client) GetPresentHeight(ctx context.Context) (uint, error) {
-	var resp ResponseFrame[uint]
-	if result, err := c.resty.R().
-		SetContext(ctx).
-		SetResult(&resp).
-		Get(c.url + "/getPresentHeight"); err != nil {
-		return 0, fmt.Errorf("getPresentHeight request: %w", err)
-	} else if result.StatusCode() != 200 {
-		c.logger.DebugContext(ctx, "chaintracks getPresentHeight non-200 HTTP status", "status", result.StatusCode(), "body", result.String())
-		return 0, fmt.Errorf("getPresentHeight HTTP status: %d", result.StatusCode())
-	} else if !resp.IsSuccess() {
-		return 0, fmt.Errorf("getPresentHeight response not successful: status: %q", resp.Status)
+	if resp, err := getRequest[uint](c, ctx, c.url+"/getPresentHeight"); err != nil {
+		return 0, fmt.Errorf("getPresentHeight: %w", err)
+	} else {
+		return *resp, nil
 	}
-
-	return *resp.Value, nil
 }
 
+// FindChainTipHashHex retrieves the current chain tip block hash in hex format from the backend service.
+// Returns the hash as a lowercase hexadecimal string, or an error if the request or response fails.
 func (c *Client) FindChainTipHashHex(ctx context.Context) (string, error) {
-	var resp ResponseFrame[string]
-	if result, err := c.resty.R().
+	if resp, err := getRequest[string](c, ctx, c.url+"/findChainTipHashHex"); err != nil {
+		return "", fmt.Errorf("findChainTipHashHex: %w", err)
+	} else {
+		return *resp, nil
+	}
+}
+
+func getRequest[T any](c *Client, ctx context.Context, url string) (*T, error) {
+	var resp ResponseFrame[T]
+	result, err := c.resty.R().
 		SetContext(ctx).
 		SetResult(&resp).
-		Get(c.url + "/findChainTipHashHex"); err != nil {
-		return "", fmt.Errorf("findChainTipHashHex request: %w", err)
+		Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("request: %w", err)
 	} else if result.StatusCode() != 200 {
-		c.logger.DebugContext(ctx, "chaintracks findChainTipHashHex non-200 HTTP status", "status", result.StatusCode(), "body", result.String())
-		return "", fmt.Errorf("findChainTipHashHex HTTP status: %d", result.StatusCode())
+		c.logger.DebugContext(ctx, "chaintracks non-200 HTTP status", "status", result.StatusCode(), "body", result.String())
+		return nil, fmt.Errorf("HTTP status: %d", result.StatusCode())
 	} else if !resp.IsSuccess() {
-		return "", fmt.Errorf("findChainTipHashHex response not successful: status: %q", resp.Status)
+		return nil, fmt.Errorf("response not successful: status: %q", resp.Status)
 	}
-
-	return *resp.Value, nil
+	return resp.Value, nil
 }

--- a/pkg/services/chaintracks/chaintracks_client.go
+++ b/pkg/services/chaintracks/chaintracks_client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/logging"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/services/internal/httpx"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 	"github.com/go-resty/resty/v2"
 	"github.com/go-softwarelab/common/pkg/to"
 )
@@ -84,8 +85,8 @@ func (c *Client) GetInfo(ctx context.Context) (*InfoResponse, error) {
 
 // GetPresentHeight queries the backend for the current blockchain height and returns it as a uint value.
 // Returns an error if the request fails, the HTTP status is not 200, or the response indicates failure.
-func (c *Client) GetPresentHeight(ctx context.Context) (uint, error) {
-	if resp, err := getRequest[uint](c, ctx, c.url+"/getPresentHeight"); err != nil {
+func (c *Client) GetPresentHeight(ctx context.Context) (uint32, error) {
+	if resp, err := getRequest[uint32](c, ctx, c.url+"/getPresentHeight"); err != nil {
 		return 0, fmt.Errorf("getPresentHeight: %w", err)
 	} else {
 		return *resp, nil
@@ -110,6 +111,14 @@ func (c *Client) FindChainTipHeaderHex(ctx context.Context) (*BlockHeader, error
 	}
 }
 
+func (c *Client) FindHeaderHexForHeight(ctx context.Context, height uint32) (*BlockHeader, error) {
+	if resp, err := getRequest[BlockHeader](c, ctx, fmt.Sprintf("%s/findHeaderHexForHeight?height=%d", c.url, height)); err != nil {
+		return nil, fmt.Errorf("findHeaderHexForHeight: %w", err)
+	} else {
+		return resp, nil
+	}
+}
+
 func getRequest[T any](c *Client, ctx context.Context, url string) (*T, error) {
 	var resp ResponseFrame[T]
 	result, err := c.resty.R().
@@ -123,6 +132,9 @@ func getRequest[T any](c *Client, ctx context.Context, url string) (*T, error) {
 		return nil, fmt.Errorf("HTTP status: %d", result.StatusCode())
 	} else if !resp.IsSuccess() {
 		return nil, fmt.Errorf("response not successful: status: %q", resp.Status)
+	} else if resp.IsNotFound() {
+		return nil, fmt.Errorf("response value missing: %w", wdk.ErrNotFoundError)
 	}
+
 	return resp.Value, nil
 }

--- a/pkg/services/chaintracks/chaintracks_client.go
+++ b/pkg/services/chaintracks/chaintracks_client.go
@@ -91,6 +91,8 @@ func (c *Client) GetInfo(ctx context.Context) (*InfoResponse, error) {
 	return resp.Value, nil
 }
 
+// GetPresentHeight queries the backend for the current blockchain height and returns it as a uint value.
+// Returns an error if the request fails, the HTTP status is not 200, or the response indicates failure.
 func (c *Client) GetPresentHeight(ctx context.Context) (uint, error) {
 	var resp ResponseFrame[uint]
 	if result, err := c.resty.R().
@@ -103,6 +105,23 @@ func (c *Client) GetPresentHeight(ctx context.Context) (uint, error) {
 		return 0, fmt.Errorf("getPresentHeight HTTP status: %d", result.StatusCode())
 	} else if !resp.IsSuccess() {
 		return 0, fmt.Errorf("getPresentHeight response not successful: status: %q", resp.Status)
+	}
+
+	return *resp.Value, nil
+}
+
+func (c *Client) FindChainTipHashHex(ctx context.Context) (string, error) {
+	var resp ResponseFrame[string]
+	if result, err := c.resty.R().
+		SetContext(ctx).
+		SetResult(&resp).
+		Get(c.url + "/findChainTipHashHex"); err != nil {
+		return "", fmt.Errorf("findChainTipHashHex request: %w", err)
+	} else if result.StatusCode() != 200 {
+		c.logger.DebugContext(ctx, "chaintracks findChainTipHashHex non-200 HTTP status", "status", result.StatusCode(), "body", result.String())
+		return "", fmt.Errorf("findChainTipHashHex HTTP status: %d", result.StatusCode())
+	} else if !resp.IsSuccess() {
+		return "", fmt.Errorf("findChainTipHashHex response not successful: status: %q", resp.Status)
 	}
 
 	return *resp.Value, nil

--- a/pkg/services/chaintracks/chaintracks_client_test.go
+++ b/pkg/services/chaintracks/chaintracks_client_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/logging"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/services/chaintracks"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/services/chaintracks/internal/testabilities"
+	"github.com/go-softwarelab/common/pkg/to"
 	"github.com/stretchr/testify/require"
 )
 
@@ -87,6 +88,72 @@ func TestChaintracksClient_GetInfo(t *testing.T) {
 
 			// then:
 			test.Then(t, info, err)
+		})
+	}
+}
+
+func TestChaintracksClient_GetPresentHeight(t *testing.T) {
+	tests := map[string]struct {
+		ResponseCode int
+		ResponseBody any
+		Then         func(t *testing.T, height uint, err error)
+	}{
+		"should return correct chain": {
+			ResponseCode: 200,
+			ResponseBody: chaintracks.ResponseFrame[uint]{
+				Status: "success",
+				Value:  to.Ptr[uint](1000),
+			},
+			Then: func(t *testing.T, height uint, err error) {
+				require.NoError(t, err)
+				require.Equal(t, uint(1000), height)
+			},
+		},
+		"should return error on non-200 response": {
+			ResponseCode: 500,
+			ResponseBody: `{"status":"error","message":"internal server error"}`,
+			Then: func(t *testing.T, height uint, err error) {
+				require.Error(t, err)
+				require.Equal(t, uint(0), height)
+			},
+		},
+		"should return error on invalid JSON": {
+			ResponseCode: 200,
+			ResponseBody: `{"status":"success","value":{invalid json}}`,
+			Then: func(t *testing.T, height uint, err error) {
+				require.Error(t, err)
+				require.Equal(t, uint(0), height)
+			},
+		},
+		"should return error on error status in response": {
+			ResponseCode: 200,
+			ResponseBody: chaintracks.ResponseFrame[uint]{
+				Status: "error",
+				Value:  nil,
+			},
+			Then: func(t *testing.T, height uint, err error) {
+				require.Error(t, err)
+				require.Equal(t, uint(0), height)
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// given:
+			given := testabilities.Given(t)
+
+			mockServer := given.MockServer()
+			mockServer.
+				WillRespondOn("/getPresentHeight", "GET").
+				WithJSONResponse(test.ResponseCode, test.ResponseBody)
+
+			chaintr := chaintracks.NewClient(logging.NewTestLogger(t), defs.NetworkMainnet, "http://mock-chaintracks.com", chaintracks.WithRestyClient(mockServer.HttpClient()))
+
+			// when:
+			height, err := chaintr.GetPresentHeight(t.Context())
+
+			// then:
+			test.Then(t, height, err)
 		})
 	}
 }

--- a/pkg/services/chaintracks/chaintracks_client_test.go
+++ b/pkg/services/chaintracks/chaintracks_client_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/logging"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/services/chaintracks"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/services/chaintracks/internal/testabilities"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 	"github.com/go-softwarelab/common/pkg/to"
 	"github.com/stretchr/testify/require"
 )
@@ -96,33 +97,33 @@ func TestChaintracksClient_GetPresentHeight(t *testing.T) {
 	tests := map[string]struct {
 		ResponseCode int
 		ResponseBody any
-		Then         func(t *testing.T, height uint, err error)
+		Then         func(t *testing.T, height uint32, err error)
 	}{
 		"should return correct chain": {
 			ResponseCode: 200,
-			ResponseBody: chaintracks.ResponseFrame[uint]{
+			ResponseBody: chaintracks.ResponseFrame[uint32]{
 				Status: "success",
-				Value:  to.Ptr[uint](1000),
+				Value:  to.Ptr[uint32](1000),
 			},
-			Then: func(t *testing.T, height uint, err error) {
+			Then: func(t *testing.T, height uint32, err error) {
 				require.NoError(t, err)
-				require.Equal(t, uint(1000), height)
+				require.Equal(t, uint32(1000), height)
 			},
 		},
 		"should return error on non-200 response": {
 			ResponseCode: 500,
 			ResponseBody: `{"status":"error","message":"internal server error"}`,
-			Then: func(t *testing.T, height uint, err error) {
+			Then: func(t *testing.T, height uint32, err error) {
 				require.Error(t, err)
-				require.Equal(t, uint(0), height)
+				require.Equal(t, uint32(0), height)
 			},
 		},
 		"should return error on invalid JSON": {
 			ResponseCode: 200,
 			ResponseBody: `{"status":"success","value":{invalid json}}`,
-			Then: func(t *testing.T, height uint, err error) {
+			Then: func(t *testing.T, height uint32, err error) {
 				require.Error(t, err)
-				require.Equal(t, uint(0), height)
+				require.Equal(t, uint32(0), height)
 			},
 		},
 		"should return error on error status in response": {
@@ -131,9 +132,9 @@ func TestChaintracksClient_GetPresentHeight(t *testing.T) {
 				Status: "error",
 				Value:  nil,
 			},
-			Then: func(t *testing.T, height uint, err error) {
+			Then: func(t *testing.T, height uint32, err error) {
 				require.Error(t, err)
-				require.Equal(t, uint(0), height)
+				require.Equal(t, uint32(0), height)
 			},
 		},
 	}
@@ -225,24 +226,6 @@ func TestChaintracksClient_FindChainTipHashHex(t *testing.T) {
 }
 
 func TestChaintracksClient_FindChainTipHeader(t *testing.T) {
-	correctBlockHeader := &chaintracks.BlockHeader{
-		Height: 918934,
-		Hash:   "00000000000000000165924d2b7e41fd586d88e02f846ea6428d37c51f97db31",
-		BaseBlockHeader: chaintracks.BaseBlockHeader{
-			Version:          594616320,
-			PreviousHash:     "000000000000000007dce4ee864f0569066bcded7a6a3eca9b977eebf9cb3926",
-			MerkleRoot:       "f4afaab11ec4921a59c9eb1e49435aeaaef6e4396ee9d4a77ef88fdd60057928",
-			Time:             1760620895,
-			Bits:             405131341,
-			Nonce:            2411550733,
-			HeaderID:         2025,
-			PreviousHeaderID: to.Ptr[uint](2024),
-			Chainwork:        "0000000000000000000000000000000000000000016934b62084adb28c318e3c",
-			IsChainTip:       true,
-			IsActive:         true,
-		},
-	}
-
 	tests := map[string]struct {
 		ResponseCode int
 		ResponseBody any
@@ -252,7 +235,7 @@ func TestChaintracksClient_FindChainTipHeader(t *testing.T) {
 			ResponseCode: 200,
 			ResponseBody: chaintracks.ResponseFrame[chaintracks.BlockHeader]{
 				Status: "success",
-				Value: correctBlockHeader,
+				Value:  correctBlockHeader,
 			},
 			Then: func(t *testing.T, header *chaintracks.BlockHeader, err error) {
 				require.NoError(t, err)
@@ -306,4 +289,105 @@ func TestChaintracksClient_FindChainTipHeader(t *testing.T) {
 			test.Then(t, blockHeader, err)
 		})
 	}
+}
+
+func TestChaintracksClient_FindHeaderHexForHeight(t *testing.T) {
+	tests := map[string]struct {
+		Height       uint32
+		ResponseCode int
+		ResponseBody any
+		Then         func(t *testing.T, header *chaintracks.BlockHeader, err error)
+	}{
+		"should return correct header": {
+			Height:       918934,
+			ResponseCode: 200,
+			ResponseBody: chaintracks.ResponseFrame[chaintracks.BlockHeader]{
+				Status: "success",
+				Value:  correctBlockHeader,
+			},
+			Then: func(t *testing.T, header *chaintracks.BlockHeader, err error) {
+				require.NoError(t, err)
+				require.Equal(t, correctBlockHeader, header)
+			},
+		},
+		"should handle not-found as success with no value": {
+			Height:       123456,
+			ResponseCode: 200,
+			ResponseBody: chaintracks.ResponseFrame[chaintracks.BlockHeader]{
+				Status: "success",
+				Value:  nil,
+			},
+			Then: func(t *testing.T, header *chaintracks.BlockHeader, err error) {
+				require.ErrorIs(t, err, wdk.ErrNotFoundError)
+				require.Nil(t, header)
+			},
+		},
+		"should return error on non-200 response": {
+			Height:       918934,
+			ResponseCode: 500,
+			ResponseBody: `{"status":"error","message":"internal server error"}`,
+			Then: func(t *testing.T, header *chaintracks.BlockHeader, err error) {
+				require.Error(t, err)
+				require.Nil(t, header)
+			},
+		},
+		"should return error on invalid JSON": {
+			Height:       918934,
+			ResponseCode: 200,
+			ResponseBody: `{"status":"success","value":{invalid json}}`,
+			Then: func(t *testing.T, header *chaintracks.BlockHeader, err error) {
+				require.Error(t, err)
+				require.Nil(t, header)
+			},
+		},
+		"should return error on error status in response": {
+			Height:       918934,
+			ResponseCode: 200,
+			ResponseBody: chaintracks.ResponseFrame[chaintracks.BlockHeader]{
+				Status: "error",
+				Value:  nil,
+			},
+			Then: func(t *testing.T, header *chaintracks.BlockHeader, err error) {
+				require.Error(t, err)
+				require.Nil(t, header)
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// given:
+			given := testabilities.Given(t)
+
+			mockServer := given.MockServer()
+			mockServer.
+				WillRespondOn("/findHeaderHexForHeight", "GET").
+				WithJSONResponse(test.ResponseCode, test.ResponseBody)
+
+			chaintr := chaintracks.NewClient(logging.NewTestLogger(t), defs.NetworkMainnet, "http://mock-chaintracks.com", chaintracks.WithRestyClient(mockServer.HttpClient()))
+
+			// when:
+			blockHeader, err := chaintr.FindHeaderHexForHeight(t.Context(), test.Height)
+
+			// then:
+			test.Then(t, blockHeader, err)
+		})
+	}
+}
+
+var correctBlockHeader = &chaintracks.BlockHeader{
+	Height: 918934,
+	Hash:   "00000000000000000165924d2b7e41fd586d88e02f846ea6428d37c51f97db31",
+	BaseBlockHeader: chaintracks.BaseBlockHeader{
+		Version:          594616320,
+		PreviousHash:     "000000000000000007dce4ee864f0569066bcded7a6a3eca9b977eebf9cb3926",
+		MerkleRoot:       "f4afaab11ec4921a59c9eb1e49435aeaaef6e4396ee9d4a77ef88fdd60057928",
+		Time:             1760620895,
+		Bits:             405131341,
+		Nonce:            2411550733,
+		HeaderID:         2025,
+		PreviousHeaderID: to.Ptr[uint](2024),
+		Chainwork:        "0000000000000000000000000000000000000000016934b62084adb28c318e3c",
+		IsChainTip:       true,
+		IsActive:         true,
+	},
 }

--- a/pkg/services/chaintracks/chaintracks_client_test.go
+++ b/pkg/services/chaintracks/chaintracks_client_test.go
@@ -223,3 +223,87 @@ func TestChaintracksClient_FindChainTipHashHex(t *testing.T) {
 		})
 	}
 }
+
+func TestChaintracksClient_FindChainTipHeader(t *testing.T) {
+	correctBlockHeader := &chaintracks.BlockHeader{
+		Height: 918934,
+		Hash:   "00000000000000000165924d2b7e41fd586d88e02f846ea6428d37c51f97db31",
+		BaseBlockHeader: chaintracks.BaseBlockHeader{
+			Version:          594616320,
+			PreviousHash:     "000000000000000007dce4ee864f0569066bcded7a6a3eca9b977eebf9cb3926",
+			MerkleRoot:       "f4afaab11ec4921a59c9eb1e49435aeaaef6e4396ee9d4a77ef88fdd60057928",
+			Time:             1760620895,
+			Bits:             405131341,
+			Nonce:            2411550733,
+			HeaderID:         2025,
+			PreviousHeaderID: to.Ptr[uint](2024),
+			Chainwork:        "0000000000000000000000000000000000000000016934b62084adb28c318e3c",
+			IsChainTip:       true,
+			IsActive:         true,
+		},
+	}
+
+	tests := map[string]struct {
+		ResponseCode int
+		ResponseBody any
+		Then         func(t *testing.T, header *chaintracks.BlockHeader, err error)
+	}{
+		"should return correct header": {
+			ResponseCode: 200,
+			ResponseBody: chaintracks.ResponseFrame[chaintracks.BlockHeader]{
+				Status: "success",
+				Value: correctBlockHeader,
+			},
+			Then: func(t *testing.T, header *chaintracks.BlockHeader, err error) {
+				require.NoError(t, err)
+				require.Equal(t, correctBlockHeader, header)
+			},
+		},
+		"should return error on non-200 response": {
+			ResponseCode: 500,
+			ResponseBody: `{"status":"error","message":"internal server error"}`,
+			Then: func(t *testing.T, header *chaintracks.BlockHeader, err error) {
+				require.Error(t, err)
+				require.Nil(t, header)
+			},
+		},
+		"should return error on invalid JSON": {
+			ResponseCode: 200,
+			ResponseBody: `{"status":"success","value":{invalid json}}`,
+			Then: func(t *testing.T, header *chaintracks.BlockHeader, err error) {
+				require.Error(t, err)
+				require.Nil(t, header)
+			},
+		},
+		"should return error on error status in response": {
+			ResponseCode: 200,
+			ResponseBody: chaintracks.ResponseFrame[chaintracks.BlockHeader]{
+				Status: "error",
+				Value:  nil,
+			},
+			Then: func(t *testing.T, header *chaintracks.BlockHeader, err error) {
+				require.Error(t, err)
+				require.Nil(t, header)
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// given:
+			given := testabilities.Given(t)
+
+			mockServer := given.MockServer()
+			mockServer.
+				WillRespondOn("/findChainTipHeaderHex", "GET").
+				WithJSONResponse(test.ResponseCode, test.ResponseBody)
+
+			chaintr := chaintracks.NewClient(logging.NewTestLogger(t), defs.NetworkMainnet, "http://mock-chaintracks.com", chaintracks.WithRestyClient(mockServer.HttpClient()))
+
+			// when:
+			blockHeader, err := chaintr.FindChainTipHeaderHex(t.Context())
+
+			// then:
+			test.Then(t, blockHeader, err)
+		})
+	}
+}

--- a/pkg/services/chaintracks/chaintracks_client_test.go
+++ b/pkg/services/chaintracks/chaintracks_client_test.go
@@ -457,16 +457,84 @@ func TestChaintracksClient_FindHeaderHexForBlockHash(t *testing.T) {
 	}
 }
 
+func TestChaintracksClient_GetHeaders(t *testing.T) {
+	tests := map[string]struct {
+		ResponseCode int
+		ResponseBody any
+		Then         func(t *testing.T, hashedHeaders chaintracks.HashedBaseHeaders, err error)
+	}{
+		"should return correct hashed headers": {
+			ResponseCode: 200,
+			ResponseBody: chaintracks.ResponseFrame[chaintracks.HashedBaseHeaders]{
+				Status: "success",
+				Value:  to.Ptr(chaintracks.HashedBaseHeaders(correctTwoHashedBaseHeaders)),
+			},
+			Then: func(t *testing.T, header chaintracks.HashedBaseHeaders, err error) {
+				require.NoError(t, err)
+				require.Equal(t, correctTwoHashedBaseHeaders, string(header))
+			},
+		},
+		"should return error on non-200 response": {
+			ResponseCode: 500,
+			ResponseBody: `{"status":"error","message":"internal server error"}`,
+			Then: func(t *testing.T, header chaintracks.HashedBaseHeaders, err error) {
+				require.Error(t, err)
+				require.Empty(t, header)
+			},
+		},
+		"should return error on invalid JSON": {
+			ResponseCode: 200,
+			ResponseBody: `{"status":"success","value":{invalid json}}`,
+			Then: func(t *testing.T, header chaintracks.HashedBaseHeaders, err error) {
+				require.Error(t, err)
+				require.Empty(t, header)
+			},
+		},
+		"should return error on error status in response": {
+			ResponseCode: 200,
+			ResponseBody: chaintracks.ResponseFrame[chaintracks.HashedBaseHeaders]{
+				Status: "error",
+				Value:  nil,
+			},
+			Then: func(t *testing.T, header chaintracks.HashedBaseHeaders, err error) {
+				require.Error(t, err)
+				require.Empty(t, header)
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// given:
+			given := testabilities.Given(t)
+
+			mockServer := given.MockServer()
+			mockServer.
+				WillRespondOn("/getHeaders?height=919053&count=10", "GET").
+				WithJSONResponse(test.ResponseCode, test.ResponseBody)
+
+			chaintr := chaintracks.NewClient(logging.NewTestLogger(t), defs.NetworkMainnet, "http://mock-chaintracks.com", chaintracks.WithRestyClient(mockServer.HttpClient()))
+
+			// when:
+			blockHeader, err := chaintr.GetHeaders(t.Context(), 919053, 10)
+
+			// then:
+			test.Then(t, blockHeader, err)
+		})
+	}
+}
+
 var correctBlockHeader = &chaintracks.BlockHeader{
 	Height: 918934,
 	Hash:   "00000000000000000165924d2b7e41fd586d88e02f846ea6428d37c51f97db31",
 	BaseBlockHeader: chaintracks.BaseBlockHeader{
-		Version:          594616320,
-		PreviousHash:     "000000000000000007dce4ee864f0569066bcded7a6a3eca9b977eebf9cb3926",
-		MerkleRoot:       "f4afaab11ec4921a59c9eb1e49435aeaaef6e4396ee9d4a77ef88fdd60057928",
-		Time:             1760620895,
-		Bits:             405131341,
-		Nonce:            2411550733,
+		Version:      594616320,
+		PreviousHash: "000000000000000007dce4ee864f0569066bcded7a6a3eca9b977eebf9cb3926",
+		MerkleRoot:   "f4afaab11ec4921a59c9eb1e49435aeaaef6e4396ee9d4a77ef88fdd60057928",
+		Time:         1760620895,
+		Bits:         405131341,
+		Nonce:        2411550733,
+	},
+	BlockHeaderInfo: chaintracks.BlockHeaderInfo{
 		HeaderID:         2025,
 		PreviousHeaderID: to.Ptr[uint](2024),
 		Chainwork:        "0000000000000000000000000000000000000000016934b62084adb28c318e3c",

--- a/pkg/services/chaintracks/chaintracks_client_test.go
+++ b/pkg/services/chaintracks/chaintracks_client_test.go
@@ -374,6 +374,89 @@ func TestChaintracksClient_FindHeaderHexForHeight(t *testing.T) {
 	}
 }
 
+func TestChaintracksClient_FindHeaderHexForBlockHash(t *testing.T) {
+	tests := map[string]struct {
+		BlockHash    string
+		ResponseCode int
+		ResponseBody any
+		Then         func(t *testing.T, header *chaintracks.BlockHeader, err error)
+	}{
+		"should return correct header": {
+			BlockHash:    correctBlockHeader.Hash,
+			ResponseCode: 200,
+			ResponseBody: chaintracks.ResponseFrame[chaintracks.BlockHeader]{
+				Status: "success",
+				Value:  correctBlockHeader,
+			},
+			Then: func(t *testing.T, header *chaintracks.BlockHeader, err error) {
+				require.NoError(t, err)
+				require.Equal(t, correctBlockHeader, header)
+			},
+		},
+		"should handle not-found as success with no value": {
+			BlockHash:    correctBlockHeader.Hash,
+			ResponseCode: 200,
+			ResponseBody: chaintracks.ResponseFrame[chaintracks.BlockHeader]{
+				Status: "success",
+				Value:  nil,
+			},
+			Then: func(t *testing.T, header *chaintracks.BlockHeader, err error) {
+				require.ErrorIs(t, err, wdk.ErrNotFoundError)
+				require.Nil(t, header)
+			},
+		},
+		"should return error on non-200 response": {
+			BlockHash:    correctBlockHeader.Hash,
+			ResponseCode: 500,
+			ResponseBody: `{"status":"error","message":"internal server error"}`,
+			Then: func(t *testing.T, header *chaintracks.BlockHeader, err error) {
+				require.Error(t, err)
+				require.Nil(t, header)
+			},
+		},
+		"should return error on invalid JSON": {
+			BlockHash:    correctBlockHeader.Hash,
+			ResponseCode: 200,
+			ResponseBody: `{"status":"success","value":{invalid json}}`,
+			Then: func(t *testing.T, header *chaintracks.BlockHeader, err error) {
+				require.Error(t, err)
+				require.Nil(t, header)
+			},
+		},
+		"should return error on error status in response": {
+			BlockHash:    correctBlockHeader.Hash,
+			ResponseCode: 200,
+			ResponseBody: chaintracks.ResponseFrame[chaintracks.BlockHeader]{
+				Status: "error",
+				Value:  nil,
+			},
+			Then: func(t *testing.T, header *chaintracks.BlockHeader, err error) {
+				require.Error(t, err)
+				require.Nil(t, header)
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// given:
+			given := testabilities.Given(t)
+
+			mockServer := given.MockServer()
+			mockServer.
+				WillRespondOn("/findHeaderHexForBlockHash", "GET").
+				WithJSONResponse(test.ResponseCode, test.ResponseBody)
+
+			chaintr := chaintracks.NewClient(logging.NewTestLogger(t), defs.NetworkMainnet, "http://mock-chaintracks.com", chaintracks.WithRestyClient(mockServer.HttpClient()))
+
+			// when:
+			blockHeader, err := chaintr.FindHeaderHexForBlockHash(t.Context(), test.BlockHash)
+
+			// then:
+			test.Then(t, blockHeader, err)
+		})
+	}
+}
+
 var correctBlockHeader = &chaintracks.BlockHeader{
 	Height: 918934,
 	Hash:   "00000000000000000165924d2b7e41fd586d88e02f846ea6428d37c51f97db31",

--- a/pkg/services/chaintracks/chaintracks_client_test.go
+++ b/pkg/services/chaintracks/chaintracks_client_test.go
@@ -157,3 +157,69 @@ func TestChaintracksClient_GetPresentHeight(t *testing.T) {
 		})
 	}
 }
+
+func TestChaintracksClient_FindChainTipHashHex(t *testing.T) {
+	tests := map[string]struct {
+		ResponseCode int
+		ResponseBody any
+		Then         func(t *testing.T, hash string, err error)
+	}{
+		"should return correct hash": {
+			ResponseCode: 200,
+			ResponseBody: chaintracks.ResponseFrame[string]{
+				Status: "success",
+				Value:  to.Ptr("0000000000000000000a7b3c4d5e6f708090a0b0c0d0e0f1011121314151617"),
+			},
+			Then: func(t *testing.T, hash string, err error) {
+				require.NoError(t, err)
+				require.Equal(t, "0000000000000000000a7b3c4d5e6f708090a0b0c0d0e0f1011121314151617", hash)
+			},
+		},
+		"should return error on non-200 response": {
+			ResponseCode: 500,
+			ResponseBody: `{"status":"error","message":"internal server error"}`,
+			Then: func(t *testing.T, hash string, err error) {
+				require.Error(t, err)
+				require.Empty(t, hash)
+			},
+		},
+		"should return error on invalid JSON": {
+			ResponseCode: 200,
+			ResponseBody: `{"status":"success","value":{invalid json}}`,
+			Then: func(t *testing.T, hash string, err error) {
+				require.Error(t, err)
+				require.Empty(t, hash)
+			},
+		},
+		"should return error on error status in response": {
+			ResponseCode: 200,
+			ResponseBody: chaintracks.ResponseFrame[string]{
+				Status: "error",
+				Value:  nil,
+			},
+			Then: func(t *testing.T, hash string, err error) {
+				require.Error(t, err)
+				require.Empty(t, hash)
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// given:
+			given := testabilities.Given(t)
+
+			mockServer := given.MockServer()
+			mockServer.
+				WillRespondOn("/findChainTipHashHex", "GET").
+				WithJSONResponse(test.ResponseCode, test.ResponseBody)
+
+			chaintr := chaintracks.NewClient(logging.NewTestLogger(t), defs.NetworkMainnet, "http://mock-chaintracks.com", chaintracks.WithRestyClient(mockServer.HttpClient()))
+
+			// when:
+			hash, err := chaintr.FindChainTipHashHex(t.Context())
+
+			// then:
+			test.Then(t, hash, err)
+		})
+	}
+}

--- a/pkg/services/chaintracks/chaintracks_dto.go
+++ b/pkg/services/chaintracks/chaintracks_dto.go
@@ -36,6 +36,8 @@ type BaseBlockHeader struct {
 	Nonce        uint32 `json:"nonce"`
 }
 
+// NewBaseBlockHeaderFromWDK creates a BaseBlockHeader from a given wdk.ChainBaseBlockHeader instance.
+// The existence of those two types is to decouple the chaintracks service DTOs from the WDK's models.
 func NewBaseBlockHeaderFromWDK(bh *wdk.ChainBaseBlockHeader) BaseBlockHeader {
 	return BaseBlockHeader{
 		Version:      bh.Version,
@@ -84,8 +86,16 @@ func (c *ResponseFrame[T]) IsNotFound() bool {
 	return c.Status == "success" && c.Value == nil
 }
 
+// HashedBaseHeaders represents a hex-encoded string of one or more concatenated Bitcoin base block headers.
+// Used for efficient transport of serialized block header data in API responses or storage contexts.
+// To obtain individual block headers, methods should decode and parse this type appropriately.
+// An empty value denotes no serialized block headers are present.
 type HashedBaseHeaders string
 
+// ToBaseBlockHeaders decodes the hex-encoded string and returns a slice of BaseBlockHeader pointers or an error.
+// Returns an error if the string is not valid hex or its length is not a multiple of the block header length (80 bytes).
+// Each decoded header is parsed into a BaseBlockHeader struct and included in the result slice.
+// If the input is an empty string, an empty slice is returned without error.
 func (h HashedBaseHeaders) ToBaseBlockHeaders() ([]*BaseBlockHeader, error) {
 	data, err := hex.DecodeString(string(h))
 	if err != nil {

--- a/pkg/services/chaintracks/chaintracks_dto.go
+++ b/pkg/services/chaintracks/chaintracks_dto.go
@@ -102,7 +102,7 @@ func (h HashedBaseHeaders) ToBaseBlockHeaders() ([]*BaseBlockHeader, error) {
 		return nil, fmt.Errorf("failed to decode hex string: %w", err)
 	}
 
-	const headerLength = 80
+	const headerLength = wdk.BlockHeaderLength
 	if len(data)%headerLength != 0 {
 		return nil, fmt.Errorf("decoded data length %d is not a multiple of header length %d", len(data), headerLength)
 	}

--- a/pkg/services/chaintracks/chaintracks_dto.go
+++ b/pkg/services/chaintracks/chaintracks_dto.go
@@ -49,5 +49,9 @@ type ResponseFrame[T any] struct {
 
 // IsSuccess returns true if the response status is "success" and a non-nil value payload is present.
 func (c *ResponseFrame[T]) IsSuccess() bool {
-	return c.Status == "success" && c.Value != nil
+	return c.Status == "success"
+}
+
+func (c *ResponseFrame[T]) IsNotFound() bool {
+	return c.Status == "success" && c.Value == nil
 }

--- a/pkg/services/chaintracks/chaintracks_dto.go
+++ b/pkg/services/chaintracks/chaintracks_dto.go
@@ -19,6 +19,7 @@ type PackageInfo struct {
 	Version string `json:"version"`
 }
 
+// BaseBlockHeader defines the essential fields for a blockchain block header, including version, hash links, and metadata.
 type BaseBlockHeader struct {
 	Version      uint32 `json:"version"`
 	PreviousHash string `json:"previousHash"`
@@ -27,6 +28,7 @@ type BaseBlockHeader struct {
 	Bits         uint32 `json:"bits"`
 	Nonce        uint32 `json:"nonce"`
 
+	// TODO: Below fields are not part of TS-BaseBlockHeader, even though they are returned from server - check if they are always present
 	HeaderID         uint   `json:"headerId"`
 	PreviousHeaderID *uint  `json:"previousHeaderId,omitempty"`
 	Chainwork        string `json:"chainwork"`
@@ -34,6 +36,8 @@ type BaseBlockHeader struct {
 	IsActive         bool   `json:"isActive"`
 }
 
+// BlockHeader represents a full blockchain block header, including base header fields, block height, and block hash.
+// It extends BaseBlockHeader with additional height and hash information for block identification and lookup.
 type BlockHeader struct {
 	BaseBlockHeader
 	Height uint32 `json:"height"`
@@ -47,11 +51,13 @@ type ResponseFrame[T any] struct {
 	Value  *T     `json:"value,omitempty"`
 }
 
-// IsSuccess returns true if the response status is "success" and a non-nil value payload is present.
+// IsSuccess returns true if the response status is "success"
 func (c *ResponseFrame[T]) IsSuccess() bool {
 	return c.Status == "success"
 }
 
+// IsNotFound returns true if the response status is "success" and the value is nil, indicating a not found result.
+// NOTE: Current server implementation returns HTTP 200 with {"status":"success"} for not found cases.
 func (c *ResponseFrame[T]) IsNotFound() bool {
 	return c.Status == "success" && c.Value == nil
 }

--- a/pkg/services/chaintracks/chaintracks_dto.go
+++ b/pkg/services/chaintracks/chaintracks_dto.go
@@ -19,6 +19,27 @@ type PackageInfo struct {
 	Version string `json:"version"`
 }
 
+type BaseBlockHeader struct {
+	Version      uint32 `json:"version"`
+	PreviousHash string `json:"previousHash"`
+	MerkleRoot   string `json:"merkleRoot"`
+	Time         uint32 `json:"time"`
+	Bits         uint32 `json:"bits"`
+	Nonce        uint32 `json:"nonce"`
+
+	HeaderID         uint   `json:"headerId"`
+	PreviousHeaderID *uint  `json:"previousHeaderId,omitempty"`
+	Chainwork        string `json:"chainwork"`
+	IsChainTip       bool   `json:"isChainTip"`
+	IsActive         bool   `json:"isActive"`
+}
+
+type BlockHeader struct {
+	BaseBlockHeader
+	Height uint32 `json:"height"`
+	Hash   string `json:"hash"`
+}
+
 // ResponseFrame represents a generic response wrapper with status information and an optional value payload.
 // Used for unmarshalling HTTP API responses where the frame's status field indicates success or error state.
 type ResponseFrame[T any] struct {

--- a/pkg/services/chaintracks/chaintracks_dto.go
+++ b/pkg/services/chaintracks/chaintracks_dto.go
@@ -1,6 +1,13 @@
 package chaintracks
 
-import "github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+	"github.com/go-softwarelab/common/pkg/to"
+)
 
 // InfoResponse contains details about the BSV network, block heights, storage backend, endpoints, and installed packages.
 type InfoResponse struct {
@@ -27,8 +34,21 @@ type BaseBlockHeader struct {
 	Time         uint32 `json:"time"`
 	Bits         uint32 `json:"bits"`
 	Nonce        uint32 `json:"nonce"`
+}
 
-	// TODO: Below fields are not part of TS-BaseBlockHeader, even though they are returned from server - check if they are always present
+func NewBaseBlockHeaderFromWDK(bh *wdk.ChainBaseBlockHeader) BaseBlockHeader {
+	return BaseBlockHeader{
+		Version:      bh.Version,
+		PreviousHash: bh.PreviousHash,
+		MerkleRoot:   bh.MerkleRoot,
+		Time:         bh.Time,
+		Bits:         bh.Bits,
+		Nonce:        bh.Nonce,
+	}
+}
+
+// BlockHeaderInfo provides summarized metadata for a block header including identifiers, chainwork, and chain tip status.
+type BlockHeaderInfo struct {
 	HeaderID         uint   `json:"headerId"`
 	PreviousHeaderID *uint  `json:"previousHeaderId,omitempty"`
 	Chainwork        string `json:"chainwork"`
@@ -40,6 +60,8 @@ type BaseBlockHeader struct {
 // It extends BaseBlockHeader with additional height and hash information for block identification and lookup.
 type BlockHeader struct {
 	BaseBlockHeader
+	BlockHeaderInfo
+
 	Height uint32 `json:"height"`
 	Hash   string `json:"hash"`
 }
@@ -60,4 +82,33 @@ func (c *ResponseFrame[T]) IsSuccess() bool {
 // NOTE: Current server implementation returns HTTP 200 with {"status":"success"} for not found cases.
 func (c *ResponseFrame[T]) IsNotFound() bool {
 	return c.Status == "success" && c.Value == nil
+}
+
+type HashedBaseHeaders string
+
+func (h HashedBaseHeaders) ToBaseBlockHeaders() ([]*BaseBlockHeader, error) {
+	data, err := hex.DecodeString(string(h))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode hex string: %w", err)
+	}
+
+	const headerLength = 80
+	if len(data)%headerLength != 0 {
+		return nil, fmt.Errorf("decoded data length %d is not a multiple of header length %d", len(data), headerLength)
+	}
+
+	numHeaders := len(data) / headerLength
+	hashes := make([]*BaseBlockHeader, numHeaders)
+	for i := 0; i < numHeaders; i++ {
+		start := i * headerLength
+		end := start + headerLength
+		chainBaseHeader, err := wdk.ChainBaseBlockHeaderFromBytes(data[start:end])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse block header at index %d: %w", i, err)
+		}
+
+		hashes[i] = to.Ptr(NewBaseBlockHeaderFromWDK(chainBaseHeader))
+	}
+
+	return hashes, nil
 }

--- a/pkg/services/chaintracks/chaintracks_dto_test.go
+++ b/pkg/services/chaintracks/chaintracks_dto_test.go
@@ -1,0 +1,84 @@
+package chaintracks_test
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/services/chaintracks"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	correctTwoHashedBaseHeaders = "00c046275b8a91ef8cecacb3ec7ed44652ada0da54434680b3ee1f130000000000000000a629bb863cd0e0e8ee103f98a0116e2f583de339f72347de53c2593f2444cad0d2f3f168faa22418426b621b000000388a0da2e9107ca07ab9db3df8a0979f372a318c3182aa2802000000000000000039f253b785ad25c117eb04fe633d36975d8397368ee6f9126470c37a7a4cdf15fbf4f16855982418f6ba4787"
+)
+
+func TestDTO_ToBaseBlockHeaders(t *testing.T) {
+	tests := map[string]struct {
+		hashed    string
+		expected  []chaintracks.BaseBlockHeader
+		expectErr bool
+	}{
+		"two headers hashed": {
+			hashed: correctTwoHashedBaseHeaders,
+			expected: []chaintracks.BaseBlockHeader{
+				{
+					Version:      0x2746c000,
+					PreviousHash: "0000000000000000131feeb380464354daa0ad5246d47eecb3acec8cef918a5b",
+					MerkleRoot:   "d0ca44243f59c253de4723f739e33d582f6e11a0983f10eee8e0d03c86bb29a6",
+					Time:         1760687058,
+					Bits:         0x1824a2fa,
+					Nonce:        459434818,
+				},
+				{
+					Version:      0x38000000,
+					PreviousHash: "00000000000000000228aa82318c312a379f97a0f83ddbb97aa07c10e9a20d8a",
+					MerkleRoot:   "15df4c7a7ac3706412f9e68e3697835d97363d63fe04eb17c125ad85b753f239",
+					Time:         1760687355,
+					Bits:         0x18249855,
+					Nonce:        2269625078,
+				},
+			},
+		},
+		"single header hashed": {
+			hashed: correctTwoHashedBaseHeaders[:80],
+			expected: []chaintracks.BaseBlockHeader{
+				{
+					Version:      0x2746c000,
+					PreviousHash: "0000000000000000131feeb380464354daa0ad5246d47eecb3acec8cef918a5b",
+					MerkleRoot:   "d0ca44243f59c253de4723f739e33d582f6e11a0983f10eee8e0d03c86bb29a6",
+					Time:         1760687058,
+					Bits:         0x1824a2fa,
+					Nonce:        459434818,
+				},
+			},
+		},
+		"empty hashed": {
+			hashed:   "",
+			expected: []chaintracks.BaseBlockHeader{},
+		},
+		"invalid hashed - odd length": {
+			hashed:    "00c046275b8a91ef8cecacb3ec7ed44652ada0da54434680b3ee1f130000000000000000a629bb863cd0e0e8ee103f98a0116e2f583de339f72347de53c2593f2444cad0d2f3f168faa22418426b621",
+			expected:  nil,
+			expectErr: true,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// given:
+			hexEncodedBlockHeaders := chaintracks.HashedBaseHeaders(test.hashed)
+
+			// when:
+			actual, err := hexEncodedBlockHeaders.ToBaseBlockHeaders()
+
+			// then:
+			if test.expectErr {
+				require.Error(t, err)
+			} else {
+				require.Len(t, actual, len(test.expected))
+
+				for i := range actual {
+					require.Equal(t, test.expected[i], *actual[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/services/chaintracks/chaintracks_dto_test.go
+++ b/pkg/services/chaintracks/chaintracks_dto_test.go
@@ -39,7 +39,7 @@ func TestDTO_ToBaseBlockHeaders(t *testing.T) {
 			},
 		},
 		"single header hashed": {
-			hashed: correctTwoHashedBaseHeaders[:80],
+			hashed: correctTwoHashedBaseHeaders[:2*80], // first 80 bytes (160 hex chars)
 			expected: []chaintracks.BaseBlockHeader{
 				{
 					Version:      0x2746c000,

--- a/pkg/services/internal/bhs/internal/dto/dto.go
+++ b/pkg/services/internal/bhs/internal/dto/dto.go
@@ -20,15 +20,17 @@ type BlockHeaderByHeightResponse struct {
 
 func (b *BlockHeaderByHeightResponse) IsZero() bool { return *b == BlockHeaderByHeightResponse{} }
 
-func (b *BlockHeaderByHeightResponse) ConvertChainBaseBlockHeader() *wdk.ChainBaseBlockHeader {
-	return &wdk.ChainBaseBlockHeader{
-		Version:      b.Version,
-		PreviousHash: b.PreviousBlock,
-		MerkleRoot:   b.MerkleRoot,
-		Time:         b.Timestamp,
-		Bits:         b.DifficultyTarget,
-		Nonce:        b.Nonce,
-		Hash:         b.Hash,
+func (b *BlockHeaderByHeightResponse) ConvertChainBlockHeader() *wdk.ChainBlockHeader {
+	return &wdk.ChainBlockHeader{
+		ChainBaseBlockHeader: wdk.ChainBaseBlockHeader{
+			Version:      b.Version,
+			PreviousHash: b.PreviousBlock,
+			MerkleRoot:   b.MerkleRoot,
+			Time:         b.Timestamp,
+			Bits:         b.DifficultyTarget,
+			Nonce:        b.Nonce,
+		},
+		Hash: b.Hash,
 	}
 }
 
@@ -60,7 +62,6 @@ func (t *TipStateResponse) ConvertToChainBlockHeader() *wdk.ChainBlockHeader {
 			MerkleRoot:   t.Header.MerkleRoot,
 			Time:         t.Header.Timestamp,
 			Nonce:        t.Header.Nonce,
-			Hash:         t.Header.Hash,
 		},
 		Height: t.Height,
 		Hash:   t.Header.Hash,

--- a/pkg/services/internal/bhs/service.go
+++ b/pkg/services/internal/bhs/service.go
@@ -54,7 +54,7 @@ func New(httpClient *resty.Client, logger *slog.Logger, network defs.BSVNetwork,
 	}
 }
 
-func (b *BlockHeadersService) ChainHeaderByHeight(ctx context.Context, height uint32) (*wdk.ChainBaseBlockHeader, error) {
+func (b *BlockHeadersService) ChainHeaderByHeight(ctx context.Context, height uint32) (*wdk.ChainBlockHeader, error) {
 	url, err := headerByHeight(b.cfg.URL)
 	if err != nil {
 		return nil, fmt.Errorf("error building URL: %w", err)
@@ -84,7 +84,7 @@ func (b *BlockHeadersService) ChainHeaderByHeight(ctx context.Context, height ui
 		return nil, fmt.Errorf("expected a non-empty block header at height %d. Verify the BHS API and query parameters used", height)
 	}
 
-	return first.ConvertChainBaseBlockHeader(), nil
+	return first.ConvertChainBlockHeader(), nil
 }
 
 func (b *BlockHeadersService) IsValidRootForHeight(ctx context.Context, root *chainhash.Hash, height uint32) (bool, error) {

--- a/pkg/services/internal/bhs/service_test.go
+++ b/pkg/services/internal/bhs/service_test.go
@@ -96,7 +96,6 @@ func TestBlockHeadersService_FindChainTipHeader(t *testing.T) {
 				MerkleRoot:   def.MerkleRoot,
 				Time:         def.Timestamp,
 				Nonce:        def.Nonce,
-				Hash:         def.Hash,
 			},
 			Height: def.Height,
 			Hash:   def.Hash,

--- a/pkg/services/internal/bitails/get_chain_by_height.go
+++ b/pkg/services/internal/bitails/get_chain_by_height.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 )
 
-func (b *Bitails) ChainHeaderByHeight(ctx context.Context, height uint32) (*wdk.ChainBaseBlockHeader, error) {
+func (b *Bitails) ChainHeaderByHeight(ctx context.Context, height uint32) (*wdk.ChainBlockHeader, error) {
 	url, err := blockByHeight(b.url, height)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build URL to retrieve block by height from Bitails: %w", err)
@@ -33,7 +33,7 @@ func (b *Bitails) ChainHeaderByHeight(ctx context.Context, height uint32) (*wdk.
 		return nil, fmt.Errorf("expected a non-empty block header at height %d", height)
 	}
 
-	base, err := dst.ConvertToChainBaseBlockHeader()
+	base, err := dst.ConvertToChainBlockHeader()
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert block header response by height from Bitails to a chain base block header: %w", err)
 	}

--- a/pkg/services/internal/bitails/internal/dto/script_hash_history.go
+++ b/pkg/services/internal/bitails/internal/dto/script_hash_history.go
@@ -35,19 +35,21 @@ type BlockHeaderByHeight struct {
 
 func (b *BlockHeaderByHeight) IsZero() bool { return *b == BlockHeaderByHeight{} }
 
-func (b *BlockHeaderByHeight) ConvertToChainBaseBlockHeader() (*wdk.ChainBaseBlockHeader, error) {
+func (b *BlockHeaderByHeight) ConvertToChainBlockHeader() (*wdk.ChainBlockHeader, error) {
 	bits, err := strconv.ParseUint(b.Bits, 16, 32)
 	if err != nil {
 		return nil, fmt.Errorf("invalid bits value %q: expected hex string convertible to uint32: %w", b.Bits, err)
 	}
 
-	return &wdk.ChainBaseBlockHeader{
-		Version:      b.Version,
-		PreviousHash: b.PreviousBlockHash,
-		MerkleRoot:   b.MerkleRoot,
-		Time:         b.Time,
-		Bits:         uint32(bits),
-		Nonce:        b.Nonce,
-		Hash:         b.Hash,
+	return &wdk.ChainBlockHeader{
+		ChainBaseBlockHeader: wdk.ChainBaseBlockHeader{
+			Version:      b.Version,
+			PreviousHash: b.PreviousBlockHash,
+			MerkleRoot:   b.MerkleRoot,
+			Time:         b.Time,
+			Bits:         uint32(bits),
+			Nonce:        b.Nonce,
+		},
+		Hash: b.Hash,
 	}, nil
 }

--- a/pkg/services/internal/bitails/utils.go
+++ b/pkg/services/internal/bitails/utils.go
@@ -55,7 +55,6 @@ func ConvertHeader(raw []byte, height uint32) (*wdk.ChainBlockHeader, error) {
 			Time:         timestamp,
 			Bits:         bits,
 			Nonce:        nonce,
-			Hash:         blockHash,
 		},
 		Height: uint(height),
 		Hash:   blockHash,

--- a/pkg/services/internal/whatsonchain/get_chain_by_height.go
+++ b/pkg/services/internal/whatsonchain/get_chain_by_height.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 )
 
-func (woc *WhatsOnChain) ChainHeaderByHeight(ctx context.Context, height uint32) (*wdk.ChainBaseBlockHeader, error) {
+func (woc *WhatsOnChain) ChainHeaderByHeight(ctx context.Context, height uint32) (*wdk.ChainBlockHeader, error) {
 	var dst dto.BlockHeader
 	req := woc.httpClient.
 		R().
@@ -29,9 +29,9 @@ func (woc *WhatsOnChain) ChainHeaderByHeight(ctx context.Context, height uint32)
 		return nil, fmt.Errorf("expected a non-empty block header at height %d", height)
 	}
 
-	base, err := dst.ConvertToChainBaseBlockHeader()
+	blockHeader, err := dst.ConvertToChainBlockHeader()
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert block header response by height from WoC to a chain base block header: %w", err)
 	}
-	return base, nil
+	return blockHeader, nil
 }

--- a/pkg/services/internal/whatsonchain/internal/dto/block_headers_dto.go
+++ b/pkg/services/internal/whatsonchain/internal/dto/block_headers_dto.go
@@ -54,7 +54,6 @@ func (b *BlockHeader) ConvertToChainBaseBlockHeader() (*wdk.ChainBaseBlockHeader
 		Time:         b.Time,
 		Bits:         uint32(bits),
 		Nonce:        b.Nonce,
-		Hash:         b.Hash,
 	}, nil
 }
 

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -35,7 +35,7 @@ type WalletServices struct {
 	isValidRootForHeightServices servicequeue.Queue2[*chainhash.Hash, uint32, bool]
 	currentHeightServices        servicequeue.Queue[uint32]
 	getScriptHashHistoryServices servicequeue.Queue1[string, *wdk.ScriptHistoryResult]
-	chainHeaderByHeightServices  servicequeue.Queue1[uint32, *wdk.ChainBaseBlockHeader]
+	chainHeaderByHeightServices  servicequeue.Queue1[uint32, *wdk.ChainBlockHeader]
 	hashToHeaderServices         servicequeue.Queue1[string, *wdk.ChainBlockHeader]
 	getUtxoStatusServices        servicequeue.Queue2[string, *transaction.Outpoint, *wdk.UtxoStatusResult]
 	isUtxoServices               servicequeue.Queue2[string, *transaction.Outpoint, bool]
@@ -321,7 +321,7 @@ func (s *WalletServices) RawTx(ctx context.Context, txID string) (wdk.RawTxResul
 }
 
 // ChainHeaderByHeight returns serialized block header for given height on active chain.
-func (s *WalletServices) ChainHeaderByHeight(ctx context.Context, height uint32) (*wdk.ChainBaseBlockHeader, error) {
+func (s *WalletServices) ChainHeaderByHeight(ctx context.Context, height uint32) (*wdk.ChainBlockHeader, error) {
 	h, err := s.chainHeaderByHeightServices.OneByOne(ctx, height)
 	if err != nil {
 		return nil, fmt.Errorf("unable to determine block header: all block header height services failed to return a result: %w", err)

--- a/pkg/services/services_config_test.go
+++ b/pkg/services/services_config_test.go
@@ -446,9 +446,9 @@ func (m *mockImplementation) HashToHeader(context.Context, string) (*wdk.ChainBl
 	return &wdk.ChainBlockHeader{}, nil
 }
 
-func (m *mockImplementation) ChainHeaderByHeight(context.Context, uint32) (*wdk.ChainBaseBlockHeader, error) {
+func (m *mockImplementation) ChainHeaderByHeight(context.Context, uint32) (*wdk.ChainBlockHeader, error) {
 	m.chainHeaderByHeightCounter++
-	return &wdk.ChainBaseBlockHeader{}, nil
+	return &wdk.ChainBlockHeader{}, nil
 }
 
 func (m *mockImplementation) GetStatusForTxIDs(context.Context, []string) (*wdk.GetStatusForTxIDsResult, error) {

--- a/pkg/services/services_definition.go
+++ b/pkg/services/services_definition.go
@@ -33,7 +33,7 @@ type (
 	// HashToHeaderFunc is a function type for HashToHeader service method.
 	HashToHeaderFunc = func(ctx context.Context, hash string) (*wdk.ChainBlockHeader, error)
 	// ChainHeaderByHeightFunc is a function type for ChainHeaderByHeight service method.
-	ChainHeaderByHeightFunc = func(ctx context.Context, height uint32) (*wdk.ChainBaseBlockHeader, error)
+	ChainHeaderByHeightFunc = func(ctx context.Context, height uint32) (*wdk.ChainBlockHeader, error)
 	// GetStatusForTxIDsFunc is a function type for GetStatusForTxIDs service method.
 	GetStatusForTxIDsFunc = func(ctx context.Context, txIDs []string) (*wdk.GetStatusForTxIDsResult, error)
 	// GetUtxoStatusFunc is a function type for GetUtxoStatus service method.

--- a/pkg/services/services_get_chain_header_by_height_test.go
+++ b/pkg/services/services_get_chain_header_by_height_test.go
@@ -26,14 +26,16 @@ func TestGetChainHeaderByHeight_AtLeastOneChainServiceIsResponsive(t *testing.T)
 		bits, err := strconv.ParseUint(testservices.TestBlockBits, 16, 32)
 		require.NoError(t, err)
 
-		expectedHeader := &wdk.ChainBaseBlockHeader{
-			MerkleRoot:   testservices.TestBlockMerkleRoot,
-			Version:      testservices.TestBlockVersion,
-			PreviousHash: testservices.TestBlockPreviousBlockHash,
-			Time:         uint32(testservices.TestBlockTime),
-			Bits:         uint32(bits),
-			Nonce:        testservices.TestBlockNonce,
-			Hash:         testservices.TestBlockHash,
+		expectedHeader := &wdk.ChainBlockHeader{
+			ChainBaseBlockHeader: wdk.ChainBaseBlockHeader{
+				MerkleRoot:   testservices.TestBlockMerkleRoot,
+				Version:      testservices.TestBlockVersion,
+				PreviousHash: testservices.TestBlockPreviousBlockHash,
+				Time:         uint32(testservices.TestBlockTime),
+				Bits:         uint32(bits),
+				Nonce:        testservices.TestBlockNonce,
+			},
+			Hash: testservices.TestBlockHash,
 		}
 
 		// when:
@@ -57,14 +59,17 @@ func TestGetChainHeaderByHeight_AtLeastOneChainServiceIsResponsive(t *testing.T)
 		bits, err := strconv.ParseUint(testservices.TestBlockBits, 16, 32)
 		require.NoError(t, err)
 
-		expectedHeader := &wdk.ChainBaseBlockHeader{
-			MerkleRoot:   testservices.TestBlockMerkleRoot,
-			Version:      testservices.TestBlockVersion,
-			PreviousHash: testservices.TestBlockPreviousBlockHash,
-			Time:         uint32(testservices.TestBlockTime),
-			Bits:         uint32(bits),
-			Nonce:        testservices.TestBlockNonce,
-			Hash:         testservices.TestBlockHash,
+		expectedHeader := &wdk.ChainBlockHeader{
+			ChainBaseBlockHeader: wdk.ChainBaseBlockHeader{
+				MerkleRoot:   testservices.TestBlockMerkleRoot,
+				Version:      testservices.TestBlockVersion,
+				PreviousHash: testservices.TestBlockPreviousBlockHash,
+				Time:         uint32(testservices.TestBlockTime),
+				Bits:         uint32(bits),
+				Nonce:        testservices.TestBlockNonce,
+			},
+			Hash:   testservices.TestBlockHash,
+			Height: testservices.TestBlockHeight,
 		}
 
 		// when:
@@ -85,14 +90,16 @@ func TestGetChainHeaderByHeight_AtLeastOneChainServiceIsResponsive(t *testing.T)
 		given.Bitails().WillRespondWithInternalFailure()
 		first := given.BHS().IsUpAndRunning().DefaultHeaderByHeightResponse()
 
-		expectedHeader := &wdk.ChainBaseBlockHeader{
-			Version:      uint32(first.Version),
-			PreviousHash: first.PreviousBlock,
-			MerkleRoot:   first.MerkleRoot,
-			Time:         first.Timestamp,
-			Bits:         first.DifficultyTarget,
-			Nonce:        first.Nonce,
-			Hash:         first.Hash,
+		expectedHeader := &wdk.ChainBlockHeader{
+			ChainBaseBlockHeader: wdk.ChainBaseBlockHeader{
+				Version:      uint32(first.Version),
+				PreviousHash: first.PreviousBlock,
+				MerkleRoot:   first.MerkleRoot,
+				Time:         first.Timestamp,
+				Bits:         first.DifficultyTarget,
+				Nonce:        first.Nonce,
+			},
+			Hash: first.Hash,
 		}
 
 		// when:

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -575,7 +575,7 @@ func (w *Wallet) GetHeaderForHeight(ctx context.Context, args sdk.GetHeaderArgs,
 		return nil, fmt.Errorf("failed to get header for height %d: %w", args.Height, err)
 	}
 
-	result, err := mapping.MapGetHeaderResults(wdkResult)
+	result, err := mapping.MapGetHeaderResults(&wdkResult.ChainBaseBlockHeader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to map get header results: %w", err)
 	}

--- a/pkg/wdk/services.interface.go
+++ b/pkg/wdk/services.interface.go
@@ -27,5 +27,5 @@ type HeightProvider interface {
 
 // BlockHeaderLoader is an interface that provides the block chain block header with given height.
 type BlockHeaderLoader interface {
-	ChainHeaderByHeight(ctx context.Context, height uint32) (*ChainBaseBlockHeader, error)
+	ChainHeaderByHeight(ctx context.Context, height uint32) (*ChainBlockHeader, error)
 }

--- a/pkg/wdk/services_chain_block_headers.go
+++ b/pkg/wdk/services_chain_block_headers.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 )
 
+// BlockHeaderLength defines the fixed byte size of a block header, commonly used in blockchain data structures.
+const BlockHeaderLength = 80
+
 // ChainBaseBlockHeader represents the raw fields of a Bitcoin block header,
 // corresponding to the 80-byte serialized format used in the Bitcoin protocol.
 // The double SHA-256 hash of this serialized data is the block's identifier (hash)
@@ -97,7 +100,7 @@ func (c *ChainBaseBlockHeader) Bytes() ([]byte, error) {
 		return nil, fmt.Errorf("'merkle root' field should be a 32 byte-hex length")
 	}
 
-	buff := bytes.NewBuffer(make([]byte, 0, 80))
+	buff := bytes.NewBuffer(make([]byte, 0, BlockHeaderLength))
 	if err := writeLittleEndianOrder(buff, c.Version); err != nil {
 		return nil, fmt.Errorf("failed to write the 'version' field bytes in little-endian order: %w", err)
 	}
@@ -156,9 +159,11 @@ func readLittleEndianOrder[T any](buff *bytes.Buffer) (T, error) {
 	return v, nil
 }
 
+// ChainBaseBlockHeaderFromBytes parses an 80-byte slice as a Bitcoin block header and returns a ChainBaseBlockHeader.
+// Returns an error if the byte slice is not exactly 80 bytes or if decoding individual fields fails.
 func ChainBaseBlockHeaderFromBytes(data []byte) (*ChainBaseBlockHeader, error) {
-	if len(data) != 80 {
-		return nil, fmt.Errorf("data length %d is not equal to block header length 80", len(data))
+	if len(data) != BlockHeaderLength {
+		return nil, fmt.Errorf("data length %d is not equal to block header length %d", len(data), BlockHeaderLength)
 	}
 
 	buff := bytes.NewBuffer(data)

--- a/pkg/wdk/services_chain_block_headers.go
+++ b/pkg/wdk/services_chain_block_headers.go
@@ -39,10 +39,6 @@ type ChainBaseBlockHeader struct {
 	// Nonce is the 32-bit nonce used in the mining process to vary the block hash.
 	// Serialized as 4 bytes.
 	Nonce uint32
-
-	// Hash is the double SHA-256 hash of the serialized block header.
-	// Represented as a 32-byte hex string with reversed byte order.
-	Hash string
 }
 
 // ChainBlockHeader extends ChainBaseBlockHeader with metadata about the block's
@@ -138,4 +134,73 @@ func writeLittleEndianOrder(buff *bytes.Buffer, v any) error {
 		return fmt.Errorf("failed to write the binary representation of data '%v' to buffer: %w", v, err)
 	}
 	return nil
+}
+
+func readReversedBytes(buff *bytes.Buffer, length int) ([]byte, error) {
+	data := make([]byte, length)
+	for i := length - 1; i >= 0; i-- {
+		b, err := buff.ReadByte()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read byte %d of data: %w", i, err)
+		}
+		data[i] = b
+	}
+	return data, nil
+}
+
+func readLittleEndianOrder[T any](buff *bytes.Buffer) (T, error) {
+	var v T
+	if err := binary.Read(buff, binary.LittleEndian, &v); err != nil {
+		return v, fmt.Errorf("failed to read the binary representation of data into type '%T': %w", v, err)
+	}
+	return v, nil
+}
+
+func ChainBaseBlockHeaderFromBytes(data []byte) (*ChainBaseBlockHeader, error) {
+	if len(data) != 80 {
+		return nil, fmt.Errorf("data length %d is not equal to block header length 80", len(data))
+	}
+
+	buff := bytes.NewBuffer(data)
+
+	version, err := readLittleEndianOrder[uint32](buff)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read 'version' field from data: %w", err)
+	}
+
+	prevHashBytes, err := readReversedBytes(buff, 32)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read 'previous hash' field from data: %w", err)
+	}
+	prevHash := hex.EncodeToString(prevHashBytes)
+
+	merkleRootBytes, err := readReversedBytes(buff, 32)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read 'merkle root' field from data: %w", err)
+	}
+	merkleRoot := hex.EncodeToString(merkleRootBytes)
+
+	time, err := readLittleEndianOrder[uint32](buff)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read 'time' field from data: %w", err)
+	}
+
+	bits, err := readLittleEndianOrder[uint32](buff)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read 'bits' field from data: %w", err)
+	}
+
+	nonce, err := readLittleEndianOrder[uint32](buff)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read 'nonce' field from data: %w", err)
+	}
+
+	return &ChainBaseBlockHeader{
+		Version:      version,
+		PreviousHash: prevHash,
+		MerkleRoot:   merkleRoot,
+		Time:         time,
+		Bits:         bits,
+		Nonce:        nonce,
+	}, nil
 }

--- a/pkg/wdk/services_chain_block_headers_test.go
+++ b/pkg/wdk/services_chain_block_headers_test.go
@@ -155,6 +155,46 @@ func TestChainBaseBlockHeader_Bytes_NegativePaths(t *testing.T) {
 	}
 }
 
+func TestChainBaseBlockHeader_ToAndFromBytes(t *testing.T) {
+	tests := map[string]struct {
+		block *wdk.ChainBaseBlockHeader
+	}{
+		"valid block header - height 3000, with version 1, time 1233748223, bits 486604799, nonce 2650070842 and known hashes": {
+			block: &wdk.ChainBaseBlockHeader{
+				Version:      1,
+				PreviousHash: "00000000690d22ab76cbb5eca33cb018e36aebe4648e6ed79791aefe0f936e07",
+				MerkleRoot:   "00000000a1496d802a4a4074590ec34074b76a8ea6b81c1c9ad4192d3c2ea226",
+				Time:         1233748223,
+				Bits:         486604799,
+				Nonce:        2650070842,
+			},
+		},
+		"valid block header - height 5000, with version 1, time 1235123456, bits 486604799, nonce 1234567890 and known hashes": {
+			block: &wdk.ChainBaseBlockHeader{
+				Version:      1,
+				PreviousHash: "00000000690d22ab76cbb5eca33cb018e36aebe4648e6ed79791aefe0f936e07",
+				MerkleRoot:   "00000000a1496d802a4a4074590ec34074b76a8ea6b81c1c9ad4192d3c2ea226",
+				Time:         1235123456,
+				Bits:         486604799,
+				Nonce:        1234567890,
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// when:
+			bytes, err := tc.block.Bytes()
+			assert.NoError(t, err)
+
+			actualBlock, err := wdk.ChainBaseBlockHeaderFromBytes(bytes)
+
+			// then:
+			assert.NoError(t, err)
+			assert.Equal(t, tc.block, actualBlock)
+		})
+	}
+}
+
 func assertBlockHash(t *testing.T, expectedHash string, fingerprint []byte) {
 	actualHash := chainhash.DoubleHashH(fingerprint)
 	assert.Equal(t, expectedHash, actualHash.String(), "Double hash does not match expected value")


### PR DESCRIPTION
New endpoints supported:
- getPresentHeight
- findChainTipHashHex
- findChainTipHeaderHex
- findHeaderHexForHeight
- findHeaderHexForBlockHash
- getHeaders (returns concatenated hex-encoded headers)

Additionally I needed to create a converter from hex-encoded header data into BaseHeader struct.
I found out that in wdk.ChainBaseHeader there was the `Hash` field that shouldn't be there - the binary form of it doesn't contain such field. 