### PR TITLE
UserID is not the relevant value here, it’s the public key (identityKey)

### DIFF
--- a/pkg/storage/provider.go
+++ b/pkg/storage/provider.go
@@ -171,7 +171,7 @@ func (p *Provider) SetActive(ctx context.Context, auth wdk.AuthID, newActiveStor
 
 // InsertCertificateAuth inserts certificate to the database for authenticated user
 func (p *Provider) InsertCertificateAuth(ctx context.Context, auth wdk.AuthID, certificate *wdk.TableCertificateX) (uint, error) {
-	if auth.UserID == nil || certificate.UserID != *auth.UserID {
+	if auth.UserID == nil || string(certificate.Subject) != auth.IdentityKey {
 		return 0, ErrAuthorization
 	}
 


### PR DESCRIPTION
Check identityKey when checking certs

## Description of Changes

During Certificate Acquisition we don't need to validate UserID, which is just an internal auto-incrementing ID number; rather we ought to be checking the identityKey which is a universally applicable pubKey.

## Linked Issues / Tickets

Unsure, but this fixes:

Running [this example code](https://fast.brc.dev/?snippet=createCertificate) against a go-wallet-toolbox instance locally.

## Testing Procedure

I ran the example code, once with no changes which failed:
```RPC Error: access is denied due to an authorization error```

running after making these changes results in successful issuance.


- [ ] I have added new unit tests
- [ ] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run the linter
