### PR TITLE
feat: add channel to background broadcaster

### DIFF
--- a/pkg/defs/monitor.go
+++ b/pkg/defs/monitor.go
@@ -54,6 +54,7 @@ const (
 	TxUpdateStatusInvalidTx    TxUpdateStatus = "invalidTx"
 	TxUpdateStatusServiceError TxUpdateStatus = "serviceError"
 	TxUpdateStatusSuccess      TxUpdateStatus = "success"
+	TxUpdateStatusUnproven     TxUpdateStatus = "unproven"
 	TxUpdateStatusUnknown      TxUpdateStatus = "unknown"
 )
 
@@ -69,6 +70,7 @@ var allTxUpdateStatuses = []TxUpdateStatus{
 	TxUpdateStatusInvalidTx,
 	TxUpdateStatusCompleted,
 	TxUpdateStatusDoubleSpend,
+	TxUpdateStatusUnproven,
 	TxUpdateStatusUnknown,
 }
 

--- a/pkg/storage/internal/actions/actions.go
+++ b/pkg/storage/internal/actions/actions.go
@@ -31,6 +31,7 @@ func New(
 	services wdk.Services,
 	syncTxStatusesConfig defs.SynchronizeTxStatuses,
 	beefVerifier wdk.BeefVerifier,
+	txBroadcastedChannel chan<- defs.TransactionStatusUpdate,
 ) *Actions {
 	return &Actions{
 		create: newCreateAction(
@@ -68,6 +69,7 @@ func New(
 			services,
 			randomizer,
 			beefVerifier,
+			txBroadcastedChannel,
 		),
 		listOutputs:           newListOutputs(logger, repos.Outputs, repos.KnownTx, repos.Transactions),
 		synchronizeTxStatuses: newSynchronizeTxStatuses(logger, syncTxStatusesConfig, services, repos.KnownTx, repos.KeyValue, repos.Transactions),

--- a/pkg/storage/internal/actions/process.go
+++ b/pkg/storage/internal/actions/process.go
@@ -57,6 +57,7 @@ func newProcessAction(
 	services wdk.Services,
 	randomizer wdk.Randomizer,
 	beefVerifier wdk.BeefVerifier,
+	txBroadcastedChannel chan<- defs.TransactionStatusUpdate,
 ) *process {
 	logger = logging.Child(logger, "processAction")
 	p := &process{
@@ -72,7 +73,7 @@ func newProcessAction(
 		beefVerifier:   beefVerifier,
 	}
 
-	p.backgroundBroadcaster = service.NewBackgroundBroadcaster(ctx, logger, p)
+	p.backgroundBroadcaster = service.NewBackgroundBroadcaster(ctx, logger, p, txBroadcastedChannel)
 	p.backgroundBroadcaster.Start()
 	return p
 }
@@ -762,17 +763,18 @@ func (p *process) StopBackgroundBroadcaster() {
 	}
 }
 
-func (p *process) BackgroundBroadcast(ctx context.Context, beef *transaction.Beef, txIDs []string) error {
+func (p *process) BackgroundBroadcast(ctx context.Context, beef *transaction.Beef, txIDs []string) ([]wdk.SendWithResult, error) {
 	results, err := p.services.PostBEEF(ctx, beef, txIDs)
 	if err != nil {
-		return fmt.Errorf("failed to post BEEF in background: %w", err)
+		return nil, fmt.Errorf("failed to post BEEF in background: %w", err)
 	}
 
 	aggregated := results.Aggregated(txIDs)
+	bResults := make([]wdk.SendWithResult, 0, len(txIDs))
 	for _, broadcastedTxID := range txIDs {
 		aggBroadcastResult, ok := aggregated[broadcastedTxID]
 		if !ok {
-			return fmt.Errorf("no broadcast result found for txID %s", broadcastedTxID)
+			return nil, fmt.Errorf("no broadcast result found for txID %s", broadcastedTxID)
 		}
 
 		sendWithResult, _, err := p.updateSingleTx(
@@ -784,11 +786,12 @@ func (p *process) BackgroundBroadcast(ctx context.Context, beef *transaction.Bee
 			txIDs,
 		)
 		if err != nil {
-			return fmt.Errorf("failed to update single tx after background broadcast (txID: %s): %w", broadcastedTxID, err)
+			return nil, fmt.Errorf("failed to update single tx after background broadcast (txID: %s): %w", broadcastedTxID, err)
 		}
 
 		p.logger.DebugContext(ctx, "Background broadcast result", "txID", broadcastedTxID, "status", sendWithResult.Status)
+		bResults = append(bResults, sendWithResult)
 	}
 
-	return nil
+	return bResults, nil
 }

--- a/pkg/storage/internal/service/background_broadcaster.go
+++ b/pkg/storage/internal/service/background_broadcaster.go
@@ -7,7 +7,9 @@ import (
 	"sync"
 
 	"github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/logging"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 )
 
 const (
@@ -21,7 +23,7 @@ const (
 )
 
 type broadcaster interface {
-	BackgroundBroadcast(ctx context.Context, beef *transaction.Beef, txIDs []string) error
+	BackgroundBroadcast(ctx context.Context, beef *transaction.Beef, txIDs []string) ([]wdk.SendWithResult, error)
 }
 
 type BackgroundBroadcaster struct {
@@ -31,6 +33,9 @@ type BackgroundBroadcaster struct {
 	wg               sync.WaitGroup
 	logger           *slog.Logger
 	broadcastHandler broadcaster
+
+	// optional notification channel
+	txBroadcastedChannel chan<- defs.TransactionStatusUpdate
 }
 
 type broadcastItem struct {
@@ -38,15 +43,16 @@ type broadcastItem struct {
 	txIDs []string
 }
 
-func NewBackgroundBroadcaster(ctx context.Context, parentLogger *slog.Logger, broadcastHandler broadcaster) *BackgroundBroadcaster {
+func NewBackgroundBroadcaster(ctx context.Context, parentLogger *slog.Logger, broadcastHandler broadcaster, txBroadcastedChannel chan<- defs.TransactionStatusUpdate) *BackgroundBroadcaster {
 	bbContext, cancel := context.WithCancel(ctx)
 	logger := logging.Child(parentLogger, "BackgroundBroadcaster")
 	return &BackgroundBroadcaster{
-		ctx:              bbContext,
-		cancel:           cancel,
-		broadcastChannel: make(chan broadcastItem, BackgroundBroadcasterChannelSize),
-		logger:           logger,
-		broadcastHandler: broadcastHandler,
+		ctx:                  bbContext,
+		cancel:               cancel,
+		broadcastChannel:     make(chan broadcastItem, BackgroundBroadcasterChannelSize),
+		logger:               logger,
+		broadcastHandler:     broadcastHandler,
+		txBroadcastedChannel: txBroadcastedChannel,
 	}
 }
 
@@ -100,9 +106,28 @@ func (bb *BackgroundBroadcaster) broadcast(item *broadcastItem) (err error) {
 		}
 	}()
 
-	err = bb.broadcastHandler.BackgroundBroadcast(bb.ctx, item.beef, item.txIDs)
+	results, err := bb.broadcastHandler.BackgroundBroadcast(bb.ctx, item.beef, item.txIDs)
 	if err != nil {
 		return fmt.Errorf("failed to broadcast beef: %w", err)
+	}
+
+	if bb.txBroadcastedChannel == nil || results == nil {
+		return nil
+	}
+
+	for _, res := range results {
+		msg := defs.TransactionStatusUpdate{
+			TxID:   res.TxID.String(),
+			Status: defs.ParseTxUpdateStatusOrUnknown(string(res.Status)),
+		}
+
+		select {
+		case bb.txBroadcastedChannel <- msg:
+		case <-bb.ctx.Done():
+			return fmt.Errorf("context done while sending tx status update: %w", bb.ctx.Err())
+		default:
+			bb.logger.Warn("TxBroadcasted channel in background broadcaster is full, dropping event")
+		}
 	}
 
 	return nil

--- a/pkg/storage/internal/service/background_broadcaster_test.go
+++ b/pkg/storage/internal/service/background_broadcaster_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/logging"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/storage/internal/service"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 	testvectors "github.com/bsv-blockchain/universal-test-vectors/pkg/testabilities"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,10 +26,10 @@ type mockBroadcaster struct {
 	panicDuringCall error
 }
 
-func (m *mockBroadcaster) BackgroundBroadcast(ctx context.Context, _ *transaction.Beef, _ []string) error {
+func (m *mockBroadcaster) BackgroundBroadcast(ctx context.Context, _ *transaction.Beef, _ []string) ([]wdk.SendWithResult, error) {
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return nil, ctx.Err()
 	case <-time.After(m.sleep):
 		// Simulate a delay for the broadcast operation
 	}
@@ -36,11 +37,11 @@ func (m *mockBroadcaster) BackgroundBroadcast(ctx context.Context, _ *transactio
 
 	switch {
 	case m.returnErr != nil:
-		return m.returnErr
+		return nil, m.returnErr
 	case m.panicDuringCall != nil:
 		panic(m.panicDuringCall)
 	default:
-		return nil
+		return nil, nil
 	}
 }
 
@@ -104,7 +105,7 @@ func TestBackgroundBroadcaster_HappyPath(t *testing.T) {
 			mockBroadcast := &mockBroadcaster{}
 
 			logger, _ := loggerForTestBroadcaster()
-			bb := service.NewBackgroundBroadcaster(t.Context(), logger, mockBroadcast)
+			bb := service.NewBackgroundBroadcaster(t.Context(), logger, mockBroadcast, nil)
 			bb.Start()
 
 			for txSpec := range broadcastItemsGenerator(tt.length) {
@@ -127,7 +128,7 @@ func TestBackgroundBroadcaster_WhenProducerIsSlowerThanConsumer(t *testing.T) {
 	mockBroadcast := &mockBroadcaster{}
 
 	logger, _ := loggerForTestBroadcaster()
-	bb := service.NewBackgroundBroadcaster(t.Context(), logger, mockBroadcast)
+	bb := service.NewBackgroundBroadcaster(t.Context(), logger, mockBroadcast, nil)
 	bb.Start()
 
 	moreThanChannerSize := 2*service.BackgroundBroadcasterChannelSize + 1
@@ -154,7 +155,7 @@ func TestBackgroundBroadcaster_WhenProducerIsFasterThanConsumer(t *testing.T) {
 	}
 
 	logger, _ := loggerForTestBroadcaster()
-	bb := service.NewBackgroundBroadcaster(t.Context(), logger, mockBroadcast)
+	bb := service.NewBackgroundBroadcaster(t.Context(), logger, mockBroadcast, nil)
 	bb.Start()
 
 	moreThanChannerSize := 2*service.BackgroundBroadcasterChannelSize + 1
@@ -183,7 +184,7 @@ func TestBackgroundBroadcast_StopDuringProcessing(t *testing.T) {
 	}
 
 	logger, _ := loggerForTestBroadcaster()
-	bb := service.NewBackgroundBroadcaster(t.Context(), logger, mockBroadcast)
+	bb := service.NewBackgroundBroadcaster(t.Context(), logger, mockBroadcast, nil)
 	bb.Start()
 
 	const count = 10
@@ -206,7 +207,7 @@ func TestBackgroundBroadcast_BroadcasterReturnsError(t *testing.T) {
 	}
 
 	logger, logsBuffer := loggerForTestBroadcaster()
-	bb := service.NewBackgroundBroadcaster(t.Context(), logger, mockBroadcast)
+	bb := service.NewBackgroundBroadcaster(t.Context(), logger, mockBroadcast, nil)
 	bb.Start()
 
 	const count = 10
@@ -231,7 +232,7 @@ func TestBackgroundBroadcast_BroadcasterPanics(t *testing.T) {
 	}
 
 	logger, logsBuffer := loggerForTestBroadcaster()
-	bb := service.NewBackgroundBroadcaster(t.Context(), logger, mockBroadcast)
+	bb := service.NewBackgroundBroadcaster(t.Context(), logger, mockBroadcast, nil)
 	bb.Start()
 
 	const count = 10

--- a/pkg/storage/provider.go
+++ b/pkg/storage/provider.go
@@ -89,6 +89,7 @@ func NewGORMProvider(chain defs.BSVNetwork, services wdk.Services, opts ...Provi
 			services,
 			options.SynchronizeTxStatusesConfig,
 			options.beefVerifier(),
+			options.BackgroundBroadcasterChannel,
 		),
 		options:  &options,
 		logger:   log,

--- a/pkg/storage/provider_options.go
+++ b/pkg/storage/provider_options.go
@@ -33,6 +33,7 @@ type ProviderConfig struct {
 	Commission defs.Commission
 
 	BackgroundBroadcasterContext context.Context
+	BackgroundBroadcasterChannel chan<- defs.TransactionStatusUpdate
 }
 
 // WithConfig returns a ProviderOption that sets the ProviderConfig to the supplied cfg value.
@@ -117,6 +118,15 @@ func WithCommission(commission defs.Commission) ProviderOption {
 func WithBackgroundBroadcasterContext(ctx context.Context) ProviderOption {
 	return func(o *ProviderConfig) {
 		o.BackgroundBroadcasterContext = ctx
+	}
+}
+
+// WithBackgroundBroadcasterChannel sets the notification channel for the background broadcaster in provider options.
+// This channel is used to send transaction status updates when transactions are broadcasted in the background.
+// This same channel which is passed to the monitor to receive broadcasted transaction updates should be used.
+func WithBackgroundBroadcasterChannel(txBroadcastedChannel chan<- defs.TransactionStatusUpdate) ProviderOption {
+	return func(o *ProviderConfig) {
+		o.BackgroundBroadcasterChannel = txBroadcastedChannel
 	}
 }
 


### PR DESCRIPTION
## Description of Changes

Added channel to background notification. It is used to pass information when the tx is broadcasted 

## Linked Issues / Tickets

Reference any related issues or tickets, e.g. "Closes #123".

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run the linter
