### PR TITLE
feat: add deviceId to SyncState for multi-device isolation

### DIFF
--- a/pkg/internal/mocks/mock_wallet_storage_writer.go
+++ b/pkg/internal/mocks/mock_wallet_storage_writer.go
@@ -72,18 +72,18 @@ func (mr *MockWalletStorageProviderMockRecorder) CreateAction(ctx, auth, args an
 }
 
 // FindOrInsertSyncStateAuth mocks base method.
-func (m *MockWalletStorageProvider) FindOrInsertSyncStateAuth(ctx context.Context, auth wdk.AuthID, storageIdentityKey, storageName string) (*wdk.FindOrInsertSyncStateAuthResponse, error) {
+func (m *MockWalletStorageProvider) FindOrInsertSyncStateAuth(ctx context.Context, auth wdk.AuthID, storageIdentityKey, storageName, deviceID string) (*wdk.FindOrInsertSyncStateAuthResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindOrInsertSyncStateAuth", ctx, auth, storageIdentityKey, storageName)
+	ret := m.ctrl.Call(m, "FindOrInsertSyncStateAuth", ctx, auth, storageIdentityKey, storageName, deviceID)
 	ret0, _ := ret[0].(*wdk.FindOrInsertSyncStateAuthResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindOrInsertSyncStateAuth indicates an expected call of FindOrInsertSyncStateAuth.
-func (mr *MockWalletStorageProviderMockRecorder) FindOrInsertSyncStateAuth(ctx, auth, storageIdentityKey, storageName any) *gomock.Call {
+func (mr *MockWalletStorageProviderMockRecorder) FindOrInsertSyncStateAuth(ctx, auth, storageIdentityKey, storageName, deviceID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOrInsertSyncStateAuth", reflect.TypeOf((*MockWalletStorageProvider)(nil).FindOrInsertSyncStateAuth), ctx, auth, storageIdentityKey, storageName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOrInsertSyncStateAuth", reflect.TypeOf((*MockWalletStorageProvider)(nil).FindOrInsertSyncStateAuth), ctx, auth, storageIdentityKey, storageName, deviceID)
 }
 
 // FindOrInsertUser mocks base method.

--- a/pkg/internal/storage/database/models/sync_state.go
+++ b/pkg/internal/storage/database/models/sync_state.go
@@ -11,8 +11,9 @@ import (
 type SyncState struct {
 	gorm.Model
 
-	UserID             int    `gorm:"uniqueIndex:idx_user_storage_key"`
-	StorageIdentityKey string `gorm:"type:varchar(130);not null;uniqueIndex:idx_user_storage_key"`
+	UserID             int    `gorm:"uniqueIndex:idx_user_storage_device"`
+	StorageIdentityKey string `gorm:"type:varchar(130);not null;uniqueIndex:idx_user_storage_device"`
+	DeviceID           string `gorm:"type:varchar(64);not null;default:'';uniqueIndex:idx_user_storage_device"`
 	StorageName        string `gorm:"type:varchar(128);not null"`
 	Status             wdk.SyncStatus
 	RefNum             string `gorm:"not null;uniqueIndex"`

--- a/pkg/internal/storage/entity/sync_state.go
+++ b/pkg/internal/storage/entity/sync_state.go
@@ -16,6 +16,7 @@ type SyncState struct {
 	UpdatedAt          time.Time
 	UserID             int
 	StorageIdentityKey string
+	DeviceID           string
 	StorageName        string
 	Status             wdk.SyncStatus
 	Reference          string
@@ -36,6 +37,7 @@ func (ss *SyncState) ToWDK() (*wdk.TableSyncState, error) {
 		SyncStateID:        ss.ID,
 		UserID:             ss.UserID,
 		StorageIdentityKey: ss.StorageIdentityKey,
+		DeviceID:           ss.DeviceID,
 		StorageName:        ss.StorageName,
 		Status:             ss.Status,
 		Init:               false, // Init as true appears to be used only for testing purposes in TS version

--- a/pkg/internal/storage/repo/sync_state.go
+++ b/pkg/internal/storage/repo/sync_state.go
@@ -26,9 +26,9 @@ func NewSyncState(db *gorm.DB) *SyncState {
 	}
 }
 
-func (s *SyncState) FindSyncState(ctx context.Context, userID int, storageIdentityKey string) (*entity.SyncState, error) {
+func (s *SyncState) FindSyncState(ctx context.Context, userID int, storageIdentityKey string, deviceID string) (*entity.SyncState, error) {
 	var err error
-	ctx, span := tracing.StartTracing(ctx, "Repository-SyncState-FindSyncState", attribute.Int("UserID", userID), attribute.String("StorageIdentityKey", storageIdentityKey))
+	ctx, span := tracing.StartTracing(ctx, "Repository-SyncState-FindSyncState", attribute.Int("UserID", userID), attribute.String("StorageIdentityKey", storageIdentityKey), attribute.String("DeviceID", deviceID))
 	defer func() {
 		tracing.EndTracing(span, err)
 	}()
@@ -36,7 +36,7 @@ func (s *SyncState) FindSyncState(ctx context.Context, userID int, storageIdenti
 	var model models.SyncState
 	err = s.db.WithContext(ctx).
 		Scopes(scopes.UserID(userID)).
-		Where("storage_identity_key = ?", storageIdentityKey).
+		Where("storage_identity_key = ? AND device_id = ?", storageIdentityKey, deviceID).
 		First(&model).Error
 
 	if err != nil {
@@ -64,6 +64,7 @@ func (s *SyncState) CreateSyncState(ctx context.Context, syncState *entity.SyncS
 	model := models.SyncState{
 		UserID:             syncState.UserID,
 		StorageIdentityKey: syncState.StorageIdentityKey,
+		DeviceID:           syncState.DeviceID,
 		StorageName:        syncState.StorageName,
 		Status:             syncState.Status,
 		RefNum:             syncState.Reference,
@@ -128,6 +129,7 @@ func mapModelToSyncStateEntity(model models.SyncState) (*entity.SyncState, error
 		UpdatedAt:          model.UpdatedAt,
 		UserID:             model.UserID,
 		StorageIdentityKey: model.StorageIdentityKey,
+		DeviceID:           model.DeviceID,
 		StorageName:        model.StorageName,
 		Status:             model.Status,
 		Reference:          model.RefNum,

--- a/pkg/storage/client_gen.go
+++ b/pkg/storage/client_gen.go
@@ -85,8 +85,8 @@ func (c *WalletStorageProviderClient) GetSyncChunk(ctx context.Context, args wdk
 
 // FindOrInsertSyncStateAuth retrieves an existing sync state or inserts a new one based on the provided authentication and storage details.
 // Skipped in WalletStorage interface and not exposed in StorageManager.
-func (c *WalletStorageProviderClient) FindOrInsertSyncStateAuth(ctx context.Context, auth wdk.AuthID, storageIdentityKey string, storageName string) (*wdk.FindOrInsertSyncStateAuthResponse, error) {
-	return c.client.FindOrInsertSyncStateAuth(ctx, auth, storageIdentityKey, storageName)
+func (c *WalletStorageProviderClient) FindOrInsertSyncStateAuth(ctx context.Context, auth wdk.AuthID, storageIdentityKey string, storageName string, deviceID string) (*wdk.FindOrInsertSyncStateAuthResponse, error) {
+	return c.client.FindOrInsertSyncStateAuth(ctx, auth, storageIdentityKey, storageName, deviceID)
 }
 
 // ProcessSyncChunk processes a sync chunk for a user, applying the changes contained within it.
@@ -125,7 +125,7 @@ type rpcWalletStorageProvider struct {
 	ListOutputs               func(context.Context, wdk.AuthID, wdk.ListOutputsArgs) (*wdk.ListOutputsResult, error)
 	ListActions               func(context.Context, wdk.AuthID, wdk.ListActionsArgs) (*wdk.ListActionsResult, error)
 	GetSyncChunk              func(context.Context, wdk.RequestSyncChunkArgs) (*wdk.SyncChunk, error)
-	FindOrInsertSyncStateAuth func(context.Context, wdk.AuthID, string, string) (*wdk.FindOrInsertSyncStateAuthResponse, error)
+	FindOrInsertSyncStateAuth func(context.Context, wdk.AuthID, string, string, string) (*wdk.FindOrInsertSyncStateAuthResponse, error)
 	ProcessSyncChunk          func(context.Context, wdk.RequestSyncChunkArgs, *wdk.SyncChunk) (*wdk.ProcessSyncChunkResult, error)
 	AbortAction               func(context.Context, wdk.AuthID, wdk.AbortActionArgs) (*wdk.AbortActionResult, error)
 	FindOutputBasketsAuth     func(context.Context, wdk.AuthID, wdk.FindOutputBasketsArgs) (wdk.TableOutputBaskets, error)

--- a/pkg/storage/internal/server/rpc_storage_provider.gen.go
+++ b/pkg/storage/internal/server/rpc_storage_provider.gen.go
@@ -177,7 +177,7 @@ func (p *RPCStorageProvider) GetSyncChunk(ctx context.Context, args wdk.RequestS
 
 // FindOrInsertSyncStateAuth retrieves an existing sync state or inserts a new one based on the provided authentication and storage details.
 // Skipped in WalletStorage interface and not exposed in StorageManager.
-func (p *RPCStorageProvider) FindOrInsertSyncStateAuth(ctx context.Context, auth wdk.AuthID, storageIdentityKey string, storageName string) (*wdk.FindOrInsertSyncStateAuthResponse, error) {
+func (p *RPCStorageProvider) FindOrInsertSyncStateAuth(ctx context.Context, auth wdk.AuthID, storageIdentityKey string, storageName string, deviceID string) (*wdk.FindOrInsertSyncStateAuthResponse, error) {
 	err := p.verifyAuthID(ctx, auth)
 	if err != nil {
 		return nil, err
@@ -187,7 +187,7 @@ func (p *RPCStorageProvider) FindOrInsertSyncStateAuth(ctx context.Context, auth
 		return nil, err
 	}
 
-	return p.localProvider.FindOrInsertSyncStateAuth(ctx, auth, storageIdentityKey, storageName)
+	return p.localProvider.FindOrInsertSyncStateAuth(ctx, auth, storageIdentityKey, storageName, deviceID)
 }
 
 // ProcessSyncChunk processes a sync chunk for a user, applying the changes contained within it.

--- a/pkg/storage/internal/sync/chunk_processor.go
+++ b/pkg/storage/internal/sync/chunk_processor.go
@@ -55,13 +55,13 @@ func NewChunkProcessor(ctx context.Context, logger *slog.Logger, repo Repository
 
 func (p *ChunkProcessor) Process() (*wdk.ProcessSyncChunkResult, error) {
 	p.logger.InfoContext(p.ctx, "processing sync chunk")
-	syncState, err := p.repo.FindSyncState(p.ctx, p.user.ID, p.args.FromStorageIdentityKey)
+	syncState, err := p.repo.FindSyncState(p.ctx, p.user.ID, p.args.FromStorageIdentityKey, p.args.DeviceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find sync state: %w", err)
 	}
 
 	if syncState == nil {
-		return nil, fmt.Errorf("sync state not found for userID %d and storage %s", p.user.ID, p.args.FromStorageIdentityKey)
+		return nil, fmt.Errorf("sync state not found for userID %d, storage %s, device %s", p.user.ID, p.args.FromStorageIdentityKey, p.args.DeviceID)
 	}
 
 	p.syncState = syncState

--- a/pkg/storage/internal/sync/find_or_insert_sync_state.go
+++ b/pkg/storage/internal/sync/find_or_insert_sync_state.go
@@ -18,20 +18,22 @@ type FindOrInsertSyncState struct {
 	userID             int
 	storageIdentityKey string
 	storageName        string
+	deviceID           string
 }
 
-func NewFindOrInsertSyncState(repo Repository, random wdk.Randomizer, userID int, storageIdentityKey, storageName string) *FindOrInsertSyncState {
+func NewFindOrInsertSyncState(repo Repository, random wdk.Randomizer, userID int, storageIdentityKey, storageName, deviceID string) *FindOrInsertSyncState {
 	return &FindOrInsertSyncState{
 		repo:               repo,
 		random:             random,
 		userID:             userID,
 		storageIdentityKey: storageIdentityKey,
 		storageName:        storageName,
+		deviceID:           deviceID,
 	}
 }
 
 func (f *FindOrInsertSyncState) FindOrInsertSyncState(ctx context.Context) (*wdk.FindOrInsertSyncStateAuthResponse, error) {
-	syncState, err := f.repo.FindSyncState(ctx, f.userID, f.storageIdentityKey)
+	syncState, err := f.repo.FindSyncState(ctx, f.userID, f.storageIdentityKey, f.deviceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find sync state: %w", err)
 	}
@@ -69,6 +71,7 @@ func (f *FindOrInsertSyncState) createNewState(ctx context.Context) (*entity.Syn
 	syncState, err := f.repo.CreateSyncState(ctx, &entity.SyncState{
 		UserID:             f.userID,
 		StorageIdentityKey: f.storageIdentityKey,
+		DeviceID:           f.deviceID,
 		StorageName:        f.storageName,
 		Status:             wdk.SyncStatusUnknown,
 		Reference:          reference,

--- a/pkg/storage/internal/sync/repos.interface.go
+++ b/pkg/storage/internal/sync/repos.interface.go
@@ -14,7 +14,7 @@ type Repository interface {
 	FindUser(ctx context.Context, identityKey string) (*pkgentity.User, error)
 	UpdateUserForSync(ctx context.Context, userID int, activeStorage string, updatedAt time.Time) error
 
-	FindSyncState(ctx context.Context, userID int, storageIdentityKey string) (*entity.SyncState, error)
+	FindSyncState(ctx context.Context, userID int, storageIdentityKey string, deviceID string) (*entity.SyncState, error)
 	CreateSyncState(ctx context.Context, syncState *entity.SyncState) (*entity.SyncState, error)
 	UpdateSyncState(ctx context.Context, syncState *entity.SyncState) error
 

--- a/pkg/storage/internal/sync/sync_to_writer.go
+++ b/pkg/storage/internal/sync/sync_to_writer.go
@@ -65,8 +65,12 @@ func (s *ReaderToWriter) Sync(
 
 	var state syncingState
 
+	// For server-to-server sync, deviceID is empty. The deviceID isolation is primarily
+	// for client-side sync where multiple client instances share the same wallet identity.
+	const deviceID = ""
+
 	for range state.doWhileChangesMade() {
-		writerSyncState, err := writer.FindOrInsertSyncStateAuth(ctx, userAuthOnWriterSide, readerSettings.StorageIdentityKey, readerSettings.StorageName)
+		writerSyncState, err := writer.FindOrInsertSyncStateAuth(ctx, userAuthOnWriterSide, readerSettings.StorageIdentityKey, readerSettings.StorageName, deviceID)
 		if err != nil {
 			return 0, 0, fmt.Errorf("failed to find or insert sync state auth: %w", err)
 		}
@@ -82,6 +86,7 @@ func (s *ReaderToWriter) Sync(
 			FromStorageIdentityKey: readerSettings.StorageIdentityKey,
 			ToStorageIdentityKey:   writerSettings.StorageIdentityKey,
 			IdentityKey:            userIdentityKey,
+			DeviceID:               deviceID,
 
 			Since:        syncState.When,
 			MaxRoughSize: maxSyncChunkSize,

--- a/pkg/storage/provider.go
+++ b/pkg/storage/provider.go
@@ -737,10 +737,10 @@ func (p *Provider) GetSyncChunk(ctx context.Context, args wdk.RequestSyncChunkAr
 	return chunk, nil
 }
 
-// FindOrInsertSyncStateAuth finds or inserts a sync state for the given user, storage identity key, and storage name.
-func (p *Provider) FindOrInsertSyncStateAuth(ctx context.Context, auth wdk.AuthID, storageIdentityKey, storageName string) (*wdk.FindOrInsertSyncStateAuthResponse, error) {
+// FindOrInsertSyncStateAuth finds or inserts a sync state for the given user, storage identity key, storage name, and device ID.
+func (p *Provider) FindOrInsertSyncStateAuth(ctx context.Context, auth wdk.AuthID, storageIdentityKey, storageName, deviceID string) (*wdk.FindOrInsertSyncStateAuthResponse, error) {
 	var err error
-	ctx, span := tracing.StartTracing(ctx, "StorageProvider-FindOrInsertSyncStateAuth", attribute.String("StorageIdentityKey", storageIdentityKey), attribute.String("StorageName", storageName))
+	ctx, span := tracing.StartTracing(ctx, "StorageProvider-FindOrInsertSyncStateAuth", attribute.String("StorageIdentityKey", storageIdentityKey), attribute.String("StorageName", storageName), attribute.String("DeviceID", deviceID))
 	defer func() {
 		tracing.EndTracing(span, err)
 	}()
@@ -749,7 +749,7 @@ func (p *Provider) FindOrInsertSyncStateAuth(ctx context.Context, auth wdk.AuthI
 		return nil, ErrAuthorization
 	}
 
-	action := sync.NewFindOrInsertSyncState(p.repo, p.options.Randomizer, *auth.UserID, storageIdentityKey, storageName)
+	action := sync.NewFindOrInsertSyncState(p.repo, p.options.Randomizer, *auth.UserID, storageIdentityKey, storageName, deviceID)
 	syncStateResponse, err := action.FindOrInsertSyncState(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find or insert sync state: %w", err)

--- a/pkg/wdk/storage.interface.go
+++ b/pkg/wdk/storage.interface.go
@@ -74,7 +74,7 @@ type WalletStorageProvider interface {
 	// FindOrInsertSyncStateAuth retrieves an existing sync state or inserts a new one based on the provided authentication and storage details.
 	// Skipped in WalletStorage interface and not exposed in StorageManager.
 	// @Sync
-	FindOrInsertSyncStateAuth(ctx context.Context, auth AuthID, storageIdentityKey, storageName string) (*FindOrInsertSyncStateAuthResponse, error)
+	FindOrInsertSyncStateAuth(ctx context.Context, auth AuthID, storageIdentityKey, storageName, deviceID string) (*FindOrInsertSyncStateAuthResponse, error)
 
 	// ProcessSyncChunk processes a sync chunk for a user, applying the changes contained within it.
 	// Skipped in WalletStorage interface and not exposed in StorageManager.

--- a/pkg/wdk/storage_request_sync_chunk_args.go
+++ b/pkg/wdk/storage_request_sync_chunk_args.go
@@ -13,6 +13,11 @@ type RequestSyncChunkArgs struct {
 	// IdentityKey - The identity of whose data is being requested
 	IdentityKey string `json:"identityKey"`
 
+	// DeviceID - Unique identifier for the client device. Used to isolate SyncState per device,
+	// preventing ID mapping corruption when multiple devices share the same wallet identity.
+	// Empty string for backwards compatibility with existing clients.
+	DeviceID string `json:"deviceId,omitempty"`
+
 	// Since - The max updated_at time received from the storage service receiving the request.
 	// Will be nil if this is the first request or if no data was previously sync'ed.
 	// `since` must include items if 'updated_at' is greater or equal. Thus, when not undefined, a sync request should always return at least one item already seen.

--- a/pkg/wdk/table_sync_state.go
+++ b/pkg/wdk/table_sync_state.go
@@ -13,6 +13,7 @@ type TableSyncState struct {
 	SyncStateID        uint                     `json:"syncStateId"`
 	UserID             int                      `json:"userId"`
 	StorageIdentityKey string                   `json:"storageIdentityKey"`
+	DeviceID           string                   `json:"deviceId,omitempty"`
 	StorageName        string                   `json:"storageName"`
 	Status             SyncStatus               `json:"status"`
 	Init               bool                     `json:"init"`


### PR DESCRIPTION
Multiple wallet instances sharing the same identity key (same private key) were sharing a single SyncState on the server, causing ID mapping corruption when local database IDs from different devices were mixed.

Adds deviceId parameter to isolate SyncState per device while still sharing user data across devices. Existing clients without deviceId continue to work with an empty string default, maintaining backwards compatibility.

## Description of Changes

Provide a brief description of the changes you've made.

## Linked Issues / Tickets

Reference any related issues or tickets, e.g. "Closes #123".

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run the linter
