### PR TITLE
feat: handle specOpWalletBalance in listOutputs

### DIFF
--- a/pkg/internal/specops/spec_ops.go
+++ b/pkg/internal/specops/spec_ops.go
@@ -3,7 +3,15 @@ package specops
 // ListActionsSpecOpFailedActionsLabel indicates that listActions should return only actions with status 'failed'.
 const ListActionsSpecOpFailedActionsLabel = "97d4eb1e49215e3374cc2c1939a7c43a55e95c7427bf2d45ed63e3b4e0c88153"
 
+// ListOutputsSpecOpWalletBalance triggers a balance query: sum of satoshis for spendable outputs in the 'default' basket.
+const ListOutputsSpecOpWalletBalance = "893b7646de0e1c9f741bd6e9169b76a8847ae34adef7bef1e6a285371206d2e8"
+
 // IsListActionsSpecOp returns true if the provided label is a reserved listActions spec-op.
 func IsListActionsSpecOp(label string) bool {
 	return label == ListActionsSpecOpFailedActionsLabel
+}
+
+// IsWalletBalanceSpecOp returns true if the basket is the reserved wallet balance spec-op.
+func IsWalletBalanceSpecOp(basket string) bool {
+	return basket == ListOutputsSpecOpWalletBalance
 }

--- a/pkg/internal/specops/spec_ops.go
+++ b/pkg/internal/specops/spec_ops.go
@@ -1,10 +1,10 @@
 package specops
 
 // ListActionsSpecOpFailedActionsLabel indicates that listActions should return only actions with status 'failed'.
-const ListActionsSpecOpFailedActionsLabel = "97d4eb1e49215e3374cc2c1939a7c43a55e95c7427bf2d45ed63e3b4e0c88153"
+const ListActionsSpecOpFailedActionsLabel = "97d4eb1e49215e3374cc2c1939a7c43a55e95c7427bf2d45ed63e3b4e0c88153" // #nosec G101
 
 // ListOutputsSpecOpWalletBalance triggers a balance query: sum of satoshis for spendable outputs in the 'default' basket.
-const ListOutputsSpecOpWalletBalance = "893b7646de0e1c9f741bd6e9169b76a8847ae34adef7bef1e6a285371206d2e8"
+const ListOutputsSpecOpWalletBalance = "893b7646de0e1c9f741bd6e9169b76a8847ae34adef7bef1e6a285371206d2e8" // #nosec G101
 
 // IsListActionsSpecOp returns true if the provided label is a reserved listActions spec-op.
 func IsListActionsSpecOp(label string) bool {

--- a/pkg/storage/internal/actions/list_outputs.go
+++ b/pkg/storage/internal/actions/list_outputs.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 
 	pkgentity "github.com/bsv-blockchain/go-wallet-toolbox/pkg/entity"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/specops"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/entity"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/validate"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/logging"
@@ -47,6 +48,26 @@ func (l *listOutputs) ListOutputs(ctx context.Context, auth wdk.AuthID, args *wd
 	defer func() {
 		tracing.EndTracing(span, err)
 	}()
+
+	if specops.IsWalletBalanceSpecOp(string(args.Basket)) {
+		balanceFilter := entity.ListOutputsFilter{
+			UserID: userID,
+			Basket: "default",
+			Limit:  -1,
+		}
+		outputModels, _, err := l.outputsRepo.ListAndCountOutputs(ctx, balanceFilter)
+		if err != nil {
+			return nil, fmt.Errorf("error listing outputs for balance: %w", err)
+		}
+		var totalSatoshis uint64
+		for _, o := range outputModels {
+			totalSatoshis += must.ConvertToUInt64(o.Satoshis)
+		}
+		return &wdk.ListOutputsResult{
+			TotalOutputs: primitives.PositiveInteger(totalSatoshis),
+			Outputs:      []*wdk.WalletOutput{},
+		}, nil
+	}
 
 	filter := l.toFilterParams(userID, args)
 


### PR DESCRIPTION
## Summary
- When `listOutputs` receives the `specOpWalletBalance` hash as the basket, swap it to `default`, fetch all spendable outputs, sum their satoshis, and return `{ totalOutputs: sum, outputs: [] }`
- Matches existing behavior in the TS wallet-toolbox
- Temporary fix until the dedicated balance method (get-balance branch) is merged

## Test plan
- [x] Verified balance returns correctly via yours-wallet Chrome extension against live server