### PR TITLE
refactor: use wdk.Services interface for wallet services

### DIFF
--- a/pkg/wallet/internal/wallet_opts/wallet_opts.go
+++ b/pkg/wallet/internal/wallet_opts/wallet_opts.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/bsv-blockchain/go-sdk/overlay/lookup"
 	sdk "github.com/bsv-blockchain/go-sdk/wallet"
-	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 	wallet_settings_manager "github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/internal/wallet_settings_manager"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/pending"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 )
 
 type Opts struct {

--- a/pkg/wallet/internal/wallet_opts/wallet_opts.go
+++ b/pkg/wallet/internal/wallet_opts/wallet_opts.go
@@ -8,14 +8,14 @@ import (
 
 	"github.com/bsv-blockchain/go-sdk/overlay/lookup"
 	sdk "github.com/bsv-blockchain/go-sdk/wallet"
-	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/services"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 	wallet_settings_manager "github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/internal/wallet_settings_manager"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/pending"
 )
 
 type Opts struct {
 	Flags
-	Services               *services.WalletServices
+	Services               wdk.Services
 	Logger                 *slog.Logger
 	PendingSignActionsRepo pending.SignActionsRepository
 	Client                 *http.Client

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -25,7 +25,6 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/validate"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/logging"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/randomizer"
-	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/services"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/storage"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/tracing"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/internal/actions"
@@ -101,7 +100,7 @@ type Wallet struct {
 	storage                 wdk.WalletStorage
 	keyDeriver              *sdk.KeyDeriver
 	flags                   *wallet_opts.Flags
-	services                *services.WalletServices
+	services                wdk.Services
 	chain                   defs.BSVNetwork
 	pendingSignActionsCache pending.SignActionsRepository
 	logger                  *slog.Logger
@@ -157,7 +156,7 @@ func WithTrustSelf(value sdk.TrustSelf) func(*wallet_opts.Opts) {
 }
 
 // WithServices allows to set the wallet services that will be used by the wallet.
-func WithServices(services *services.WalletServices) func(*wallet_opts.Opts) {
+func WithServices(services wdk.Services) func(*wallet_opts.Opts) {
 	return func(opts *wallet_opts.Opts) {
 		opts.Services = services
 	}


### PR DESCRIPTION
## Summary
- Changes `Wallet.services` field from `*services.WalletServices` to `wdk.Services`
- Updates `WithServices()` option to accept `wdk.Services` instead of the concrete type
- Updates `wallet_opts.Opts.Services` field to match

The wallet only calls `CurrentHeight` and `ChainHeaderByHeight` on the services field — both are defined on `wdk.Services`. This allows consumers to provide custom `wdk.Services` implementations without depending on the concrete `*services.WalletServices` type.

## Test plan
- `go build ./...` passes
- `go vet ./...` passes
- Existing callers passing `*services.WalletServices` continue to work since it implements the interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)