### PR TITLE
fix: update tx status to mined when one tx was both created and internalized

### DIFF
--- a/pkg/internal/storage/repo/known_tx.go
+++ b/pkg/internal/storage/repo/known_tx.go
@@ -294,7 +294,7 @@ func (p *KnownTx) UpdateKnownTxAsMined(ctx context.Context, knownTxAsMined *enti
 				tx.Model(&models.Output{}).
 					Select("id").
 					Where(
-						"transaction_id = (?)",
+						"transaction_id in (?)",
 						tx.Model(&models.Transaction{}).
 							Select("id").
 							Where(p.query.Transaction.TxID.Eq(knownTxAsMined.TxID)),


### PR DESCRIPTION
## Description of Changes

Handle case when tx was both made and internalized. Then we need to prove both tx and 

## Linked Issues / Tickets

Closes #773 

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run the linter
