### PR TITLE
fix: mark all known outputs as spent when used as inputs

### DIFF
--- a/pkg/storage/internal/actions/create_process_inputs.go
+++ b/pkg/storage/internal/actions/create_process_inputs.go
@@ -180,9 +180,7 @@ func (proc *inputsProcessor) buildInputsDefinition() (*processedInputsResult, er
 
 		var newXInput *xinputDefinition
 		if output != nil {
-			if output.Change {
-				changeOutputIDs = append(changeOutputIDs, output.ID)
-			}
+			changeOutputIDs = append(changeOutputIDs, output.ID)
 			newXInput, err = proc.xinputDefOnKnownUTXO(&xinput, output)
 		} else {
 			newXInput, err = proc.xinputDefOnUnknownUTXO(&xinput)


### PR DESCRIPTION
## Summary
- Removes the `output.Change` guard in `buildInputsDefinition()` so all known output IDs are collected for `changeOutputIDs`
- Without this fix, non-change outputs (e.g. ordinals) used as inputs in `createAction` are never marked as spent (`spendable=false`, `spent_by=txID`)
- Aligns with the TypeScript wallet-toolbox behavior which marks all known outputs as spent regardless of the `Change` flag

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] End-to-end test: use a non-change output (ordinal) as input in createAction, verify it gets marked as not spendable