### PR TITLE
fix: spent all inputs from tx

### DIFF
--- a/pkg/internal/storage/entity/new_tx_model.go
+++ b/pkg/internal/storage/entity/new_tx_model.go
@@ -27,6 +27,7 @@ type NewTx struct {
 	TxID *string
 
 	ReservedOutputIDs []uint
+	SpentOutputIDs    []uint
 	Outputs           []*NewOutput
 	UTXOStatus        wdk.UTXOStatus
 

--- a/pkg/internal/storage/repo/transactions.go
+++ b/pkg/internal/storage/repo/transactions.go
@@ -57,7 +57,7 @@ func (txs *Transactions) CreateTransaction(ctx context.Context, newTx *entity.Ne
 			return fmt.Errorf("failed to create new transaction model: %w", err)
 		}
 
-		if err = txs.markReservedOutputsAsNotSpendable(tx, model.ID, newTx.UserID, newTx.ReservedOutputIDs); err != nil {
+		if err = txs.markReservedOutputsAsNotSpendable(tx, model.ID, newTx.UserID, newTx.SpentOutputIDs); err != nil {
 			return fmt.Errorf("failed to mark reserved outputs as not spendable: %w", err)
 		}
 

--- a/pkg/storage/internal/actions/create.go
+++ b/pkg/storage/internal/actions/create.go
@@ -346,7 +346,8 @@ func (c *create) Create(ctx context.Context, userID int, params CreateActionPara
 		Description:       params.Description,
 		Satoshis:          satoshi.MustSubtract(funding.ChangeAmount, totalAllocated).Int64(),
 		Outputs:           newOutputs,
-		ReservedOutputIDs: c.allReservedOutputIDs(funding.AllocatedUTXOs, processedInputs.ChangeOutputIDs),
+		ReservedOutputIDs: c.mapReservedOutputIDs(funding.AllocatedUTXOs, processedInputs.ChangeOutputIDs),
+		SpentOutputIDs:    c.mapReservedOutputIDs(funding.AllocatedUTXOs, append(processedInputs.ChangeOutputIDs, processedInputs.KnownOutputIDs...)),
 		Labels:            params.Labels,
 		InputBeef:         inputBeef,
 		Commission:        c.createCommissionEntity(userID, commOut),
@@ -739,7 +740,7 @@ func (c *create) randomReference() (string, error) {
 	return reference, nil
 }
 
-func (c *create) allReservedOutputIDs(allocated []*funder.UTXO, providedOutputsIDs []uint) []uint {
+func (c *create) mapReservedOutputIDs(allocated []*funder.UTXO, providedOutputsIDs []uint) []uint {
 	ids := make([]uint, 0, len(allocated)+len(providedOutputsIDs))
 	ids = append(ids, providedOutputsIDs...)
 	for _, utxo := range allocated {

--- a/pkg/storage/internal/actions/create_process_inputs.go
+++ b/pkg/storage/internal/actions/create_process_inputs.go
@@ -62,6 +62,7 @@ type processedInputsResult struct {
 	Inputs          xinputDefinitions
 	Beef            *transaction.Beef
 	ChangeOutputIDs []uint
+	KnownOutputIDs  []uint
 }
 
 type inputsProcessor struct {
@@ -172,6 +173,7 @@ func (proc *inputsProcessor) processInputs() (*processedInputsResult, error) {
 func (proc *inputsProcessor) buildInputsDefinition() (*processedInputsResult, error) {
 	xinputDefs := make([]*xinputDefinition, 0, len(proc.providedInputs))
 	var changeOutputIDs []uint
+	var knownOutputIDs []uint
 	for _, xinput := range proc.providedInputs {
 		output, err := proc.parent.outputRepo.FindOutput(proc.ctx, proc.userID, xinput.Outpoint)
 		if err != nil {
@@ -182,6 +184,8 @@ func (proc *inputsProcessor) buildInputsDefinition() (*processedInputsResult, er
 		if output != nil {
 			if output.Change {
 				changeOutputIDs = append(changeOutputIDs, output.ID)
+			} else {
+				knownOutputIDs = append(knownOutputIDs, output.ID)
 			}
 			newXInput, err = proc.xinputDefOnKnownUTXO(&xinput, output)
 		} else {
@@ -199,6 +203,7 @@ func (proc *inputsProcessor) buildInputsDefinition() (*processedInputsResult, er
 		Inputs:          xinputDefs,
 		Beef:            proc.beef,
 		ChangeOutputIDs: changeOutputIDs,
+		KnownOutputIDs:  knownOutputIDs,
 	}, nil
 }
 


### PR DESCRIPTION
## Description of Changes

Previously, during transaction creation, only outputs marked as `change` were actually being updated as spent in the database. This caused an issue when spending non-change UTXOs, as they would incorrectly remain available.
This PR fixes the issue by capturing all known inputs used in the transaction (rather than just change) and passing them down ensure they are correctly marked as spent (`spendable = false`) in the `bsv_outputs` table.

## Linked Issues / Tickets

Bug was introduced #778 

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run the linter
