### PR TITLE
fix: remediate SonarQube security hotspots

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -12,8 +12,8 @@ jobs:
   sync-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: micnncim/action-label-syncer@v1.3.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/pkg/defs/arc.go
+++ b/pkg/defs/arc.go
@@ -72,11 +72,11 @@ func (arc *ARC) isLocalNetworkHost(hostname string) bool {
 	if ip != nil {
 		// RFC 1918 / RFC 5735 well-known private and reserved CIDR ranges used
 		// for local-network detection — these are not hardcoded service addresses.
-		_, private10, _ := net.ParseCIDR("10.0.0.0/8")       //nolint:gosec // well-known RFC 1918 range
-		_, private172, _ := net.ParseCIDR("172.16.0.0/12")    //nolint:gosec // well-known RFC 1918 range
-		_, private192, _ := net.ParseCIDR("192.168.0.0/16")   //nolint:gosec // well-known RFC 1918 range
-		_, loopback, _ := net.ParseCIDR("127.0.0.0/8")        //nolint:gosec // well-known loopback range
-		_, linkLocal, _ := net.ParseCIDR("169.254.0.0/16")    //nolint:gosec // well-known link-local range
+		_, private10, _ := net.ParseCIDR("10.0.0.0/8")      //nolint:gosec // well-known RFC 1918 range
+		_, private172, _ := net.ParseCIDR("172.16.0.0/12")  //nolint:gosec // well-known RFC 1918 range
+		_, private192, _ := net.ParseCIDR("192.168.0.0/16") //nolint:gosec // well-known RFC 1918 range
+		_, loopback, _ := net.ParseCIDR("127.0.0.0/8")      //nolint:gosec // well-known loopback range
+		_, linkLocal, _ := net.ParseCIDR("169.254.0.0/16")  //nolint:gosec // well-known link-local range
 
 		return private10.Contains(ip) || private172.Contains(ip) || private192.Contains(ip) || loopback.Contains(ip) || linkLocal.Contains(ip)
 	}

--- a/pkg/defs/arc.go
+++ b/pkg/defs/arc.go
@@ -70,11 +70,13 @@ func (arc *ARC) isLocalNetworkHost(hostname string) bool {
 
 	ip := net.ParseIP(hostname)
 	if ip != nil {
-		_, private10, _ := net.ParseCIDR("10.0.0.0/8")
-		_, private172, _ := net.ParseCIDR("172.16.0.0/12")
-		_, private192, _ := net.ParseCIDR("192.168.0.0/16")
-		_, loopback, _ := net.ParseCIDR("127.0.0.0/8")
-		_, linkLocal, _ := net.ParseCIDR("169.254.0.0/16")
+		// RFC 1918 / RFC 5735 well-known private and reserved CIDR ranges used
+		// for local-network detection — these are not hardcoded service addresses.
+		_, private10, _ := net.ParseCIDR("10.0.0.0/8")       //nolint:gosec // well-known RFC 1918 range
+		_, private172, _ := net.ParseCIDR("172.16.0.0/12")    //nolint:gosec // well-known RFC 1918 range
+		_, private192, _ := net.ParseCIDR("192.168.0.0/16")   //nolint:gosec // well-known RFC 1918 range
+		_, loopback, _ := net.ParseCIDR("127.0.0.0/8")        //nolint:gosec // well-known loopback range
+		_, linkLocal, _ := net.ParseCIDR("169.254.0.0/16")    //nolint:gosec // well-known link-local range
 
 		return private10.Contains(ip) || private172.Contains(ip) || private192.Contains(ip) || loopback.Contains(ip) || linkLocal.Contains(ip)
 	}

--- a/pkg/randomizer/default_randomizer.go
+++ b/pkg/randomizer/default_randomizer.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math/big"
-	"math/rand"
 
 	"github.com/go-softwarelab/common/pkg/must"
 )
@@ -48,9 +47,15 @@ func (s *DefaultRandomizer) Base64(length uint64) (string, error) {
 }
 
 // Shuffle randomizes the order of n elements using the provided swap function.
-// This is a wrapper around the standard library's rand.Shuffle.
+// Uses crypto/rand for cryptographically secure shuffling (Fisher-Yates).
 func (s *DefaultRandomizer) Shuffle(n int, swap func(i int, j int)) {
-	rand.Shuffle(n, swap)
+	for i := n - 1; i > 0; i-- {
+		jBig, err := cryptorand.Int(cryptorand.Reader, big.NewInt(int64(i+1)))
+		if err != nil {
+			panic(fmt.Errorf("failed to generate random number for shuffle: %w", err))
+		}
+		swap(i, int(jBig.Int64()))
+	}
 }
 
 // Uint64 generates a cryptographically secure random unsigned integer between 0 and max-1.


### PR DESCRIPTION
## Summary
- **Randomizer (go:S2245)**: Replaced `math/rand.Shuffle` with a crypto/rand-based Fisher-Yates shuffle in `DefaultRandomizer`, since it is used for transaction output shuffling (privacy-sensitive).
- **arc.go CIDR ranges (go:S1313)**: Added `nolint:gosec` comments documenting that these are well-known RFC 1918/5735 private network CIDR ranges used for local-network detection, not hardcoded service addresses. These should be marked SAFE in SonarCloud.
- **GitHub Actions (githubactions:S7637)**: Pinned `actions/checkout@v6` and `micnncim/action-label-syncer@v1.3.0` to full commit SHAs. The 3 `4chain-ag/workflows` reusable workflow references track org-managed branches and should be marked SAFE.

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./pkg/randomizer/...` passes (including Shuffle test)
- [x] No changes to test files required

🤖 Generated with [Claude Code](https://claude.com/claude-code)