### PR TITLE
fix: add no-op Destroy handler to RPCStorageProvider

### DIFF
--- a/pkg/storage/rpcserver/rpc_storage_provider.go
+++ b/pkg/storage/rpcserver/rpc_storage_provider.go
@@ -56,6 +56,11 @@ func (p *RPCStorageProvider) ensureUserID(ctx context.Context, auth *wdk.AuthID)
 	return nil
 }
 
+// Destroy is a no-op on the server side. Remote clients call destroy when
+// cleaning up their local wallet instance, but that should not shut down
+// the server's storage. Matches the TypeScript StorageServer behavior.
+func (p *RPCStorageProvider) Destroy() {}
+
 func (p *RPCStorageProvider) verifyAuthenticated(ctx context.Context) error {
 	if middleware.IsNotAuthenticated(ctx) {
 		return fmt.Errorf("function may only access authenticated user")


### PR DESCRIPTION
## Summary
- Adds a no-op `Destroy()` method to `RPCStorageProvider`
- Remote clients (`StorageClient`) call `destroy()` when cleaning up their local wallet instance
- The TypeScript `StorageServer` already ignores this call (logs it as `IGNORED` and returns success)
- The Go `RPCStorageProvider` was missing the handler, causing `"method 'destroy' not found"` RPC errors on every client disconnect

## Test plan
- [ ] `go build ./pkg/storage/rpcserver/...` passes
- [ ] Server no longer logs RPC errors when clients call destroy