### PR TITLE
Fix default fee model from 1 sat/KB to 100 sat/KB

### DIFF
--- a/infra-config.example.yaml
+++ b/infra-config.example.yaml
@@ -30,7 +30,7 @@ fail_abandoned:
     min_transaction_age_seconds: 300
 fee_model:
     type: sat/kb
-    value: 1
+    value: 100
 http:
     port: 8100
     request_price: 0

--- a/pkg/defs/fee_model.go
+++ b/pkg/defs/fee_model.go
@@ -33,10 +33,10 @@ func (f *FeeModel) Validate() error {
 	return nil
 }
 
-// DefaultFeeModel returns minimal fee model.
+// DefaultFeeModel returns the standard fee model (100 sat/KB).
 func DefaultFeeModel() FeeModel {
 	return FeeModel{
 		Type:  SatPerKB,
-		Value: 1,
+		Value: 100,
 	}
 }


### PR DESCRIPTION
## Summary
- Changes `DefaultFeeModel()` from 1 sat/KB to 100 sat/KB
- The BSV network minimum relay fee is 100 sat/KB — transactions at 1 sat/KB are rejected by miners

## Test plan
- Existing funder tests pass (they specify their own fee models explicitly)
- `go vet ./...` clean