### PR TITLE
feat: fixing tests and linter issues

### DIFF
--- a/infra-config.example.yaml
+++ b/infra-config.example.yaml
@@ -29,8 +29,8 @@ db:
 fail_abandoned:
   min_transaction_age_seconds: 300
 fee_model:
-    type: sat/kb
-    value: 100
+  type: sat/kb
+  value: 100
 http:
   port: 8100
   request_price: 0

--- a/pkg/internal/storage/funder/sql.go
+++ b/pkg/internal/storage/funder/sql.go
@@ -28,18 +28,16 @@ const (
 	utxoBatchSize = 1000
 )
 
-var (
-	// MaxChangeOutputsPerTransaction limits how aggressively the wallet builds up its UTXO pool in one shot.
-	// When a user first imports a large UTXO, without this cap the wallet would
-	// attempt to create numberOfDesiredUTXOs change outputs in a single transaction.
-	// That produces a very large transaction whose raw bytes are embedded in the BEEF
-	// of every subsequent child transaction, bloating those BEEFs and slowing down external processors.
-	//
-	// With this cap the UTXO pool builds gradually — at most 8 net new change
-	// outputs per transaction — so no single transaction becomes unreasonably large.
-	// A pool of 144 desired UTXOs fills over roughly 18 transactions rather than 1.
-	MaxChangeOutputsPerTransaction uint64 = 8
-)
+// MaxChangeOutputsPerTransaction limits how aggressively the wallet builds up its UTXO pool in one shot.
+// When a user first imports a large UTXO, without this cap the wallet would
+// attempt to create numberOfDesiredUTXOs change outputs in a single transaction.
+// That produces a very large transaction whose raw bytes are embedded in the BEEF
+// of every subsequent child transaction, bloating those BEEFs and slowing down external processors.
+//
+// With this cap the UTXO pool builds gradually — at most 8 net new change
+// outputs per transaction — so no single transaction becomes unreasonably large.
+// A pool of 144 desired UTXOs fills over roughly 18 transactions rather than 1.
+var MaxChangeOutputsPerTransaction uint64 = 8
 
 type UTXORepository interface {
 	FindNotReservedUTXOs(

--- a/pkg/internal/storage/funder/sql_test.go
+++ b/pkg/internal/storage/funder/sql_test.go
@@ -591,7 +591,7 @@ func TestFunderSQLFundChangeManagement(t *testing.T) {
 
 		// then: change outputs must be capped at MaxChangeOutputsPerTransaction, not 100
 		then.Result(result).WithoutError(err).
-			HasChangeCount(int(funder.MaxChangeOutputsPerTransaction)).
+			HasChangeCount(int(funder.MaxChangeOutputsPerTransaction)). //nolint:gosec // MaxChangeOutputsPerTransaction is a small constant
 			ForAmount(100_000_000)
 	})
 
@@ -613,7 +613,7 @@ func TestFunderSQLFundChangeManagement(t *testing.T) {
 		// then: only MaxChangeOutputsPerTransaction outputs created, not 20
 		then.Result(result).WithoutError(err)
 
-		require.LessOrEqual(t, int(result.ChangeOutputsCount), int(funder.MaxChangeOutputsPerTransaction),
+		require.LessOrEqual(t, result.ChangeOutputsCount, funder.MaxChangeOutputsPerTransaction,
 			"ChangeOutputsCount should not exceed MaxChangeOutputsPerTransaction")
 	})
 
@@ -655,8 +655,8 @@ func TestFunderSQLFundChangeManagement(t *testing.T) {
 		// dustFloor = 44 sats; each output must be well above that
 		require.Positive(t, int(result.ChangeAmount), "change must be positive")
 		if result.ChangeOutputsCount > 0 {
-			avgPerOutput := int(result.ChangeAmount) / int(result.ChangeOutputsCount)
-			require.GreaterOrEqual(t, avgPerOutput, 44,
+			avgPerOutput := int64(result.ChangeAmount) / int64(result.ChangeOutputsCount) //nolint:gosec // test values are small
+			require.GreaterOrEqual(t, avgPerOutput, int64(44),
 				"average change per output must be >= dustFloor (44 sats at 110 sat/kb)")
 		}
 	})
@@ -682,9 +682,9 @@ func TestFunderSQLFundChangeManagement(t *testing.T) {
 
 		// Verify that no individual output would be below the dust floor
 		if result.ChangeOutputsCount > 0 {
-			perOutput := int(result.ChangeAmount) / int(result.ChangeOutputsCount)
+			perOutput := int64(result.ChangeAmount) / int64(result.ChangeOutputsCount) //nolint:gosec // test values are small
 			// dustFloor at 1000 sat/kb = ceil(192/1000*1000)*2 = 192*2 = 384
-			require.GreaterOrEqualf(t, perOutput, 384,
+			require.GreaterOrEqualf(t, perOutput, int64(384),
 				"per-output value %d must be >= dustFloor 384 at 1000 sat/kb", perOutput)
 		}
 	})

--- a/pkg/internal/txutils/inputs_outputs_sizes.go
+++ b/pkg/internal/txutils/inputs_outputs_sizes.go
@@ -7,8 +7,10 @@ const (
 	P2PKHLockingScriptLength   = 25
 )
 
-var P2PKHOutputSize = TransactionOutputSize(P2PKHLockingScriptLength)
-var P2PKHEstimatedInputSize = TransactionInputSize(P2PKHUnlockingScriptLength)
+var (
+	P2PKHOutputSize         = TransactionOutputSize(P2PKHLockingScriptLength)
+	P2PKHEstimatedInputSize = TransactionInputSize(P2PKHUnlockingScriptLength)
+)
 
 // EstimatedInputSizeByType returns the estimated size of a transaction output based on its type.
 func EstimatedInputSizeByType(txType wdk.OutputType) uint64 {

--- a/pkg/internal/txutils/tx_size.go
+++ b/pkg/internal/txutils/tx_size.go
@@ -64,7 +64,7 @@ func TransactionSize(inputSizes, outputSizes iter.Seq2[uint64, error]) (uint64, 
 // TransactionSizeFromScriptLengths calculates the total size of a transaction
 // from concrete slices of input unlocking-script lengths and output locking-script lengths.
 // This is the equivalent of the TS function: transactionSize(inputs: number[], outputs: number[])
-func TransactionSizeFromScriptLengths(inputScriptLengths []uint64, outputScriptLengths []uint64) uint64 {
+func TransactionSizeFromScriptLengths(inputScriptLengths, outputScriptLengths []uint64) uint64 {
 	var inputsSize uint64
 	for _, scriptLen := range inputScriptLengths {
 		inputsSize += TransactionInputSize(scriptLen)

--- a/pkg/services/chaintracksclient/service_test.go
+++ b/pkg/services/chaintracksclient/service_test.go
@@ -286,7 +286,6 @@ func TestService_OnTipCallbackError(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 
 	var callbackInvoked atomic.Bool
 
@@ -305,6 +304,11 @@ func TestService_OnTipCallbackError(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return callbackInvoked.Load()
 	}, 1*time.Second, 10*time.Millisecond, "callback should be invoked even if it returns error")
+
+	// Cancel context and wait briefly for the goroutine to finish logging the error,
+	// otherwise the test logger (backed by t) panics on write-after-completion.
+	cancel()
+	time.Sleep(50 * time.Millisecond)
 }
 
 func TestService_OnReorgCallbackError(t *testing.T) {
@@ -325,7 +329,6 @@ func TestService_OnReorgCallbackError(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 
 	var callbackInvoked atomic.Bool
 
@@ -344,4 +347,9 @@ func TestService_OnReorgCallbackError(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return callbackInvoked.Load()
 	}, 1*time.Second, 10*time.Millisecond, "callback should be invoked even if it returns error")
+
+	// Cancel context and wait briefly for the goroutine to finish logging the error,
+	// otherwise the test logger (backed by t) panics on write-after-completion.
+	cancel()
+	time.Sleep(50 * time.Millisecond)
 }

--- a/pkg/storage/provider_create_action_test.go
+++ b/pkg/storage/provider_create_action_test.go
@@ -64,7 +64,7 @@ func TestCreateActionHappyPath(t *testing.T) {
 	assert.Len(t, result.Reference, 16)
 	assert.Equal(t, args.Version, result.Version)
 	assert.Equal(t, args.LockTime, result.LockTime)
-	assert.Equal(t, 9, len(result.Outputs))
+	assert.Len(t, result.Outputs, 9)
 	assert.Equal(t, 8, testutils.CountOutputsWithCondition(t, result.Outputs, testutils.ProvidedByStorageCondition))
 	assert.Equal(t, primitives.SatoshiValue(57999), testutils.SumOutputsWithCondition(t, result.Outputs, testutils.SatoshiValue, testutils.ProvidedByStorageCondition))
 
@@ -273,7 +273,7 @@ func TestCreateActionWithCommission(t *testing.T) {
 	assert.Len(t, result.Reference, 16)
 	assert.Equal(t, args.Version, result.Version)
 	assert.Equal(t, args.LockTime, result.LockTime)
-	assert.Equal(t, 10, len(result.Outputs))
+	assert.Len(t, result.Outputs, 10)
 	assert.Equal(t, 9, testutils.CountOutputsWithCondition(t, result.Outputs, testutils.ProvidedByStorageCondition))
 	assert.Equal(t, primitives.SatoshiValue(57999), testutils.SumOutputsWithCondition(t, result.Outputs, testutils.SatoshiValue, testutils.ProvidedByStorageCondition))
 
@@ -463,7 +463,7 @@ func TestCreateActionWithProvidedKnownInput(t *testing.T) {
 	assert.Len(t, result.Reference, 16)
 	assert.Equal(t, args.Version, result.Version)
 	assert.Equal(t, args.LockTime, result.LockTime)
-	assert.Equal(t, 8, len(result.Outputs))
+	assert.Len(t, result.Outputs, 8)
 	assert.Equal(t, 8, testutils.CountOutputsWithCondition(t, result.Outputs, testutils.ProvidedByStorageCondition))
 	assert.Equal(t, primitives.SatoshiValue(99999), testutils.SumOutputsWithCondition(t, result.Outputs, testutils.SatoshiValue, testutils.ProvidedByStorageCondition))
 
@@ -528,7 +528,7 @@ func TestCreateActionWithProvidedUnknownInput(t *testing.T) {
 	assert.Len(t, result.Reference, 16)
 	assert.Equal(t, args.Version, result.Version)
 	assert.Equal(t, args.LockTime, result.LockTime)
-	assert.Equal(t, 8, len(result.Outputs))
+	assert.Len(t, result.Outputs, 8)
 	assert.Equal(t, 8, testutils.CountOutputsWithCondition(t, result.Outputs, testutils.ProvidedByStorageCondition))
 	assert.Equal(t, primitives.SatoshiValue(99999), testutils.SumOutputsWithCondition(t, result.Outputs, testutils.SatoshiValue, testutils.ProvidedByStorageCondition))
 
@@ -592,7 +592,7 @@ func TestCreateActionWithProvidedInputAndSmallerOutput(t *testing.T) {
 	assert.Len(t, result.Reference, 16)
 	assert.Equal(t, args.Version, result.Version)
 	assert.Equal(t, args.LockTime, result.LockTime)
-	assert.Equal(t, 9, len(result.Outputs))
+	assert.Len(t, result.Outputs, 9)
 	assert.Equal(t, 8, testutils.CountOutputsWithCondition(t, result.Outputs, testutils.ProvidedByStorageCondition))
 	assert.Equal(t, primitives.SatoshiValue(57999), testutils.SumOutputsWithCondition(t, result.Outputs, testutils.SatoshiValue, testutils.ProvidedByStorageCondition))
 

--- a/pkg/storage/provider_no_send_test.go
+++ b/pkg/storage/provider_no_send_test.go
@@ -25,7 +25,7 @@ func TestNoSendPlusSendWithScenario(t *testing.T) {
 		// when:
 		// step 1:
 		noSendChangeOutpoints, allocatedNoSendChangeOutpoints := when.CreateAndProcessNoSendAction(nil)
-		assert.Len(t, allocatedNoSendChangeOutpoints, 0)
+		assert.Empty(t, allocatedNoSendChangeOutpoints)
 		assert.Len(t, noSendChangeOutpoints, 8)
 
 		// and:
@@ -111,7 +111,7 @@ func TestNoSendPlusSendWithScenario(t *testing.T) {
 		// when:
 		// step 1:
 		noSendChangeOutpoints, allocatedNoSendChangeOutpoints := when.CreateAndProcessNoSendAction(nil)
-		assert.Len(t, allocatedNoSendChangeOutpoints, 0)
+		assert.Empty(t, allocatedNoSendChangeOutpoints)
 		assert.Len(t, noSendChangeOutpoints, 8)
 
 		// and:
@@ -149,7 +149,7 @@ func TestNoSendPlusSendWithScenario(t *testing.T) {
 		// when:
 		// step 1:
 		noSendChangeOutpoints, allocatedNoSendChangeOutpoints := when.CreateAndProcessNoSendAction(nil)
-		assert.Len(t, allocatedNoSendChangeOutpoints, 0)
+		assert.Empty(t, allocatedNoSendChangeOutpoints)
 		assert.Len(t, noSendChangeOutpoints, 8)
 
 		// and:
@@ -209,7 +209,7 @@ func TestNoSendPlusSendWithScenario(t *testing.T) {
 		// when:
 		// step 1:
 		noSendChangeOutpoints, allocatedNoSendChangeOutpoints := when.CreateAndProcessNoSendAction(nil)
-		assert.Len(t, allocatedNoSendChangeOutpoints, 0)
+		assert.Empty(t, allocatedNoSendChangeOutpoints)
 		assert.Len(t, noSendChangeOutpoints, 8)
 
 		// and:


### PR DESCRIPTION
This pull request primarily focuses on improving code clarity and consistency in test assertions, minor refactoring for variable declarations, and enhancing test reliability. The changes do not affect core logic but improve maintainability and readability.

**Test assertion improvements:**

* Replaced `assert.Len(t, X, 0)` with `assert.Empty(t, X)` in multiple locations for clearer intent in `pkg/storage/provider_no_send_test.go`. [[1]](diffhunk://#diff-829f7a7bad05028ab6d57ebc38737127c18d0141d8872e77f95f4c947c9443dcL28-R28) [[2]](diffhunk://#diff-829f7a7bad05028ab6d57ebc38737127c18d0141d8872e77f95f4c947c9443dcL114-R114) [[3]](diffhunk://#diff-829f7a7bad05028ab6d57ebc38737127c18d0141d8872e77f95f4c947c9443dcL152-R152) [[4]](diffhunk://#diff-829f7a7bad05028ab6d57ebc38737127c18d0141d8872e77f95f4c947c9443dcL212-R212)
* Updated various assertions to use `assert.Len` instead of `assert.Equal` for slice length checks in `pkg/storage/provider_create_action_test.go`. [[1]](diffhunk://#diff-1d07ce21ade7f11ea0918523f0b4d221eb0f3dae94bb3a88deb3cd3313ef45b5L67-R67) [[2]](diffhunk://#diff-1d07ce21ade7f11ea0918523f0b4d221eb0f3dae94bb3a88deb3cd3313ef45b5L276-R276) [[3]](diffhunk://#diff-1d07ce21ade7f11ea0918523f0b4d221eb0f3dae94bb3a88deb3cd3313ef45b5L466-R466) [[4]](diffhunk://#diff-1d07ce21ade7f11ea0918523f0b4d221eb0f3dae94bb3a88deb3cd3313ef45b5L531-R531) [[5]](diffhunk://#diff-1d07ce21ade7f11ea0918523f0b4d221eb0f3dae94bb3a88deb3cd3313ef45b5L595-R595)
* Adjusted test calculations to use `int64` for division to avoid potential issues with integer division, and added `//nolint:gosec` comments where appropriate in `pkg/internal/storage/funder/sql_test.go`. [[1]](diffhunk://#diff-a6b4c33b386b9983099feb50f85fd94035e4359a5bfba68447457ed2d09dc051L658-R659) [[2]](diffhunk://#diff-a6b4c33b386b9983099feb50f85fd94035e4359a5bfba68447457ed2d09dc051L685-R687)

**Variable and declaration refactoring:**

* Changed single variable declarations to grouped `var (...)` blocks for related constants in `pkg/internal/txutils/inputs_outputs_sizes.go` and `pkg/internal/storage/funder/sql.go` for improved readability. [[1]](diffhunk://#diff-cfd27cb74b4d3b8d4bf143210f008ffd71d9fdb7c952f85621fbe540d239fca7L10-R13) [[2]](diffhunk://#diff-7e5adc964cd76987b6cdc142a8deb56ab10b4f3a9b9401780a9bfadfdb4cd2c9L31) [[3]](diffhunk://#diff-7e5adc964cd76987b6cdc142a8deb56ab10b4f3a9b9401780a9bfadfdb4cd2c9L41-R40)

**Test reliability enhancements:**

* Modified tests in `pkg/services/chaintracksclient/service_test.go` to ensure the context is cancelled and goroutines finish before test completion, preventing potential panics from the logger. [[1]](diffhunk://#diff-a6d6d702d1c032aa725c827ad6a15f22b83964189b569a235db66483ccff87f5L289) [[2]](diffhunk://#diff-a6d6d702d1c032aa725c827ad6a15f22b83964189b569a235db66483ccff87f5R307-R311) [[3]](diffhunk://#diff-a6d6d702d1c032aa725c827ad6a15f22b83964189b569a235db66483ccff87f5L328) [[4]](diffhunk://#diff-a6d6d702d1c032aa725c827ad6a15f22b83964189b569a235db66483ccff87f5R350-R354)

**Minor function signature cleanup:**

* Simplified argument formatting in `TransactionSizeFromScriptLengths` for consistency in `pkg/internal/txutils/tx_size.go`.