### PR TITLE
Add AddWalletStorageProvider to WalletStorageManager

### DIFF
--- a/pkg/storage/storage_manager.go
+++ b/pkg/storage/storage_manager.go
@@ -59,6 +59,23 @@ func NewWalletStorageManager(identityKey string, logger *slog.Logger, active wdk
 	}
 }
 
+// AddWalletStorageProvider adds a new storage provider to the manager after construction.
+// This enables the remote-wallet pattern where the wallet is created with an empty storage manager,
+// then the storage client (which needs the wallet for auth) is added dynamically.
+// After adding, the manager re-partitions all stores by calling MakeAvailable.
+func (m *WalletStorageManager) AddWalletStorageProvider(ctx context.Context, provider wdk.WalletStorageProvider) error {
+	store := managed.NewManagedStorage(provider)
+	if _, err := store.MakeAvailableStorage(ctx, m.identityKey); err != nil {
+		return fmt.Errorf("failed to make new storage provider available: %w", err)
+	}
+	m.stores = append(m.stores, store)
+	m.isAvailable = false
+	if _, err := m.MakeAvailable(ctx); err != nil {
+		return fmt.Errorf("failed to re-partition after adding storage provider: %w", err)
+	}
+	return nil
+}
+
 // IsActiveEnabled The active storage is "enabled" only if its `storageIdentityKey` matches the user's currently selected `activeStorage`,
 // and only if there are no stores with conflicting `activeStorage` selections.
 //

--- a/pkg/wallet/internal/wallet_opts/wallet_opts.go
+++ b/pkg/wallet/internal/wallet_opts/wallet_opts.go
@@ -23,6 +23,7 @@ type Opts struct {
 	Client                 *http.Client
 	WalletSettingsManager  *wallet_settings_manager.WalletSettingsManager
 	LookupResolver         *lookup.LookupResolver
+	StorageManager         wdk.WalletStorage
 }
 
 type Flags struct {

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -163,6 +163,16 @@ func WithServices(services wdk.Services) func(*wallet_opts.Opts) {
 	}
 }
 
+// WithStorageManager allows passing a pre-built WalletStorageManager instead of
+// having the wallet create one internally. This enables the remote-wallet pattern
+// where the wallet must exist before the storage client can be created (for auth),
+// and storage providers are added to the manager after wallet construction.
+func WithStorageManager(mgr wdk.WalletStorage) func(*wallet_opts.Opts) {
+	return func(opts *wallet_opts.Opts) {
+		opts.StorageManager = mgr
+	}
+}
+
 // WithPendingSignActionsRepository sets the SignActionsRepository for wallet options, allowing management of cached actions.
 func WithPendingSignActionsRepository(cache pending.SignActionsRepository) func(*wallet_opts.Opts) {
 	return func(opts *wallet_opts.Opts) {
@@ -201,10 +211,6 @@ func NewWithStorageFactory[KeySource PrivateKeySource, ActiveStorageFactory Stor
 	err := chain.Validate()
 	if err != nil {
 		return nil, fmt.Errorf("valid chain must be provided: %w", err)
-	}
-
-	if activeStorageFactory == nil {
-		return nil, fmt.Errorf("active storage factory must be provided")
 	}
 
 	options := to.OptionsWithDefault(wallet_opts.Opts{
@@ -255,14 +261,20 @@ func NewWithStorageFactory[KeySource PrivateKeySource, ActiveStorageFactory Stor
 	}
 	w.auth = clients.New(w, clients.WithHttpClientTransport(options.Client.Transport))
 
-	activeStorage, storageCleanup, err := toStorageProvider(w, activeStorageFactory)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create active storage: %w", err)
-	}
-	w.cleanup = w.cleanup.Add(storageCleanup)
+	if options.StorageManager != nil {
+		w.storage = options.StorageManager
+	} else {
+		if activeStorageFactory == nil {
+			return nil, fmt.Errorf("active storage factory must be provided when no StorageManager is set")
+		}
+		activeStorage, storageCleanup, err := toStorageProvider(w, activeStorageFactory)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create active storage: %w", err)
+		}
+		w.cleanup = w.cleanup.Add(storageCleanup)
 
-	storageManager := storage.NewWalletStorageManager(keyDeriver.IdentityKey().ToDERHex(), logger, activeStorage)
-	w.storage = storageManager
+		w.storage = storage.NewWalletStorageManager(keyDeriver.IdentityKey().ToDERHex(), logger, activeStorage)
+	}
 
 	return w, nil
 }


### PR DESCRIPTION
## Summary
- Adds `AddWalletStorageProvider(ctx, provider)` method to `WalletStorageManager`
- Adds `WithStorageManager(mgr)` option for wallet construction

## Motivation
The remote-wallet pattern requires:
1. Creating a wallet before the `StorageClient` (client needs wallet for BRC-103/104 auth)
2. Adding storage providers to the manager after wallet construction

Without these changes, there's no way to use remote storage in Go because of the circular dependency: wallet needs storage, storage client needs wallet.

The TypeScript wallet-toolbox supports both patterns — `WalletStorageManager.addWalletStorageProvider` and accepting a `WalletStorageManager` directly in the `Wallet` constructor. These changes bring the Go version to parity.

## What it does

### AddWalletStorageProvider
- Wraps provider in `ManagedStorage`, calls `MakeAvailableStorage`
- Appends to the stores list
- Resets `isAvailable` and calls `MakeAvailable` to re-partition active/backups

### WithStorageManager
- New wallet option that accepts a pre-built `wdk.WalletStorage`
- When set, the wallet uses it directly instead of creating its own manager
- The `activeStorageFactory` nil check only applies when no manager is provided

## Usage
```go
// 1. Create empty storage manager
mgr := storage.NewWalletStorageManager(identityKey, logger, nil)

// 2. Create wallet with the manager
wallet, _ := walletcore.New(network, privKey, nil,
    walletcore.WithStorageManager(mgr),
    walletcore.WithServices(services),
)

// 3. Create remote storage client (needs wallet for auth)
client, cleanup, _ := storage.NewClient(remoteURL, wallet)

// 4. Add remote storage to the manager
mgr.AddWalletStorageProvider(ctx, client)
```

## Test plan
- [x] Verify existing tests pass
- [ ] Verify remote wallet pattern works end-to-end