### PR TITLE
fix: validate merkle proofs against chaintracks before storage

### DIFF
--- a/pkg/storage/internal/actions/actions.go
+++ b/pkg/storage/internal/actions/actions.go
@@ -59,6 +59,7 @@ func New(
 			beefVerifier,
 			scriptsVerifier,
 			services,
+			services,
 		),
 		process: newProcessAction(
 			ctx,

--- a/pkg/storage/internal/actions/internalize.go
+++ b/pkg/storage/internal/actions/internalize.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/bsv-blockchain/go-sdk/transaction/chaintracker"
 	"github.com/go-softwarelab/common/pkg/is"
 	"github.com/go-softwarelab/common/pkg/optional"
 	"github.com/go-softwarelab/common/pkg/slices"
@@ -39,6 +41,7 @@ type internalize struct {
 	beefVerifier       wdk.BeefVerifier
 	scriptsVerifier    wdk.ScriptsVerifier
 	blockHeaderService wdk.BlockHeaderLoader
+	chainTracker       chaintracker.ChainTracker
 }
 
 func newInternalizeAction(
@@ -51,6 +54,7 @@ func newInternalizeAction(
 	beefVerifier wdk.BeefVerifier,
 	scriptsVerifier wdk.ScriptsVerifier,
 	blockHeader wdk.BlockHeaderLoader,
+	chainTracker chaintracker.ChainTracker,
 ) *internalize {
 	logger = logging.Child(logger, "internalizeAction")
 	return &internalize{
@@ -63,6 +67,7 @@ func newInternalizeAction(
 		beefVerifier:       beefVerifier,
 		scriptsVerifier:    scriptsVerifier,
 		blockHeaderService: blockHeader,
+		chainTracker:       chainTracker,
 	}
 }
 
@@ -268,6 +273,18 @@ func (in *internalize) updateKnownTxAsMined(ctx context.Context, userID int, txI
 	root, err := tx.MerklePath.ComputeRootHex(to.Ptr(txID))
 	if err != nil {
 		return fmt.Errorf("failed to compute root hex: %w", err)
+	}
+
+	rootHash, err := chainhash.NewHashFromHex(root)
+	if err != nil {
+		return fmt.Errorf("failed to parse computed merkle root: %w", err)
+	}
+	isValid, err := in.chainTracker.IsValidRootForHeight(ctx, rootHash, tx.MerklePath.BlockHeight)
+	if err != nil {
+		return fmt.Errorf("failed to validate merkle root against chaintracks: %w", err)
+	}
+	if !isValid {
+		return fmt.Errorf("merkle root %s invalid for height %d", root, tx.MerklePath.BlockHeight)
 	}
 
 	err = in.knownTxRepo.UpdateKnownTxAsMined(ctx, &entity.KnownTxAsMined{

--- a/pkg/storage/internal/actions/synchronize_tx_statuses.go
+++ b/pkg/storage/internal/actions/synchronize_tx_statuses.go
@@ -382,6 +382,25 @@ func (s *synchronizeTxStatuses) doSynchronizeTxStatuses(ctx context.Context, hei
 			continue
 		}
 
+		isValid, verifyErr := merkleResult.MerklePath.VerifyHex(ctx, txToSync.TxID, s.services)
+		if verifyErr != nil {
+			s.logger.Warn("failed to verify merkle proof",
+				slog.Any("err", verifyErr),
+				slog.String("txID", txToSync.TxID),
+				slog.Uint64("blockHeight", uint64(merkleResult.BlockHeader.Height)),
+			)
+			failedAttempts = append(failedAttempts, txToSync.TxID)
+			continue
+		}
+		if !isValid {
+			s.logger.Warn("merkle proof root does not match chaintracks",
+				slog.String("txID", txToSync.TxID),
+				slog.Uint64("blockHeight", uint64(merkleResult.BlockHeader.Height)),
+			)
+			failedAttempts = append(failedAttempts, txToSync.TxID)
+			continue
+		}
+
 		var transactionIDs []uint
 		transactionIDs, err = s.transactionRepo.FindTransactionIDsByTxID(ctx, txToSync.TxID)
 		if err != nil {


### PR DESCRIPTION
## Summary

- Validate merkle proof roots against chaintracks before persisting in both the sync task and internalize path
- Uses existing `MerklePath.VerifyHex()` from go-sdk and `IsValidRootForHeight` from the `Services` interface — both were available but not wired into the storage pipeline
- Invalid proofs are rejected and retried via the existing attempt counting mechanism

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./pkg/storage/ -run "TestSynchronizeTxStatuses|TestInternalize"` passes
- [ ] Verify sync cycle accepts valid proofs and rejects invalid ones
- [ ] Verify internalize path rejects transactions with mismatched merkle roots