### PR TITLE
refactor: fix nil pointer exception on chaintracks adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 *.so
 *.dylib
 
+.opencode
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/pkg/monitor/internal/tasks/send_waiting_test.go
+++ b/pkg/monitor/internal/tasks/send_waiting_test.go
@@ -74,7 +74,7 @@ func TestSendWaitingMonitorTask_FirstRunWithZeroMinTransactionAge(t *testing.T) 
 	require.NoError(t, err, "task should run without error")
 
 	// then:
-	require.Equal(t, 1, mockStorage.SendWaitingTransactionsCalled)
+	require.EqualValues(t, 1, mockStorage.SendWaitingTransactionsCalled.Load())
 	require.Equal(t, time.Duration(0), mockStorage.SendWaitingLastMinTransactionAge)
 
 	// when:
@@ -82,6 +82,6 @@ func TestSendWaitingMonitorTask_FirstRunWithZeroMinTransactionAge(t *testing.T) 
 
 	// then:
 	require.NoError(t, err, "task should run without error on subsequent call")
-	require.Equal(t, 2, mockStorage.SendWaitingTransactionsCalled)
+	require.EqualValues(t, 2, mockStorage.SendWaitingTransactionsCalled.Load())
 	require.NotZero(t, mockStorage.SendWaitingLastMinTransactionAge)
 }

--- a/pkg/monitor/internal/testabilities/assertions_monitor.go
+++ b/pkg/monitor/internal/testabilities/assertions_monitor.go
@@ -41,7 +41,7 @@ func then(t testing.TB, fixture *monitorFixture) *monitorAssertions {
 func (m *monitorAssertions) SynchronizeTransactionStatuses() ExecutedTaskAssertions {
 	return &storageMethodAssertions{
 		called: func() int {
-			return m.fixtures.mockStorage.SynchronizeTransactionStatusesCalled
+			return int(m.fixtures.mockStorage.SynchronizeTransactionStatusesCalled.Load())
 		},
 		taskName: defs.CheckForProofsMonitorTask,
 		parent:   m,
@@ -51,7 +51,7 @@ func (m *monitorAssertions) SynchronizeTransactionStatuses() ExecutedTaskAsserti
 func (m *monitorAssertions) SendWaitingTransactions() ExecutedTaskAssertions {
 	return &storageMethodAssertions{
 		called: func() int {
-			return m.fixtures.mockStorage.SendWaitingTransactionsCalled
+			return int(m.fixtures.mockStorage.SendWaitingTransactionsCalled.Load())
 		},
 		taskName: defs.SendWaitingMonitorTask,
 		parent:   m,
@@ -61,7 +61,7 @@ func (m *monitorAssertions) SendWaitingTransactions() ExecutedTaskAssertions {
 func (m *monitorAssertions) FailAbandoned() ExecutedTaskAssertions {
 	return &storageMethodAssertions{
 		called: func() int {
-			return m.fixtures.mockStorage.FailAbandonedCalled
+			return int(m.fixtures.mockStorage.FailAbandonedCalled.Load())
 		},
 		taskName: defs.FailAbandonedMonitorTask,
 		parent:   m,

--- a/pkg/monitor/internal/testabilities/mock_storage.go
+++ b/pkg/monitor/internal/testabilities/mock_storage.go
@@ -2,49 +2,50 @@ package testabilities
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 )
 
 type MockStorage struct {
-	SynchronizeTransactionStatusesCalled int
-	FailAbandonedCalled                  int
+	SynchronizeTransactionStatusesCalled atomic.Int64
+	FailAbandonedCalled                  atomic.Int64
 
-	SendWaitingTransactionsCalled    int
+	SendWaitingTransactionsCalled    atomic.Int64
 	SendWaitingLastMinTransactionAge time.Duration
-	UnFailCalled                     int
-	HandleReorgCalled                int
-	ProcessNewTipCalled              int
+	UnFailCalled                     atomic.Int64
+	HandleReorgCalled                atomic.Int64
+	ProcessNewTipCalled              atomic.Int64
 }
 
 func (m *MockStorage) SynchronizeTransactionStatuses(_ context.Context) ([]wdk.TxSynchronizedStatus, error) {
-	m.SynchronizeTransactionStatusesCalled++
+	m.SynchronizeTransactionStatusesCalled.Add(1)
 	return nil, nil
 }
 
 func (m *MockStorage) SendWaitingTransactions(_ context.Context, minTransactionAge time.Duration) (*wdk.ProcessActionResult, error) {
-	m.SendWaitingTransactionsCalled++
+	m.SendWaitingTransactionsCalled.Add(1)
 	m.SendWaitingLastMinTransactionAge = minTransactionAge
 	return nil, nil
 }
 
 func (m *MockStorage) AbortAbandoned(_ context.Context) error {
-	m.FailAbandonedCalled++
+	m.FailAbandonedCalled.Add(1)
 	return nil
 }
 
 func (m *MockStorage) UnFail(_ context.Context) error {
-	m.UnFailCalled++
+	m.UnFailCalled.Add(1)
 	return nil
 }
 
 func (m *MockStorage) HandleReorg(_ context.Context, _ []string) error {
-	m.HandleReorgCalled++
+	m.HandleReorgCalled.Add(1)
 	return nil
 }
 
 func (m *MockStorage) ProcessNewTip(_ context.Context, _ uint32, _ string) ([]wdk.TxSynchronizedStatus, error) {
-	m.ProcessNewTipCalled++
+	m.ProcessNewTipCalled.Add(1)
 	return nil, nil
 }

--- a/pkg/services/chaintracksclient/service.go
+++ b/pkg/services/chaintracksclient/service.go
@@ -45,6 +45,9 @@ func New(logger *slog.Logger, cfg *config.Config, opts ...Option) (*Adapter, err
 	}
 
 	if adapter.ct == nil {
+		if cfg == nil {
+			return nil, fmt.Errorf("chaintracks config is nil")
+		}
 		ct, err := cfg.Initialize(context.Background(), "wallet-toolbox", adapter.p2pClient)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize chaintracks: %w", err)
@@ -73,10 +76,15 @@ func (a *Adapter) subscribeToTipChan(ctx context.Context, cb func(*chaintracks.B
 	a.tipChan = a.ct.Subscribe(ctx)
 	go func() {
 		for header := range a.tipChan {
-			if cb != nil {
-				if err := cb(header); err != nil {
-					a.logger.Error("onTip callback failed", "height", header.Height, "hash", header.Hash.String(), "err", err)
-				}
+			if header == nil {
+				a.logger.Warn("received nil chaintracks tip")
+				continue
+			}
+			if err := cb(header); err != nil {
+				a.logger.Error("onTip callback failed",
+					"height", header.Height,
+					"hash", header.Hash.String(),
+					"err", err)
 			}
 		}
 	}()
@@ -93,14 +101,22 @@ func (a *Adapter) subscribeToReorgChan(ctx context.Context, cb func(*chaintracks
 	a.reorgChan = a.ct.SubscribeReorg(ctx)
 	go func() {
 		for reorgEvent := range a.reorgChan {
-			if cb != nil {
-				if err := cb(reorgEvent); err != nil {
-					a.logger.Error("onReorg callback failed",
-						"depth", reorgEvent.Depth,
-						"new tip hash", reorgEvent.NewTip.Hash.String(),
-						"orphaned hashes", reorgEvent.OrphanedHashes,
-						"err", err)
-				}
+			if reorgEvent == nil {
+				a.logger.Warn("received nil chaintracks reorg event")
+				continue
+			}
+			if reorgEvent.NewTip == nil {
+				a.logger.Warn("received chaintracks reorg event without new tip",
+					"depth", reorgEvent.Depth,
+					"orphaned hashes", reorgEvent.OrphanedHashes)
+				continue
+			}
+			if err := cb(reorgEvent); err != nil {
+				a.logger.Error("onReorg callback failed",
+					"depth", reorgEvent.Depth,
+					"new tip hash", reorgEvent.NewTip.Hash.String(),
+					"orphaned hashes", reorgEvent.OrphanedHashes,
+					"err", err)
 			}
 		}
 	}()
@@ -134,19 +150,7 @@ func (a *Adapter) GetHeight(ctx context.Context) uint32 {
 // GetTip returns the current chain tip
 func (a *Adapter) GetTip(ctx context.Context) (*wdk.ChainBlockHeader, error) {
 	tip := a.ct.GetTip(ctx)
-
-	return &wdk.ChainBlockHeader{
-		ChainBaseBlockHeader: wdk.ChainBaseBlockHeader{
-			Version:      uint32(tip.Version), //nolint:gosec // block header version is always small positive
-			PreviousHash: tip.PrevHash.String(),
-			MerkleRoot:   tip.MerkleRoot.String(),
-			Time:         tip.Timestamp,
-			Bits:         tip.Bits,
-			Nonce:        tip.Nonce,
-		},
-		Hash:   tip.Hash.String(),
-		Height: uint(tip.Height),
-	}, nil
+	return convertBlockHeader(tip, "tip header")
 }
 
 // GetHeaderByHeight retrieves a block header by its height
@@ -156,18 +160,7 @@ func (a *Adapter) GetHeaderByHeight(ctx context.Context, height uint32) (*wdk.Ch
 		return nil, fmt.Errorf("failed to get header by height %d: %w", height, err)
 	}
 
-	return &wdk.ChainBlockHeader{
-		ChainBaseBlockHeader: wdk.ChainBaseBlockHeader{
-			Version:      uint32(header.Version), //nolint:gosec // block header version is always small positive
-			PreviousHash: header.PrevHash.String(),
-			MerkleRoot:   header.MerkleRoot.String(),
-			Time:         header.Timestamp,
-			Bits:         header.Bits,
-			Nonce:        header.Nonce,
-		},
-		Hash:   header.Hash.String(),
-		Height: uint(header.Height),
-	}, nil
+	return convertBlockHeader(header, fmt.Sprintf("header at height %d", height))
 }
 
 // GetHeaderByHash retrieves a block header by its hash
@@ -180,6 +173,17 @@ func (a *Adapter) GetHeaderByHash(ctx context.Context, hash string) (*wdk.ChainB
 	header, err := a.ct.GetHeaderByHash(ctx, chainHash)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get header by hash %s: %w", hash, err)
+	}
+
+	return convertBlockHeader(header, fmt.Sprintf("header for hash %s", hash))
+}
+
+func convertBlockHeader(header *chaintracks.BlockHeader, description string) (*wdk.ChainBlockHeader, error) {
+	if header == nil {
+		return nil, fmt.Errorf("chaintracks returned no %s", description)
+	}
+	if header.Header == nil {
+		return nil, fmt.Errorf("chaintracks returned %s without block header", description)
 	}
 
 	return &wdk.ChainBlockHeader{

--- a/pkg/services/chaintracksclient/service_test.go
+++ b/pkg/services/chaintracksclient/service_test.go
@@ -269,6 +269,138 @@ func TestService_StartWithNilCallback(t *testing.T) {
 	require.NoError(t, err, "start with nil callback should not return error")
 }
 
+func TestService_GetTip_WhenChaintracksHasNoTip(t *testing.T) {
+	// given:
+	mockCT := testabilities.NewMockChaintracks()
+
+	service, err := chaintracksclient.New(
+		logging.NewTestLogger(t),
+		nil,
+		chaintracksclient.WithChaintracks(mockCT),
+	)
+	require.NoError(t, err)
+
+	// when:
+	tip, err := service.GetTip(t.Context())
+
+	// then:
+	require.Error(t, err)
+	require.Nil(t, tip)
+	assert.ErrorContains(t, err, "chaintracks returned no tip header")
+}
+
+func TestService_GetTip_WhenChaintracksTipHasNoBlockHeader(t *testing.T) {
+	// given:
+	mockCT := testabilities.NewMockChaintracks().
+		SetTip(&chaintracks.BlockHeader{})
+
+	service, err := chaintracksclient.New(
+		logging.NewTestLogger(t),
+		nil,
+		chaintracksclient.WithChaintracks(mockCT),
+	)
+	require.NoError(t, err)
+
+	// when:
+	tip, err := service.GetTip(t.Context())
+
+	// then:
+	require.Error(t, err)
+	require.Nil(t, tip)
+	assert.ErrorContains(t, err, "chaintracks returned tip header without block header")
+}
+
+func TestService_GetHeaderByHeight_WhenChaintracksHeaderHasNoBlockHeader(t *testing.T) {
+	// given:
+	mockCT := testabilities.NewMockChaintracks().
+		AddHeader(&chaintracks.BlockHeader{Height: 123})
+
+	service, err := chaintracksclient.New(
+		logging.NewTestLogger(t),
+		nil,
+		chaintracksclient.WithChaintracks(mockCT),
+	)
+	require.NoError(t, err)
+
+	// when:
+	header, err := service.GetHeaderByHeight(t.Context(), 123)
+
+	// then:
+	require.Error(t, err)
+	require.Nil(t, header)
+	assert.ErrorContains(t, err, "chaintracks returned header at height 123 without block header")
+}
+
+func TestService_GetHeaderByHash_WhenChaintracksHeaderHasNoBlockHeader(t *testing.T) {
+	// given:
+	hash, err := chainhash.NewHashFromHex("00000000000000000165924d2b7e41fd586d88e02f846ea6428d37c51f97db31")
+	require.NoError(t, err)
+	mockCT := testabilities.NewMockChaintracks().
+		AddHeader(&chaintracks.BlockHeader{Height: 123, Hash: *hash})
+
+	service, err := chaintracksclient.New(
+		logging.NewTestLogger(t),
+		nil,
+		chaintracksclient.WithChaintracks(mockCT),
+	)
+	require.NoError(t, err)
+
+	// when:
+	header, err := service.GetHeaderByHash(t.Context(), hash.String())
+
+	// then:
+	require.Error(t, err)
+	require.Nil(t, header)
+	assert.ErrorContains(t, err, "without block header")
+}
+
+func TestService_SkipsInvalidSubscriptionEvents(t *testing.T) {
+	// given:
+	mockCT := testabilities.NewMockChaintracks()
+	service, err := chaintracksclient.New(
+		logging.NewTestLogger(t),
+		nil,
+		chaintracksclient.WithChaintracks(mockCT),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	tipReceived := make(chan *chaintracks.BlockHeader, 1)
+	reorgReceived := make(chan *chaintracks.ReorgEvent, 1)
+
+	// when:
+	err = service.Start(ctx, chaintracksclient.Callbacks{
+		OnTip: func(header *chaintracks.BlockHeader) error {
+			tipReceived <- header
+			return nil
+		},
+		OnReorg: func(event *chaintracks.ReorgEvent) error {
+			reorgReceived <- event
+			return nil
+		},
+	})
+	require.NoError(t, err)
+
+	validTip := &chaintracks.BlockHeader{Header: &block.Header{}, Height: 124}
+	validReorg := &chaintracks.ReorgEvent{NewTip: validTip}
+	mockCT.SendTip(nil)
+	mockCT.SendReorg(nil)
+	time.Sleep(50 * time.Millisecond)
+	mockCT.SendReorg(&chaintracks.ReorgEvent{})
+	time.Sleep(50 * time.Millisecond)
+	mockCT.SendTip(validTip)
+	mockCT.SendReorg(validReorg)
+
+	// then:
+	require.Eventually(t, func() bool {
+		return len(tipReceived) == 1 && len(reorgReceived) == 1
+	}, 1*time.Second, 10*time.Millisecond)
+	assert.Equal(t, validTip, <-tipReceived)
+	assert.Equal(t, validReorg, <-reorgReceived)
+}
+
 func TestService_OnTipCallbackError(t *testing.T) {
 	// given:
 	mockCT := testabilities.NewMockChaintracks()

--- a/pkg/services/services_new_tip.go
+++ b/pkg/services/services_new_tip.go
@@ -47,11 +47,24 @@ func (t *tipBroadcaster) broadcast(tip *chaintracks.BlockHeader) {
 		select {
 		case sub <- tip:
 		default:
-			t.logger.Warn("new tip subscriber channel full, dropping event",
-				"tip hash", tip.Hash.String(),
-				"tip height", tip.Height,
-				"tip header", tip.String(),
-			)
+			t.logger.Warn("new tip subscriber channel full, dropping event", tipLogAttrs(tip)...)
 		}
+	}
+}
+
+func tipLogAttrs(tip *chaintracks.BlockHeader) []any {
+	if tip == nil {
+		return []any{"tip", nil}
+	}
+
+	header := any(nil)
+	if tip.Header != nil {
+		header = tip.String()
+	}
+
+	return []any{
+		"tip hash", tip.Hash.String(),
+		"tip height", tip.Height,
+		"tip header", header,
 	}
 }

--- a/pkg/services/services_new_tip_test.go
+++ b/pkg/services/services_new_tip_test.go
@@ -117,6 +117,32 @@ func TestTipBroadcaster_UnsubscribeStopsReceiving(t *testing.T) {
 	}
 }
 
+func TestTipBroadcaster_BroadcastNilTipToFullSubscriberDoesNotPanic(t *testing.T) {
+	// given:
+	broadcaster := newTipBroadcaster(slog.Default())
+	ch := make(chan *chaintracks.BlockHeader)
+	unsub := broadcaster.Subscribe(ch)
+	defer unsub()
+
+	// then:
+	require.NotPanics(t, func() {
+		broadcaster.broadcast(nil)
+	})
+}
+
+func TestTipBroadcaster_BroadcastTipWithoutBlockHeaderToFullSubscriberDoesNotPanic(t *testing.T) {
+	// given:
+	broadcaster := newTipBroadcaster(slog.Default())
+	ch := make(chan *chaintracks.BlockHeader)
+	unsub := broadcaster.Subscribe(ch)
+	defer unsub()
+
+	// then:
+	require.NotPanics(t, func() {
+		broadcaster.broadcast(&chaintracks.BlockHeader{})
+	})
+}
+
 func createTestBlockHeader(height uint32, hashStr string) *chaintracks.BlockHeader {
 	hash, _ := chainhash.NewHashFromHex(hashStr)
 	merkleRoot, _ := chainhash.NewHashFromHex("0000000000000000000000000000000000000000000000000000000000000000")

--- a/pkg/services/services_reorg.go
+++ b/pkg/services/services_reorg.go
@@ -47,9 +47,18 @@ func (b *reorgBroadcaster) broadcast(event *chaintracks.ReorgEvent) {
 		select {
 		case sub <- event:
 		default:
-			b.logger.Warn("reorg subscriber channel full, dropping event",
-				"depth", event.Depth,
-				"orphaned hashes", event.OrphanedHashes)
+			b.logger.Warn("reorg subscriber channel full, dropping event", reorgLogAttrs(event)...)
 		}
+	}
+}
+
+func reorgLogAttrs(event *chaintracks.ReorgEvent) []any {
+	if event == nil {
+		return []any{"reorg", nil}
+	}
+
+	return []any{
+		"depth", event.Depth,
+		"orphaned hashes", event.OrphanedHashes,
 	}
 }

--- a/pkg/services/services_reorg_test.go
+++ b/pkg/services/services_reorg_test.go
@@ -1,0 +1,35 @@
+package services
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/bsv-blockchain/go-chaintracks/chaintracks"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReorgBroadcaster_BroadcastNilEventToFullSubscriberDoesNotPanic(t *testing.T) {
+	// given:
+	broadcaster := newReorgBroadcaster(slog.Default())
+	ch := make(chan *chaintracks.ReorgEvent)
+	unsub := broadcaster.Subscribe(ch)
+	defer unsub()
+
+	// then:
+	require.NotPanics(t, func() {
+		broadcaster.broadcast(nil)
+	})
+}
+
+func TestReorgBroadcaster_BroadcastEventToFullSubscriberDoesNotPanic(t *testing.T) {
+	// given:
+	broadcaster := newReorgBroadcaster(slog.Default())
+	ch := make(chan *chaintracks.ReorgEvent)
+	unsub := broadcaster.Subscribe(ch)
+	defer unsub()
+
+	// then:
+	require.NotPanics(t, func() {
+		broadcaster.broadcast(&chaintracks.ReorgEvent{})
+	})
+}


### PR DESCRIPTION
This pull request introduces improvements to concurrency safety, error handling, and robustness in the monitoring and chaintracks client services. The changes focus on making the mock storage thread-safe, ensuring graceful handling of nil or incomplete data from chaintracks, and enhancing the resilience of event broadcasting to subscribers. Additional tests have been added to verify these behaviors.

Concurrency and thread safety improvements:
* Refactored the `MockStorage` struct in `mock_storage.go` to use `atomic.Int64` for all method call counters, ensuring thread-safe increments and reads. Updated all usages and assertions to use atomic operations. [[1]](diffhunk://#diff-bd6caba182a6d5eaa496e4095ce99e00fd2a04015d555486cb29a4947d84cb4dR5-R49) [[2]](diffhunk://#diff-9d50aa8659bd972f6204ed9bc021ea3aed6db689c8701568c24dcfab66778b70L77-R85) [[3]](diffhunk://#diff-f6224262a5a82a87d93e748916e94f4a103268c6383ca37d80773c2580155ec4L44-R44) [[4]](diffhunk://#diff-f6224262a5a82a87d93e748916e94f4a103268c6383ca37d80773c2580155ec4L54-R54) [[5]](diffhunk://#diff-f6224262a5a82a87d93e748916e94f4a103268c6383ca37d80773c2580155ec4L64-R64)

Robustness and error handling in chaintracks client:
* Added checks for nil config and nil or incomplete chaintracks data in `service.go`, returning descriptive errors when necessary. Extracted block header conversion logic into a helper function for reuse and clarity. [[1]](diffhunk://#diff-8d60001163b3c0272665a32fc1ec6c3bb30e998f271c0298a916ef7f8f583c5dR48-R50) [[2]](diffhunk://#diff-8d60001163b3c0272665a32fc1ec6c3bb30e998f271c0298a916ef7f8f583c5dL76-R87) [[3]](diffhunk://#diff-8d60001163b3c0272665a32fc1ec6c3bb30e998f271c0298a916ef7f8f583c5dL96-R113) [[4]](diffhunk://#diff-8d60001163b3c0272665a32fc1ec6c3bb30e998f271c0298a916ef7f8f583c5dL105) [[5]](diffhunk://#diff-8d60001163b3c0272665a32fc1ec6c3bb30e998f271c0298a916ef7f8f583c5dL137-R153) [[6]](diffhunk://#diff-8d60001163b3c0272665a32fc1ec6c3bb30e998f271c0298a916ef7f8f583c5dL159-R163) [[7]](diffhunk://#diff-8d60001163b3c0272665a32fc1ec6c3bb30e998f271c0298a916ef7f8f583c5dR178-R188)
* Improved subscription handling to skip and log nil or invalid tip and reorg events, preventing panics or unexpected errors. [[1]](diffhunk://#diff-8d60001163b3c0272665a32fc1ec6c3bb30e998f271c0298a916ef7f8f583c5dL76-R87) [[2]](diffhunk://#diff-8d60001163b3c0272665a32fc1ec6c3bb30e998f271c0298a916ef7f8f583c5dL96-R113)

Testing enhancements:
* Added comprehensive tests in `service_test.go` to verify correct error handling when chaintracks returns nil or incomplete headers, and to ensure invalid subscription events are skipped without affecting valid ones.
* Added tests in `services_new_tip_test.go` and a new test file `services_reorg_test.go` to confirm that broadcasting nil or incomplete events to full subscriber channels does not cause panics. [[1]](diffhunk://#diff-3e282c2451c4c2aaf7ef0a70d87594eab646f9cd7614a303ac0815aab42c4cd2R120-R145) [[2]](diffhunk://#diff-2dc96cf192b9af852cd7e92cbf25a5eef1515e86172dcf38374223a0054d45abR1-R35)

Logging improvements for event broadcasting:
* Refactored logging in tip and reorg broadcasters to use helper functions (`tipLogAttrs`, `reorgLogAttrs`) that handle nil values gracefully and provide structured logging attributes. [[1]](diffhunk://#diff-679e15990428bbd4978ddb3cdbec96dc5967d5beccf10bf925843ae2f618e5bbL50-R68) [[2]](diffhunk://#diff-58a1c6e3ca0abe22e1d2c7ef3a1255c63f237bc40b6c50f76df199a2e123ae09L50-R63)

These changes collectively increase the reliability and maintainability of the monitoring and chaintracks client components, especially under concurrent or error-prone scenarios.