### PR TITLE
fix: sequence number

### DIFF
--- a/pkg/internal/assembler/create_action_tx_assembler.go
+++ b/pkg/internal/assembler/create_action_tx_assembler.go
@@ -176,7 +176,7 @@ func (a *CreateActionTransactionAssembler) toTxInputFromArgs(it *wdk.StorageCrea
 		SourceTXID:        &argsInput.Outpoint.Txid,
 		SourceTxOutIndex:  argsInput.Outpoint.Index,
 		UnlockingScript:   script.NewFromBytes(argsInput.UnlockingScript),
-		SequenceNumber:    to.Value(argsInput.SequenceNumber),
+		SequenceNumber:    to.ValueOr(argsInput.SequenceNumber, transaction.DefaultSequenceNumber),
 		SourceTransaction: sourceTx,
 	}, nil
 }

--- a/pkg/internal/assembler/sequence_number_test.go
+++ b/pkg/internal/assembler/sequence_number_test.go
@@ -1,0 +1,51 @@
+package assembler_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	sdk "github.com/bsv-blockchain/go-sdk/wallet"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/assembler"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/tsgenerated"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
+)
+
+func TestSequenceNumberDefaultsToMaxUint32(t *testing.T) {
+	// given:
+	keyDeriver := givenKeyDeriver(t, testusers.Alice)
+	
+	// Create a storage result with at least one input. We use the generated one for convenience.
+	var createActionResult wdk.StorageCreateActionResult
+	err := json.Unmarshal([]byte(tsgenerated.CreateActionResultJSON()), &createActionResult)
+	require.NoError(t, err)
+
+	// provide args inputs so that it goes through the user-provided args path
+	// The generated JSON has an input at Vin=0. We'll match its Txid and Outpoint.
+	storageInput := createActionResult.Inputs[0]
+	
+	hash, _ := chainhash.NewHashFromHex(storageInput.SourceTxID)
+
+	providedInputs := []sdk.CreateActionInput{
+		{
+			Outpoint: transaction.Outpoint{
+				Txid:  *hash,
+				Index: storageInput.SourceVout,
+			},
+			SequenceNumber: nil, // This should default to 0xffffffff
+		},
+	}
+
+	// when:
+	assembled, err := assembler.NewCreateActionTransactionAssembler(keyDeriver, providedInputs, &createActionResult).Assemble()
+
+	// then:
+	require.NoError(t, err)
+
+	// verify that the input sequence number defaulted correctly
+	require.Equal(t, transaction.DefaultSequenceNumber, assembled.Transaction.Inputs[0].SequenceNumber)
+}

--- a/pkg/internal/assembler/sequence_number_test.go
+++ b/pkg/internal/assembler/sequence_number_test.go
@@ -4,21 +4,21 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/bsv-blockchain/go-sdk/transaction"
 	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/transaction"
 	sdk "github.com/bsv-blockchain/go-sdk/wallet"
 	"github.com/stretchr/testify/require"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/assembler"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/tsgenerated"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
-	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
 )
 
 func TestSequenceNumberDefaultsToMaxUint32(t *testing.T) {
 	// given:
 	keyDeriver := givenKeyDeriver(t, testusers.Alice)
-	
+
 	// Create a storage result with at least one input. We use the generated one for convenience.
 	var createActionResult wdk.StorageCreateActionResult
 	err := json.Unmarshal([]byte(tsgenerated.CreateActionResultJSON()), &createActionResult)
@@ -27,7 +27,7 @@ func TestSequenceNumberDefaultsToMaxUint32(t *testing.T) {
 	// provide args inputs so that it goes through the user-provided args path
 	// The generated JSON has an input at Vin=0. We'll match its Txid and Outpoint.
 	storageInput := createActionResult.Inputs[0]
-	
+
 	hash, _ := chainhash.NewHashFromHex(storageInput.SourceTxID)
 
 	providedInputs := []sdk.CreateActionInput{


### PR DESCRIPTION
## What Changed

Fixes an issue where transaction inputs provided by users via `CreateAction` without an explicit `SequenceNumber` were being assigned a default sequence number of `0` during transaction assembly. 
The transaction assembler previously relied on `to.Value()` which implicitly fell back to the `uint32` zero-value. This was incorrect for sequence numbers and resulted in an asymmetry between storage-managed inputs (which correctly received `0xffffffff`) and user-provided inputs.
### Changes
- Updated `create_action_tx_assembler.go` to use `to.ValueOr` to ensure `SequenceNumber` correctly defaults to `transaction.DefaultSequenceNumber` (`0xffffffff`) when absent.
- Added `sequence_number_test.go` to explicitly verify this defaulting behavior.

## Why It Was Necessary
-

## Testing Performed
- [x] Full `go-wallet-toolbox` test suite run via `go test ./...`.
- [x] Added specific unit test verifying that `nil` sequence inputs correctly default to `0xffffffff`.

## Impact / Risk
-

## Notifications
- @username
