### PR TITLE
fix: CreateAction incorrectly reorders inputs and assumes their position

### DIFF
--- a/pkg/internal/assembler/create_action_tx_assembler.go
+++ b/pkg/internal/assembler/create_action_tx_assembler.go
@@ -17,19 +17,26 @@ import (
 )
 
 type CreateActionTransactionAssembler struct {
-	tx                 *transaction.Transaction
-	keyDeriver         *wallet.KeyDeriver
-	createActionResult *wdk.StorageCreateActionResult
-	providedInputs     []wallet.CreateActionInput
-	inputBEEF          *transaction.Beef
+	tx                        *transaction.Transaction
+	keyDeriver                *wallet.KeyDeriver
+	createActionResult        *wdk.StorageCreateActionResult
+	providedInputs            []wallet.CreateActionInput
+	providedInputsByOutpoint  map[string]wallet.CreateActionInput
+	inputBEEF                 *transaction.Beef
 }
 
 func NewCreateActionTransactionAssembler(keyDeriver *wallet.KeyDeriver, providedInputs []wallet.CreateActionInput, createActionResult *wdk.StorageCreateActionResult) *CreateActionTransactionAssembler {
+	byOutpoint := make(map[string]wallet.CreateActionInput, len(providedInputs))
+	for _, inp := range providedInputs {
+		key := fmt.Sprintf("%s.%d", inp.Outpoint.Txid.String(), inp.Outpoint.Index)
+		byOutpoint[key] = inp
+	}
 	return &CreateActionTransactionAssembler{
-		keyDeriver:         keyDeriver,
-		createActionResult: createActionResult,
-		providedInputs:     providedInputs,
-		tx:                 &transaction.Transaction{},
+		keyDeriver:               keyDeriver,
+		createActionResult:       createActionResult,
+		providedInputs:           providedInputs,
+		providedInputsByOutpoint: byOutpoint,
+		tx:                       &transaction.Transaction{},
 	}
 }
 
@@ -161,19 +168,16 @@ func (a *CreateActionTransactionAssembler) toTxInputFromManagedInput(it *wdk.Sto
 }
 
 func (a *CreateActionTransactionAssembler) toTxInputFromArgs(it *wdk.StorageCreateTransactionSdkInput, sourceTxID *chainhash.Hash) (*transaction.TransactionInput, error) {
-	if it.Vin < 0 {
-		return nil, fmt.Errorf("unexpected negative input index %d", it.Vin)
-	}
-
-	argsInput := a.providedInputs[it.Vin]
-	if !argsInput.Outpoint.Txid.Equal(*sourceTxID) || argsInput.Outpoint.Index != it.SourceVout {
-		return nil, fmt.Errorf("unexpected input (outpoint: %s.%d) on index %d", it.SourceTxID, it.SourceVout, it.Vin)
+	key := fmt.Sprintf("%s.%d", it.SourceTxID, it.SourceVout)
+	argsInput, ok := a.providedInputsByOutpoint[key]
+	if !ok {
+		return nil, fmt.Errorf("unexpected input (outpoint: %s) not found in provided inputs", key)
 	}
 
 	sourceTx := a.inputBEEF.FindTransaction(it.SourceTxID)
 
 	return &transaction.TransactionInput{
-		SourceTXID:        &argsInput.Outpoint.Txid,
+		SourceTXID:        sourceTxID,
 		SourceTxOutIndex:  argsInput.Outpoint.Index,
 		UnlockingScript:   script.NewFromBytes(argsInput.UnlockingScript),
 		SequenceNumber:    to.ValueOr(argsInput.SequenceNumber, transaction.DefaultSequenceNumber),
@@ -182,7 +186,9 @@ func (a *CreateActionTransactionAssembler) toTxInputFromArgs(it *wdk.StorageCrea
 }
 
 func (a *CreateActionTransactionAssembler) isInputFromArgs(it *wdk.StorageCreateTransactionSdkInput) bool {
-	return len(a.providedInputs) > it.Vin
+	key := fmt.Sprintf("%s.%d", it.SourceTxID, it.SourceVout)
+	_, ok := a.providedInputsByOutpoint[key]
+	return ok
 }
 
 func (a *CreateActionTransactionAssembler) parseInputBEEF() error {

--- a/pkg/internal/assembler/create_action_tx_assembler.go
+++ b/pkg/internal/assembler/create_action_tx_assembler.go
@@ -17,12 +17,12 @@ import (
 )
 
 type CreateActionTransactionAssembler struct {
-	tx                        *transaction.Transaction
-	keyDeriver                *wallet.KeyDeriver
-	createActionResult        *wdk.StorageCreateActionResult
-	providedInputs            []wallet.CreateActionInput
-	providedInputsByOutpoint  map[string]wallet.CreateActionInput
-	inputBEEF                 *transaction.Beef
+	tx                       *transaction.Transaction
+	keyDeriver               *wallet.KeyDeriver
+	createActionResult       *wdk.StorageCreateActionResult
+	providedInputs           []wallet.CreateActionInput
+	providedInputsByOutpoint map[string]wallet.CreateActionInput
+	inputBEEF                *transaction.Beef
 }
 
 func NewCreateActionTransactionAssembler(keyDeriver *wallet.KeyDeriver, providedInputs []wallet.CreateActionInput, createActionResult *wdk.StorageCreateActionResult) *CreateActionTransactionAssembler {


### PR DESCRIPTION
## BUG in CreateAction()
In `create.go:resultInputs()`, storage re-orders inputs — all unknown inputs first (vin=0,1,…), then known inputs — regardless of the original order the caller provided them.

The assembler in `create_action_tx_assembler.go:isInputFromArgs()` assumes `providedInputs[Vin]` is the matching input for a given storage result entry, which only works if `Vin` corresponds positionally to the original caller-provided slice.

Scenario that breaks: caller provides `[knownInput, unknownInput]`
- Storage assigns `Vin=0 → unknownInput, Vin=1 → knownInput`
- Assembler checks `providedInputs[0]` (= `knownInput`) against `Vin=0` entry (= `unknownInput`) → mismatch → error

## Solution
1. Added `providedInputsByOutpoint map[string]wallet.CreateActionInput` to the struct — a map keyed by `"txid.vout"` built at construction time from `providedInputs`.
2. `isInputFromArgs()` now checks if the storage input's outpoint exists in the map, instead of using `it.Vin` as a positional index into `providedInputs`.
3. `toTxInputFromArgs()` now looks up the provided input by outpoint from the map, instead of using `providedInputs[it.Vin]`.

## Why this fixes the bug
Storage's `resultInputs()` re-orders inputs — all unknown inputs get assigned `Vin=0,1,…` first, then known inputs follow. This broke the assembler's assumption that `providedInputs[Vin]` is the matching input for a storage result entry at that `Vin`. The fix eliminates the positional assumption entirely by matching on outpoint identity instead.


