### PR TITLE
fix: Check if BUMP idx exists before merging rawTx to BEEF

### DIFF
--- a/pkg/internal/assembler/assembled_transaction.go
+++ b/pkg/internal/assembler/assembled_transaction.go
@@ -55,13 +55,16 @@ func (a *AssembledTransaction) ToAtomicBEEF(allowPartials bool) (*transaction.Be
 		})
 	}
 
-	inputsRawTx := seqerr.Map(inputsWithSourceTx, inputRawTxBytes)
+	inputSourceTxs := seqerr.Map(inputsWithSourceTx, inputSourceTransaction)
 
-	allRawTxs := seqerr.Append(inputsRawTx, a.Bytes())
-
-	err = seqerr.ForEach(allRawTxs, mergeRawTxIntoBEEF(beef))
+	err = seqerr.ForEach(inputSourceTxs, mergeSourceTxIntoBEEF(beef))
 	if err != nil {
 		return nil, fmt.Errorf("failed to build beef from tx, %w", err)
+	}
+
+	_, err = beef.MergeRawTx(a.Bytes(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot merge new tx into beef: %w", err)
 	}
 
 	return beef, nil
@@ -74,13 +77,19 @@ func validateInputs(input *transaction.TransactionInput) error {
 	return nil
 }
 
-func inputRawTxBytes(input *transaction.TransactionInput) []byte {
-	return input.SourceTransaction.Bytes()
+func inputSourceTransaction(input *transaction.TransactionInput) *transaction.Transaction {
+	return input.SourceTransaction
 }
 
-func mergeRawTxIntoBEEF(beef *transaction.Beef) func([]byte) error {
-	return func(rawTx []byte) error {
-		_, err := beef.MergeRawTx(rawTx, nil)
+func mergeSourceTxIntoBEEF(beef *transaction.Beef) func(*transaction.Transaction) error {
+	return func(tx *transaction.Transaction) error {
+		txid := tx.TxID()
+		var bumpIndex *int
+		if existing, ok := beef.Transactions[*txid]; ok && existing.DataFormat == transaction.RawTxAndBumpIndex {
+			idx := existing.BumpIndex
+			bumpIndex = &idx
+		}
+		_, err := beef.MergeRawTx(tx.Bytes(), bumpIndex)
 		if err != nil {
 			return fmt.Errorf("cannot merge raw tx into beef: %w", err)
 		}


### PR DESCRIPTION
## The Bug

After doing SignAction() the returned AtomicBEEF is missing a BUMP index for one or more transactions in the BEEF. This causes issues when Internalizing that AtomicBEEF on a remote wallet that is a receiver of that transaction. The example error reads:

```
failed to internalize action: failed to process internalizeAction: failed to hydrate beef for script verification: failed to hydrate input aa55f5122414d4748b47f30573809dad694bc5b6cf52c7311cf43a32432b9b85 of tx a371d51c788bac255d698f5d175c06124145fcaa3597d8e741c55853d78a233d: could not find transaction aa55f5122414d4748b47f30573809dad694bc5b6cf52c7311cf43a32432b9b85 in beef
```

## Why it happens

In `ToAtomicBEEF`, the following two operations happen in sequence:

1. **`beef.MergeBeef(a.inputBEEF)`** — correctly merges all ancestor transactions with their BUMPs, setting `BeefTx.DataFormat = RawTxAndBumpIndex` with the proper `BumpIndex` for each proven tx.

2. **`mergeRawTxIntoBEEF`** — iterates over inputs that have a `SourceTransaction` and calls `beef.MergeRawTx(rawTx, nil)` for each.
   - `MergeRawTx` calls **`b.RemoveExistingTxid(txid)`** first, which **deletes** the correctly-linked `BeefTx` entry just set up in step 1.
   - A new `BeefTx` is created with `DataFormat = RawTx` (no BUMP link), because `bumpIndex` is always passed as `nil`.
   - The BUMP still exists in `beef.BUMPs`, but the tx→BUMP linkage is now broken.

## Key Locations

| File | Line | What |
|------|------|------|
| `pkg/internal/assembler/assembled_transaction.go` | ~42 | `beef.MergeBeef(a.inputBEEF)` — correct merge with BUMPs |
| `pkg/internal/assembler/assembled_transaction.go` | ~83 | `beef.MergeRawTx(rawTx, nil)` — **root cause**: `nil` bumpIndex clobbers prior merge |
| `go-sdk/.../transaction/beef.go` | ~690 | `b.RemoveExistingTxid(txid)` — removes the existing entry before re-adding without BUMP |

## Root Cause

`assembled_transaction.go:83` always passes `nil` for `bumpIndex` in `MergeRawTx`. Since `MergeRawTx` removes the existing entry before inserting the new one, any ancestor tx that was already correctly linked to its BUMP (by `MergeBeef`) gets replaced with a BUMP-less `BeefTx`.

The fix would be: either skip re-merging a raw tx if it's already present in the BEEF with a BUMP, or look up whether the tx has a BUMP in the existing BEEF before calling `MergeRawTx` and pass the correct `bumpIndex` instead of `nil`.

## The fix

**`assembled_transaction.go`** — replaced the `[]byte`-based pipeline with a `*transaction.Transaction`-based one for input source txs:

- `inputRawTxBytes` → `inputSourceTransaction` — passes the `*Transaction` object through instead of serialized bytes, so we have access to `TxID()` without re-parsing.
- `mergeRawTxIntoBEEF` → `mergeSourceTxIntoBEEF` — before calling `MergeRawTx`, looks up the txid in `beef.Transactions`; if an entry with `DataFormat == RawTxAndBumpIndex` exists (set by the earlier `MergeBeef`), its `BumpIndex` is passed through instead of `nil`, preserving the BUMP linkage.
- The new tx itself (`a.Bytes()`) is merged separately after the loop with `nil`, which is correct since it's never mined.