### PR TITLE
fix: remove unsigned tx from atomic beef

### DIFF
--- a/pkg/internal/assembler/assembled_transaction.go
+++ b/pkg/internal/assembler/assembled_transaction.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"iter"
 
+	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/bsv-blockchain/go-sdk/transaction"
 	"github.com/go-softwarelab/common/pkg/seqerr"
 
@@ -13,13 +14,15 @@ import (
 type AssembledTransaction struct {
 	*transaction.Transaction
 
-	inputBEEF *transaction.Beef
+	inputBEEF    *transaction.Beef
+	initialTxID *chainhash.Hash
 }
 
 func NewAssembledTxFromPendingSignAction(pendingSignAction *pending.SignAction) *AssembledTransaction {
 	return &AssembledTransaction{
-		Transaction: &pendingSignAction.Tx,
-		inputBEEF:   pendingSignAction.InputBEEF,
+		Transaction:  &pendingSignAction.Tx,
+		inputBEEF:    pendingSignAction.InputBEEF,
+		initialTxID: pendingSignAction.Tx.TxID(),
 	}
 }
 
@@ -42,6 +45,10 @@ func (a *AssembledTransaction) ToAtomicBEEF(allowPartials bool) (*transaction.Be
 	err := beef.MergeBeef(a.inputBEEF)
 	if err != nil {
 		return nil, fmt.Errorf("failed to merge input beef into transaction beef: %w", err)
+	}
+
+	if a.initialTxID != nil {
+		delete(beef.Transactions, *a.initialTxID)
 	}
 
 	allInputs := seqerr.FromSlice(a.Inputs)

--- a/pkg/internal/assembler/assembled_transaction.go
+++ b/pkg/internal/assembler/assembled_transaction.go
@@ -14,14 +14,14 @@ import (
 type AssembledTransaction struct {
 	*transaction.Transaction
 
-	inputBEEF    *transaction.Beef
+	inputBEEF   *transaction.Beef
 	initialTxID *chainhash.Hash
 }
 
 func NewAssembledTxFromPendingSignAction(pendingSignAction *pending.SignAction) *AssembledTransaction {
 	return &AssembledTransaction{
-		Transaction:  &pendingSignAction.Tx,
-		inputBEEF:    pendingSignAction.InputBEEF,
+		Transaction: &pendingSignAction.Tx,
+		inputBEEF:   pendingSignAction.InputBEEF,
 		initialTxID: pendingSignAction.Tx.TxID(),
 	}
 }

--- a/pkg/internal/assembler/assembled_transaction_test.go
+++ b/pkg/internal/assembler/assembled_transaction_test.go
@@ -1,0 +1,42 @@
+package assembler_test
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/stretchr/testify/require"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/assembler"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/pending"
+)
+
+func TestToAtomicBEEF_RemovesUnsignedTx(t *testing.T) {
+	// Create a transaction
+	tx := &transaction.Transaction{Version: 1}
+	unsignedID := tx.TxID()
+
+	// Create a BEEF and add the unsigned transaction to it
+	beef := transaction.NewBeef()
+	_, err := beef.MergeRawTx(tx.Bytes(), nil)
+	require.NoError(t, err)
+	require.Contains(t, beef.Transactions, *unsignedID)
+
+	// Create AssembledTransaction from pending action
+	pAction := &pending.SignAction{
+		Tx:        *tx,
+		InputBEEF: beef,
+	}
+	assembled := assembler.NewAssembledTxFromPendingSignAction(pAction)
+
+	// Now "sign" the transaction (simulated by changing something that changes TXID)
+	assembled.Transaction.LockTime = 12345
+	signedID := assembled.Transaction.TxID()
+	require.NotEqual(t, unsignedID, signedID)
+
+	// Generate BEEF
+	finalBeef, err := assembled.ToAtomicBEEF(true)
+	require.NoError(t, err)
+
+	// Final BEEF should not contain the unsigned TXID
+	require.Contains(t, finalBeef.Transactions, *signedID)
+	require.NotContains(t, finalBeef.Transactions, *unsignedID, "Final BEEF should NOT contain the unsigned transaction ID")
+}

--- a/pkg/internal/assembler/assembled_transaction_test.go
+++ b/pkg/internal/assembler/assembled_transaction_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bsv-blockchain/go-sdk/transaction"
 	"github.com/stretchr/testify/require"
+
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/assembler"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/pending"
 )

--- a/pkg/internal/assembler/assembled_transaction_test.go
+++ b/pkg/internal/assembler/assembled_transaction_test.go
@@ -29,8 +29,8 @@ func TestToAtomicBEEF_RemovesUnsignedTx(t *testing.T) {
 	assembled := assembler.NewAssembledTxFromPendingSignAction(pAction)
 
 	// Now "sign" the transaction (simulated by changing something that changes TXID)
-	assembled.Transaction.LockTime = 12345
-	signedID := assembled.Transaction.TxID()
+	assembled.LockTime = 12345
+	signedID := assembled.TxID()
 	require.NotEqual(t, unsignedID, signedID)
 
 	// Generate BEEF

--- a/pkg/internal/assembler/create_action_tx_assembler.go
+++ b/pkg/internal/assembler/create_action_tx_assembler.go
@@ -58,7 +58,9 @@ func (a *CreateActionTransactionAssembler) Assemble() (*AssembledTransaction, er
 		return nil, err
 	}
 
-	return &AssembledTransaction{Transaction: a.tx, inputBEEF: a.inputBEEF}, nil
+	assembled := &AssembledTransaction{Transaction: a.tx, inputBEEF: a.inputBEEF}
+	assembled.initialTxID = assembled.TxID()
+	return assembled, nil
 }
 
 func (a *CreateActionTransactionAssembler) fillTransactionHeader() {


### PR DESCRIPTION
## What Changed
- Modified `AssembledTransaction` struct to store `initialTxID` (the TXID of the unsigned transaction).
- Updated `NewAssembledTxFromPendingSignAction` to capture the TXID from the pending transaction before signing.
- Updated `ToAtomicBEEF` in `pkg/internal/assembler/assembled_transaction.go` to explicitly delete the `initialTxID` from the BEEF map after merging the input BEEF and before adding the final signed transaction.
- Added a reproduction test case in `pkg/internal/assembler/assembled_transaction_test.go`.

## Why It Was Necessary
- **Bug:** During `SignAction`, the toolbox merged the `inputBEEF` (containing the unsigned transaction from `CreateAction`) with the new signed transaction bytes.
- **Root Cause:** Since the signed transaction has a different TXID than the unsigned one, the resulting BEEF contained *both* versions.
- **Consequence:** `InternalizeAction` attempts to verify scripts for all transactions in a BEEF. The presence of the unsigned transaction (which lacks valid unlocking scripts) caused script verification failures and prevented successful internalization of signed transactions.

## Testing Performed
- **Unit Test:** Created `TestToAtomicBEEF_RemovesUnsignedTx` which confirms that the unsigned TXID is no longer present in the final Atomic BEEF.
- **Integration Tests:** Verified that the wallet flow (`SignAction` -> `Internalize`) passes without script verification errors.
- **Regression:** Ran `go test ./pkg/wallet/...` to ensure no impact on existing signing logic.

## Impact / Risk
- **Low Risk:** The change only affects the construction of the Atomic BEEF during the signing phase by ensuring the subject transaction is not duplicated.
- **Impact:** Fixes a critical blocker where signed transactions could not be internalized due to BEEF corruption.


> It is still waiting for testing in battle
