### PR TITLE
fix(sync): BRC-40 stale-chunk guard on syncrepo upserts (#853)

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -1,0 +1,46 @@
+# Cross-impl conformance vectors
+
+Vendored copies of BRC conformance vectors maintained in
+[`bsv-blockchain/ts-stack`](https://github.com/bsv-blockchain/ts-stack)
+under `conformance/vectors/`. Each vector subdir ships a small Go package
+exposing the JSON via `go:embed` (e.g. `conformance/vectors/sync/sync.go`).
+Test runners import that package — no filesystem paths, no `runtime.Caller`,
+no sibling-repo checkout. Tests stay hermetic, work identically for every
+cloner.
+
+## Why vendor?
+
+- **Determinism** — every commit in this repo pins the exact vector revision
+  the code passes against.
+- **Offline / CI hermeticity** — no GitHub fetch during `go test`.
+- **Diffability** — vector changes show up in PR review.
+
+## Refreshing
+
+Use the helper script:
+
+```sh
+./conformance/scripts/refresh-vectors.sh           # pull latest from ts-stack main
+./conformance/scripts/refresh-vectors.sh <sha>     # pin to specific upstream commit
+```
+
+The script:
+
+1. Resolves the upstream commit SHA (default: `main` tip).
+2. Downloads each tracked vector from `raw.githubusercontent.com`.
+3. Updates `conformance/SOURCE` with the pinned SHA + timestamp.
+
+Re-run the test suite after refresh:
+
+```sh
+go test ./pkg/internal/storage/repo/syncrepo/... -run TestBRC40Conformance -v
+```
+
+If new vectors land that the Go impl doesn't satisfy, fix the impl or open an
+issue tagged with the failing vector ID.
+
+## Tracked vector files
+
+| Path                                  | Upstream                                                                |
+|---------------------------------------|-------------------------------------------------------------------------|
+| `vectors/sync/brc40-user-state.json`  | `conformance/vectors/sync/brc40-user-state.json` in `ts-stack`          |

--- a/conformance/SOURCE
+++ b/conformance/SOURCE
@@ -1,0 +1,6 @@
+# Upstream conformance vector pin.
+# Update via ./conformance/scripts/refresh-vectors.sh
+upstream_repo=bsv-blockchain/ts-stack
+upstream_sha=1920a9c1b34010ff7ede34e424f0fca19b2ed3e6
+upstream_ref=1920a9c1b34010ff7ede34e424f0fca19b2ed3e6
+fetched_at=2026-05-14

--- a/conformance/scripts/refresh-vectors.sh
+++ b/conformance/scripts/refresh-vectors.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Refresh vendored BRC conformance vectors from upstream ts-stack.
+#
+# Usage:
+#   ./conformance/scripts/refresh-vectors.sh             # latest main
+#   ./conformance/scripts/refresh-vectors.sh <sha|ref>   # pin to specific commit/ref
+
+set -euo pipefail
+
+UPSTREAM_REPO="bsv-blockchain/ts-stack"
+DEFAULT_REF="main"
+REF="${1:-$DEFAULT_REF}"
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SOURCE_FILE="$ROOT_DIR/SOURCE"
+
+# Tracked vector paths — keep in sync with conformance/README.md.
+VECTOR_PATHS=(
+  "vectors/sync/brc40-user-state.json"
+)
+
+# Resolve ref → full commit SHA so the pin is immutable.
+SHA="$(curl -sSL \
+  -H 'Accept: application/vnd.github+json' \
+  "https://api.github.com/repos/${UPSTREAM_REPO}/commits/${REF}" \
+  | sed -n 's/^[[:space:]]*"sha":[[:space:]]*"\([0-9a-f]\{40\}\)".*/\1/p' \
+  | head -n1)"
+
+if [[ -z "$SHA" ]]; then
+  echo "ERROR: could not resolve $UPSTREAM_REPO@$REF to a commit SHA" >&2
+  exit 1
+fi
+
+echo "Pinning to ${UPSTREAM_REPO}@${SHA} (ref: ${REF})"
+
+for path in "${VECTOR_PATHS[@]}"; do
+  url="https://raw.githubusercontent.com/${UPSTREAM_REPO}/${SHA}/conformance/${path}"
+  dest="$ROOT_DIR/$path"
+  mkdir -p "$(dirname "$dest")"
+  echo "  $path"
+  curl -fsSL "$url" -o "$dest"
+done
+
+cat > "$SOURCE_FILE" <<EOF
+# Upstream conformance vector pin.
+# Update via ./conformance/scripts/refresh-vectors.sh
+upstream_repo=${UPSTREAM_REPO}
+upstream_sha=${SHA}
+upstream_ref=${REF}
+fetched_at=$(date -u +%Y-%m-%d)
+EOF
+
+echo "Done. Re-run: go test ./pkg/internal/storage/repo/syncrepo/... -v"

--- a/conformance/vectors/sync/brc40-user-state.json
+++ b/conformance/vectors/sync/brc40-user-state.json
@@ -1,0 +1,711 @@
+{
+  "$schema": "../../schema/vector.schema.json",
+  "id": "sync.brc40",
+  "name": "BRC-40 — User Wallet Data Synchronization (request/response shape + protocol flow)",
+  "brc": ["BRC-40"],
+  "version": "0.1.0",
+  "reference_impl": "packages/wallet/wallet-toolbox/src/storage/methods/getSyncChunk.ts@2.1.25",
+  "parity_class": "intended",
+  "vectors": [
+    {
+      "id": "sync.brc40.request.1",
+      "description": "RequestSyncChunkArgs — minimum valid full-sync request (no `since`, single zero offset for ProvenTxs)",
+      "input": {
+        "channel": "brc40/requestSyncChunk",
+        "message": {
+          "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+          "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+          "identityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc",
+          "maxRoughSize": 10000000,
+          "maxItems": 1000,
+          "offsets": [{ "name": "ProvenTxs", "offset": 0 }]
+        }
+      },
+      "expected": {
+        "valid": true,
+        "schema_note": "RequestSyncChunkArgs: { fromStorageIdentityKey: string, toStorageIdentityKey: string, identityKey: string, since?: ISO-8601 string, maxRoughSize: integer >= 1, maxItems: integer >= 1, offsets: { name: string, offset: integer >= 0 }[] }. Omitting `since` means full sync from epoch."
+      },
+      "tags": ["brc40", "sync", "happy-path", "request", "full-sync"]
+    },
+    {
+      "id": "sync.brc40.request.2",
+      "description": "RequestSyncChunkArgs — incremental sync with ISO-8601 `since` and all 12 entity offsets in dependency order",
+      "input": {
+        "channel": "brc40/requestSyncChunk",
+        "message": {
+          "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+          "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+          "identityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc",
+          "since": "2026-04-23T12:34:56.789Z",
+          "maxRoughSize": 10000000,
+          "maxItems": 1000,
+          "offsets": [
+            { "name": "ProvenTxs", "offset": 0 },
+            { "name": "ProvenTxReqs", "offset": 0 },
+            { "name": "OutputBaskets", "offset": 0 },
+            { "name": "TxLabels", "offset": 0 },
+            { "name": "OutputTags", "offset": 0 },
+            { "name": "Transactions", "offset": 0 },
+            { "name": "TxLabelMaps", "offset": 0 },
+            { "name": "Commissions", "offset": 0 },
+            { "name": "Outputs", "offset": 0 },
+            { "name": "OutputTagMaps", "offset": 0 },
+            { "name": "Certificates", "offset": 0 },
+            { "name": "CertificateFields", "offset": 0 }
+          ]
+        }
+      },
+      "expected": {
+        "valid": true,
+        "schema_note": "Entity dependency order per BRC-40 §request.offsets matches RequestSyncChunkArgs.offsets in WalletStorage.interfaces.ts:524-537. `since` is inclusive lower bound on updated_at."
+      },
+      "tags": ["brc40", "sync", "happy-path", "request", "incremental", "pagination"]
+    },
+    {
+      "id": "sync.brc40.request.3",
+      "description": "RequestSyncChunkArgs — resume mid-stream with non-zero offset on Transactions and Outputs",
+      "input": {
+        "channel": "brc40/requestSyncChunk",
+        "message": {
+          "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+          "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+          "identityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc",
+          "since": "2026-04-23T12:34:56.789Z",
+          "maxRoughSize": 5000000,
+          "maxItems": 500,
+          "offsets": [
+            { "name": "Transactions", "offset": 1500 },
+            { "name": "Outputs", "offset": 3200 }
+          ]
+        }
+      },
+      "expected": {
+        "valid": true,
+        "schema_note": "Resumable pagination — consumer carries the last offset per entity across requests until SyncChunk arrays return empty (completion)."
+      },
+      "tags": ["brc40", "sync", "happy-path", "request", "resume"]
+    },
+    {
+      "id": "sync.brc40.request.error.1",
+      "description": "RequestSyncChunkArgs missing fromStorageIdentityKey — producer must reject",
+      "input": {
+        "channel": "brc40/requestSyncChunk",
+        "message": {
+          "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+          "identityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc",
+          "maxRoughSize": 10000000,
+          "maxItems": 1000,
+          "offsets": []
+        }
+      },
+      "expected": {
+        "valid": false,
+        "error": { "code": "ERR_BRC40_MISSING_FIELD", "field": "fromStorageIdentityKey" },
+        "schema_note": "All three identityKey fields are required."
+      },
+      "tags": ["brc40", "sync", "error-case", "request", "validation"]
+    },
+    {
+      "id": "sync.brc40.request.error.2",
+      "description": "RequestSyncChunkArgs missing identityKey — producer must reject (no user scope)",
+      "input": {
+        "channel": "brc40/requestSyncChunk",
+        "message": {
+          "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+          "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+          "maxRoughSize": 10000000,
+          "maxItems": 1000,
+          "offsets": []
+        }
+      },
+      "expected": {
+        "valid": false,
+        "error": { "code": "ERR_BRC40_MISSING_FIELD", "field": "identityKey" }
+      },
+      "tags": ["brc40", "sync", "error-case", "request", "validation"]
+    },
+    {
+      "id": "sync.brc40.request.error.3",
+      "description": "RequestSyncChunkArgs unknown identityKey — producer must reject with ERR_BRC40_UNKNOWN_USER",
+      "input": {
+        "channel": "brc40/requestSyncChunk",
+        "message": {
+          "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+          "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+          "identityKey": "02deadbeef000000000000000000000000000000000000000000000000deadbeef",
+          "maxRoughSize": 10000000,
+          "maxItems": 1000,
+          "offsets": []
+        }
+      },
+      "expected": {
+        "valid": false,
+        "error": { "code": "ERR_BRC40_UNKNOWN_USER" },
+        "schema_note": "Producer has no records for the requested identityKey."
+      },
+      "tags": ["brc40", "sync", "error-case", "request", "unknown-user"],
+      "skip": true,
+      "skip_reason": "Runtime-state assertion; requires producer with seeded user table. Cannot be validated by shape-only dispatcher."
+    },
+    {
+      "id": "sync.brc40.request.error.4",
+      "description": "RequestSyncChunkArgs malformed offset entry — missing `name`",
+      "input": {
+        "channel": "brc40/requestSyncChunk",
+        "message": {
+          "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+          "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+          "identityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc",
+          "maxRoughSize": 10000000,
+          "maxItems": 1000,
+          "offsets": [{ "offset": 0 }]
+        }
+      },
+      "expected": {
+        "valid": false,
+        "error": { "code": "ERR_BRC40_MALFORMED_OFFSETS" }
+      },
+      "tags": ["brc40", "sync", "error-case", "request", "validation"]
+    },
+    {
+      "id": "sync.brc40.request.error.5",
+      "description": "RequestSyncChunkArgs negative offset — must be rejected",
+      "input": {
+        "channel": "brc40/requestSyncChunk",
+        "message": {
+          "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+          "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+          "identityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc",
+          "maxRoughSize": 10000000,
+          "maxItems": 1000,
+          "offsets": [{ "name": "Transactions", "offset": -1 }]
+        }
+      },
+      "expected": {
+        "valid": false,
+        "error": { "code": "ERR_BRC40_MALFORMED_OFFSETS", "reason": "offset must be integer >= 0" }
+      },
+      "tags": ["brc40", "sync", "error-case", "request", "edge-case"]
+    },
+    {
+      "id": "sync.brc40.request.error.6",
+      "description": "RequestSyncChunkArgs maxItems <= 0 — must be rejected",
+      "input": {
+        "channel": "brc40/requestSyncChunk",
+        "message": {
+          "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+          "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+          "identityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc",
+          "maxRoughSize": 10000000,
+          "maxItems": 0,
+          "offsets": []
+        }
+      },
+      "expected": {
+        "valid": false,
+        "error": { "code": "ERR_BRC40_INVALID_LIMIT", "field": "maxItems" }
+      },
+      "tags": ["brc40", "sync", "error-case", "request", "edge-case"]
+    },
+    {
+      "id": "sync.brc40.response.1",
+      "description": "SyncChunk — non-empty incremental response with provenTxs and transactions populated, other entities omitted (size cap hit)",
+      "input": {
+        "channel": "brc40/syncChunk",
+        "message": {
+          "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+          "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+          "userIdentityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc",
+          "provenTxs": [
+            {
+              "provenTxId": 1,
+              "txid": "f4b3d8e3b27e3e6d2c1b1aebf2d2f3e1c4a9f0eedc7a8b1f2e3d4c5b6a7f8e9d",
+              "created_at": "2026-04-23T12:34:56.789Z",
+              "updated_at": "2026-04-23T12:34:56.789Z"
+            }
+          ],
+          "transactions": [
+            {
+              "transactionId": 42,
+              "userId": 7,
+              "status": "completed",
+              "created_at": "2026-04-23T12:34:57.001Z",
+              "updated_at": "2026-04-23T12:34:57.001Z"
+            }
+          ]
+        }
+      },
+      "expected": {
+        "valid": true,
+        "schema_note": "SyncChunk per WalletStorage.interfaces.ts:548-566. Omitted entity properties mean 'no attempt to update'. Every record must include created_at and updated_at."
+      },
+      "tags": ["brc40", "sync", "happy-path", "response", "partial"]
+    },
+    {
+      "id": "sync.brc40.response.2",
+      "description": "SyncChunk — completion sentinel: all entity arrays present and empty",
+      "input": {
+        "channel": "brc40/syncChunk",
+        "message": {
+          "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+          "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+          "userIdentityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc",
+          "provenTxs": [],
+          "provenTxReqs": [],
+          "outputBaskets": [],
+          "txLabels": [],
+          "outputTags": [],
+          "transactions": [],
+          "txLabelMaps": [],
+          "commissions": [],
+          "outputs": [],
+          "outputTagMaps": [],
+          "certificates": [],
+          "certificateFields": []
+        }
+      },
+      "expected": {
+        "valid": true,
+        "done": true,
+        "schema_note": "Per BRC-40: completion requires all 12 entity arrays present AND empty. Consumer's ProcessSyncChunkResult.done = true."
+      },
+      "tags": ["brc40", "sync", "happy-path", "response", "completion"]
+    },
+    {
+      "id": "sync.brc40.response.error.1",
+      "description": "SyncChunk with record missing updated_at — consumer must reject",
+      "input": {
+        "channel": "brc40/syncChunk",
+        "message": {
+          "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+          "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+          "userIdentityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc",
+          "transactions": [
+            {
+              "transactionId": 42,
+              "userId": 7,
+              "status": "completed",
+              "created_at": "2026-04-23T12:34:57.001Z"
+            }
+          ]
+        }
+      },
+      "expected": {
+        "valid": false,
+        "error": { "code": "ERR_BRC40_MISSING_TIMESTAMP", "field": "updated_at" }
+      },
+      "tags": ["brc40", "sync", "error-case", "response", "validation"]
+    },
+    {
+      "id": "sync.brc40.response.error.2",
+      "description": "SyncChunk with null inside entity array — disallowed by spec (no null values)",
+      "input": {
+        "channel": "brc40/syncChunk",
+        "message": {
+          "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+          "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+          "userIdentityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc",
+          "outputs": [null]
+        }
+      },
+      "expected": {
+        "valid": false,
+        "error": { "code": "ERR_BRC40_NULL_ENTITY" }
+      },
+      "tags": ["brc40", "sync", "error-case", "response", "validation"]
+    },
+    {
+      "id": "sync.brc40.response.error.3",
+      "description": "SyncChunk with mismatched userIdentityKey vs request.identityKey — consumer must reject",
+      "input": {
+        "channel": "brc40/syncChunk",
+        "request": {
+          "identityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc"
+        },
+        "message": {
+          "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+          "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+          "userIdentityKey": "02dddd00000000000000000000000000000000000000000000000000000000dddd",
+          "transactions": []
+        }
+      },
+      "expected": {
+        "valid": false,
+        "error": { "code": "ERR_BRC40_USER_MISMATCH" }
+      },
+      "tags": ["brc40", "sync", "error-case", "response", "integrity"]
+    },
+    {
+      "id": "sync.brc40.flow.idmap.1",
+      "description": "Persistent ID mapping — same logical record arriving with different producer-side primary key on second chunk must converge via stable natural key",
+      "input": {
+        "channel": "brc40/flow",
+        "messages": [
+          {
+            "syncChunk": {
+              "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+              "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+              "userIdentityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc",
+              "provenTxs": [
+                {
+                  "provenTxId": 1,
+                  "txid": "f4b3d8e3b27e3e6d2c1b1aebf2d2f3e1c4a9f0eedc7a8b1f2e3d4c5b6a7f8e9d",
+                  "created_at": "2026-04-23T12:34:56.789Z",
+                  "updated_at": "2026-04-23T12:34:56.789Z"
+                }
+              ]
+            }
+          },
+          {
+            "syncChunk": {
+              "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+              "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+              "userIdentityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc",
+              "provenTxs": [
+                {
+                  "provenTxId": 99,
+                  "txid": "f4b3d8e3b27e3e6d2c1b1aebf2d2f3e1c4a9f0eedc7a8b1f2e3d4c5b6a7f8e9d",
+                  "created_at": "2026-04-23T12:34:56.789Z",
+                  "updated_at": "2026-04-23T13:00:00.000Z"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "expected": {
+        "valid": true,
+        "schema_note": "Consumer must dedupe on natural key (txid for provenTxs) and treat producer-side surrogate IDs as opaque. Result: 1 row, updated_at = 2026-04-23T13:00:00.000Z."
+      },
+      "tags": ["brc40", "sync", "happy-path", "flow", "id-mapping", "convergence"]
+    },
+    {
+      "id": "sync.brc40.flow.idmap.error.1",
+      "description": "Conflicting ID mapping — same natural key arrives with incompatible payloads across chunks",
+      "input": {
+        "channel": "brc40/flow",
+        "messages": [
+          {
+            "syncChunk": {
+              "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+              "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+              "userIdentityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc",
+              "outputBaskets": [
+                {
+                  "basketId": 1,
+                  "userId": 7,
+                  "name": "default",
+                  "created_at": "2026-04-23T12:34:56.789Z",
+                  "updated_at": "2026-04-23T12:34:56.789Z"
+                }
+              ]
+            }
+          },
+          {
+            "syncChunk": {
+              "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+              "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+              "userIdentityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc",
+              "outputBaskets": [
+                {
+                  "basketId": 2,
+                  "userId": 7,
+                  "name": "default",
+                  "created_at": "2026-04-23T12:34:56.789Z",
+                  "updated_at": "2026-04-23T12:34:56.789Z"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "expected": {
+        "valid": false,
+        "error": { "code": "ERR_BRC40_ID_MAPPING_CONFLICT" },
+        "schema_note": "Two distinct producer-side rows claim the same (userId, name) natural key for OutputBaskets."
+      },
+      "tags": ["brc40", "sync", "error-case", "flow", "id-mapping", "conflict"]
+    },
+    {
+      "id": "sync.brc40.merge.tx.1",
+      "description": "EntityTransaction.mergeExisting — incoming chunk row is newer; consumer must UPDATE (status, provenTxId, updated_at advance)",
+      "input": {
+        "channel": "brc40/mergeExisting",
+        "entity": "transactions",
+        "existing": {
+          "transactionId": 42,
+          "userId": 7,
+          "status": "unsigned",
+          "provenTxId": null,
+          "created_at": "2026-04-23T12:00:00.000Z",
+          "updated_at": "2026-04-23T12:30:00.000Z"
+        },
+        "incoming": {
+          "transactionId": 42,
+          "userId": 7,
+          "status": "completed",
+          "provenTxId": 1001,
+          "created_at": "2026-04-23T12:00:00.000Z",
+          "updated_at": "2026-04-23T13:00:00.000Z"
+        }
+      },
+      "expected": {
+        "valid": true,
+        "action": "update",
+        "schema_note": "incoming.updated_at > existing.updated_at — apply update (per TS EntityTransaction.mergeExisting in wallet-toolbox)."
+      },
+      "tags": ["brc40", "sync", "happy-path", "merge", "monotonic-updated-at"]
+    },
+    {
+      "id": "sync.brc40.merge.tx.error.regression.1",
+      "description": "EntityTransaction.mergeExisting — stale chunk MUST NOT regress status from 'completed' back to 'unsigned' (go-wallet-toolbox#853)",
+      "input": {
+        "channel": "brc40/mergeExisting",
+        "entity": "transactions",
+        "existing": {
+          "transactionId": 42,
+          "userId": 7,
+          "status": "completed",
+          "provenTxId": 1001,
+          "created_at": "2026-04-23T12:00:00.000Z",
+          "updated_at": "2026-04-23T13:00:00.000Z"
+        },
+        "incoming": {
+          "transactionId": 42,
+          "userId": 7,
+          "status": "unsigned",
+          "provenTxId": null,
+          "created_at": "2026-04-23T12:00:00.000Z",
+          "updated_at": "2026-04-23T12:30:00.000Z"
+        }
+      },
+      "expected": {
+        "valid": true,
+        "action": "skip",
+        "schema_note": "incoming.updated_at < existing.updated_at — SKIP. Direct regression case from go-wallet-toolbox#853: status MUST NOT regress; provenTxId MUST NOT be cleared."
+      },
+      "tags": ["brc40", "sync", "regression-case", "merge", "monotonic-updated-at", "go-wallet-toolbox-853"]
+    },
+    {
+      "id": "sync.brc40.merge.tx.error.regression.2",
+      "description": "EntityTransaction.mergeExisting — equal updated_at: incoming is not strictly newer, so it MUST NOT overwrite (boundary)",
+      "input": {
+        "channel": "brc40/mergeExisting",
+        "entity": "transactions",
+        "existing": {
+          "transactionId": 42,
+          "userId": 7,
+          "status": "completed",
+          "provenTxId": 1001,
+          "created_at": "2026-04-23T12:00:00.000Z",
+          "updated_at": "2026-04-23T13:00:00.000Z"
+        },
+        "incoming": {
+          "transactionId": 42,
+          "userId": 7,
+          "status": "unsigned",
+          "provenTxId": null,
+          "created_at": "2026-04-23T12:00:00.000Z",
+          "updated_at": "2026-04-23T13:00:00.000Z"
+        }
+      },
+      "expected": {
+        "valid": true,
+        "action": "skip",
+        "schema_note": "Reference TS uses strict `if (ei.updated_at > this.updated_at)`. Equal timestamps → no update."
+      },
+      "tags": ["brc40", "sync", "edge-case", "merge", "monotonic-updated-at", "boundary"]
+    },
+    {
+      "id": "sync.brc40.merge.output.error.regression.1",
+      "description": "EntityOutput.mergeExisting — stale chunk MUST NOT flip spendable from false → true (double-spend hazard, go-wallet-toolbox#853)",
+      "input": {
+        "channel": "brc40/mergeExisting",
+        "entity": "outputs",
+        "existing": {
+          "outputId": 555,
+          "userId": 7,
+          "transactionId": 42,
+          "vout": 0,
+          "satoshis": 5000,
+          "spendable": false,
+          "spentBy": 43,
+          "created_at": "2026-04-23T12:00:00.000Z",
+          "updated_at": "2026-04-23T13:30:00.000Z"
+        },
+        "incoming": {
+          "outputId": 555,
+          "userId": 7,
+          "transactionId": 42,
+          "vout": 0,
+          "satoshis": 5000,
+          "spendable": true,
+          "spentBy": null,
+          "created_at": "2026-04-23T12:00:00.000Z",
+          "updated_at": "2026-04-23T13:00:00.000Z"
+        }
+      },
+      "expected": {
+        "valid": true,
+        "action": "skip",
+        "schema_note": "go-wallet-toolbox#853: output.spendable false→true via stale chunk = double-spend hazard. MUST be rejected by upsert."
+      },
+      "tags": ["brc40", "sync", "regression-case", "merge", "monotonic-updated-at", "double-spend-hazard", "go-wallet-toolbox-853"]
+    },
+    {
+      "id": "sync.brc40.merge.output.error.regression.2",
+      "description": "EntityOutput.mergeExisting — stale chunk MUST NOT clear spentBy (spend-attribution loss, go-wallet-toolbox#853)",
+      "input": {
+        "channel": "brc40/mergeExisting",
+        "entity": "outputs",
+        "existing": {
+          "outputId": 555,
+          "userId": 7,
+          "transactionId": 42,
+          "vout": 0,
+          "satoshis": 5000,
+          "spendable": false,
+          "spentBy": 43,
+          "created_at": "2026-04-23T12:00:00.000Z",
+          "updated_at": "2026-04-23T13:30:00.000Z"
+        },
+        "incoming": {
+          "outputId": 555,
+          "userId": 7,
+          "transactionId": 42,
+          "vout": 0,
+          "satoshis": 5000,
+          "spendable": false,
+          "spentBy": null,
+          "created_at": "2026-04-23T12:00:00.000Z",
+          "updated_at": "2026-04-23T12:45:00.000Z"
+        }
+      },
+      "expected": {
+        "valid": true,
+        "action": "skip",
+        "schema_note": "Stale incoming has spentBy=null but existing has spentBy=43. Skip preserves attribution."
+      },
+      "tags": ["brc40", "sync", "regression-case", "merge", "monotonic-updated-at", "go-wallet-toolbox-853"]
+    },
+    {
+      "id": "sync.brc40.merge.proventx.error.regression.1",
+      "description": "EntityProvenTx.mergeExisting — stale chunk MUST NOT overwrite proven tx (no merkle-proof regression)",
+      "input": {
+        "channel": "brc40/mergeExisting",
+        "entity": "provenTxs",
+        "existing": {
+          "provenTxId": 1,
+          "txid": "f4b3d8e3b27e3e6d2c1b1aebf2d2f3e1c4a9f0eedc7a8b1f2e3d4c5b6a7f8e9d",
+          "height": 845123,
+          "merklePath": "fe83df0c00…",
+          "created_at": "2026-04-23T12:00:00.000Z",
+          "updated_at": "2026-04-23T13:00:00.000Z"
+        },
+        "incoming": {
+          "provenTxId": 1,
+          "txid": "f4b3d8e3b27e3e6d2c1b1aebf2d2f3e1c4a9f0eedc7a8b1f2e3d4c5b6a7f8e9d",
+          "height": 845123,
+          "merklePath": "fe83df0c00…",
+          "created_at": "2026-04-23T12:00:00.000Z",
+          "updated_at": "2026-04-23T12:30:00.000Z"
+        }
+      },
+      "expected": {
+        "valid": true,
+        "action": "skip",
+        "schema_note": "Older incoming for an already-proven tx must be ignored."
+      },
+      "tags": ["brc40", "sync", "regression-case", "merge", "monotonic-updated-at", "go-wallet-toolbox-853"]
+    },
+    {
+      "id": "sync.brc40.flow.regression.1",
+      "description": "Two-chunk sequence: newer local-equivalent chunk arrives, then a STALE chunk for same row. Final consumer state must reflect the NEWER write (regression scenario from go-wallet-toolbox#853).",
+      "input": {
+        "channel": "brc40/flow",
+        "messages": [
+          {
+            "syncChunk": {
+              "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+              "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+              "userIdentityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc",
+              "transactions": [
+                {
+                  "transactionId": 42,
+                  "userId": 7,
+                  "status": "completed",
+                  "provenTxId": 1001,
+                  "created_at": "2026-04-23T12:00:00.000Z",
+                  "updated_at": "2026-04-23T13:00:00.000Z"
+                }
+              ]
+            }
+          },
+          {
+            "syncChunk": {
+              "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+              "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+              "userIdentityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc",
+              "transactions": [
+                {
+                  "transactionId": 42,
+                  "userId": 7,
+                  "status": "unsigned",
+                  "provenTxId": null,
+                  "created_at": "2026-04-23T12:00:00.000Z",
+                  "updated_at": "2026-04-23T12:30:00.000Z"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "expected": {
+        "valid": true,
+        "finalState": {
+          "transactions": [
+            {
+              "transactionId": 42,
+              "status": "completed",
+              "provenTxId": 1001,
+              "updated_at": "2026-04-23T13:00:00.000Z"
+            }
+          ]
+        },
+        "schema_note": "Post-merge consumer state must equal the chunk with the greatest updated_at per natural key, regardless of arrival order."
+      },
+      "tags": ["brc40", "sync", "regression-case", "flow", "monotonic-updated-at", "go-wallet-toolbox-853"]
+    },
+    {
+      "id": "sync.brc40.flow.since.inclusive.1",
+      "description": "`since` is inclusive lower bound — response must include at least one item with updated_at == since (so consumer can detect 'already seen' boundary)",
+      "input": {
+        "channel": "brc40/flow",
+        "request": {
+          "since": "2026-04-23T12:34:56.789Z"
+        },
+        "response": {
+          "syncChunk": {
+            "fromStorageIdentityKey": "02aaaa00000000000000000000000000000000000000000000000000000000aaaa",
+            "toStorageIdentityKey": "02bbbb00000000000000000000000000000000000000000000000000000000bbbb",
+            "userIdentityKey": "02cccc00000000000000000000000000000000000000000000000000000000cccc",
+            "transactions": [
+              {
+                "transactionId": 100,
+                "userId": 7,
+                "status": "completed",
+                "created_at": "2026-04-23T12:00:00.000Z",
+                "updated_at": "2026-04-23T12:34:56.789Z"
+              }
+            ]
+          }
+        }
+      },
+      "expected": {
+        "valid": true,
+        "schema_note": "Per WalletStorage.interfaces.ts:508 — 'since must include items if updated_at is greater or equal'. Boundary item required when prior sync exists."
+      },
+      "tags": ["brc40", "sync", "happy-path", "flow", "boundary", "inclusive"]
+    }
+  ]
+}

--- a/conformance/vectors/sync/sync.go
+++ b/conformance/vectors/sync/sync.go
@@ -1,0 +1,15 @@
+// Package sync embeds the vendored BRC sync conformance vectors so Go test
+// runners can consume them without filesystem path resolution.
+//
+// Origin: bsv-blockchain/ts-stack. Pinned via conformance/SOURCE.
+// Refresh: ./conformance/scripts/refresh-vectors.sh
+package sync
+
+import _ "embed"
+
+// BRC40UserState is the raw JSON corpus for sync.brc40 (BRC-40 User Wallet
+// Data Synchronization). See ts-stack conformance/runner/ts/dispatchers/sync.ts
+// for the reference dispatcher contract.
+//
+//go:embed brc40-user-state.json
+var BRC40UserState []byte

--- a/pkg/internal/storage/repo/syncrepo/brc40_conformance_test.go
+++ b/pkg/internal/storage/repo/syncrepo/brc40_conformance_test.go
@@ -3,13 +3,12 @@ package syncrepo_test
 import (
 	"encoding/json"
 	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	conformancevectors "github.com/bsv-blockchain/go-wallet-toolbox/conformance/vectors/sync"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/entity"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
@@ -20,8 +19,11 @@ import (
 
 // BRC-40 conformance vector runner.
 //
-// Consumes the conformance corpus at:
-//   ts-stack/conformance/vectors/sync/brc40-user-state.json
+// Consumes the vendored conformance corpus embedded via go:embed in:
+//   conformance/vectors/sync/sync.go
+//
+// Origin: bsv-blockchain/ts-stack, pinned via conformance/SOURCE.
+// Refresh: ./conformance/scripts/refresh-vectors.sh
 //
 // Reference dispatcher contract:
 //   ts-stack/conformance/runner/ts/dispatchers/sync.ts
@@ -34,12 +36,8 @@ import (
 // replays each syncChunk against the syncrepo and asserts the post-merge state
 // per natural key matches the finalState block.
 //
-// Vector file lookup order:
-//   1. $BRC40_VECTORS_FILE
-//   2. ../../../../../../../ts-stack/conformance/vectors/sync/brc40-user-state.json
-//      (relative to this test file)
-//
-// If neither is found, the test is skipped with a helpful pointer.
+// $BRC40_VECTORS_FILE may override the embedded corpus for ad-hoc testing
+// against an unreleased upstream version.
 
 type brc40Vector struct {
 	ID          string            `json:"id"`
@@ -74,32 +72,15 @@ type brc40File struct {
 	Vectors []brc40Vector  `json:"vectors"`
 }
 
-func locateBRC40Vectors(t *testing.T) string {
-	t.Helper()
-	if p := os.Getenv("BRC40_VECTORS_FILE"); p != "" {
-		return p
-	}
-	_, thisFile, _, ok := runtime.Caller(0)
-	require.True(t, ok)
-	candidate := filepath.Join(filepath.Dir(thisFile),
-		"..", "..", "..", "..", "..", "..", "..",
-		"ts-stack", "conformance", "vectors", "sync", "brc40-user-state.json")
-	abs, _ := filepath.Abs(candidate)
-	if _, err := os.Stat(abs); err == nil {
-		return abs
-	}
-	return ""
-}
-
 func loadBRC40Vectors(t *testing.T) brc40File {
 	t.Helper()
-	path := locateBRC40Vectors(t)
-	if path == "" {
-		t.Skip("BRC-40 conformance vectors not found. Set BRC40_VECTORS_FILE or " +
-			"check out ts-stack as a sibling repo. See conformance/vectors/sync/brc40-user-state.json.")
+	data := conformancevectors.BRC40UserState
+	if p := os.Getenv("BRC40_VECTORS_FILE"); p != "" {
+		override, err := os.ReadFile(p)
+		require.NoError(t, err, "BRC40_VECTORS_FILE=%s unreadable", p)
+		data = override
 	}
-	data, err := os.ReadFile(path)
-	require.NoError(t, err)
+	require.NotEmpty(t, data, "embedded BRC-40 vectors empty — refresh via ./conformance/scripts/refresh-vectors.sh")
 	var f brc40File
 	require.NoError(t, json.Unmarshal(data, &f))
 	return f

--- a/pkg/internal/storage/repo/syncrepo/brc40_conformance_test.go
+++ b/pkg/internal/storage/repo/syncrepo/brc40_conformance_test.go
@@ -1,0 +1,496 @@
+package syncrepo_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/entity"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/repo"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/dbfixtures"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+)
+
+// BRC-40 conformance vector runner.
+//
+// Consumes the conformance corpus at:
+//   ts-stack/conformance/vectors/sync/brc40-user-state.json
+//
+// Reference dispatcher contract:
+//   ts-stack/conformance/runner/ts/dispatchers/sync.ts
+//
+// For brc40/mergeExisting vectors the runner seeds the `existing` row into the
+// Go syncrepo, calls the upsert with `incoming`, then compares the resulting
+// post-state to expected.action (update vs skip).
+//
+// For brc40/flow vectors with `messages[]` + `expected.finalState`, the runner
+// replays each syncChunk against the syncrepo and asserts the post-merge state
+// per natural key matches the finalState block.
+//
+// Vector file lookup order:
+//   1. $BRC40_VECTORS_FILE
+//   2. ../../../../../../../ts-stack/conformance/vectors/sync/brc40-user-state.json
+//      (relative to this test file)
+//
+// If neither is found, the test is skipped with a helpful pointer.
+
+type brc40Vector struct {
+	ID          string            `json:"id"`
+	Description string            `json:"description"`
+	Input       brc40Input        `json:"input"`
+	Expected    brc40Expected     `json:"expected"`
+	Tags        []string          `json:"tags"`
+	Skip        bool              `json:"skip"`
+}
+
+type brc40Input struct {
+	Channel  string                   `json:"channel"`
+	Entity   string                   `json:"entity"`
+	Existing map[string]any           `json:"existing"`
+	Incoming map[string]any           `json:"incoming"`
+	Messages []map[string]any         `json:"messages"`
+	Message  map[string]any           `json:"message"`
+	Request  map[string]any           `json:"request"`
+	Response map[string]any           `json:"response"`
+}
+
+type brc40Expected struct {
+	Valid      bool           `json:"valid"`
+	Action     string         `json:"action"`
+	FinalState map[string]any `json:"finalState"`
+	Done       bool           `json:"done"`
+}
+
+type brc40File struct {
+	ID      string         `json:"id"`
+	Name    string         `json:"name"`
+	Vectors []brc40Vector  `json:"vectors"`
+}
+
+func locateBRC40Vectors(t *testing.T) string {
+	t.Helper()
+	if p := os.Getenv("BRC40_VECTORS_FILE"); p != "" {
+		return p
+	}
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	candidate := filepath.Join(filepath.Dir(thisFile),
+		"..", "..", "..", "..", "..", "..", "..",
+		"ts-stack", "conformance", "vectors", "sync", "brc40-user-state.json")
+	abs, _ := filepath.Abs(candidate)
+	if _, err := os.Stat(abs); err == nil {
+		return abs
+	}
+	return ""
+}
+
+func loadBRC40Vectors(t *testing.T) brc40File {
+	t.Helper()
+	path := locateBRC40Vectors(t)
+	if path == "" {
+		t.Skip("BRC-40 conformance vectors not found. Set BRC40_VECTORS_FILE or " +
+			"check out ts-stack as a sibling repo. See conformance/vectors/sync/brc40-user-state.json.")
+	}
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var f brc40File
+	require.NoError(t, json.Unmarshal(data, &f))
+	return f
+}
+
+func parseISO(t *testing.T, s string) time.Time {
+	t.Helper()
+	tt, err := time.Parse(time.RFC3339Nano, s)
+	require.NoError(t, err)
+	return tt
+}
+
+// TestBRC40Conformance_MergeExisting iterates each brc40/mergeExisting vector,
+// drives the Go syncrepo upserts, and asserts the merge action matches
+// expected.action ("update" or "skip"). Covers regression set from
+// go-wallet-toolbox#853:
+//   - sync.brc40.merge.tx.1
+//   - sync.brc40.merge.tx.error.regression.{1,2}
+//   - sync.brc40.merge.output.error.regression.{1,2}
+//   - sync.brc40.merge.proventx.error.regression.1
+func TestBRC40Conformance_MergeExisting(t *testing.T) {
+	f := loadBRC40Vectors(t)
+
+	for _, v := range f.Vectors {
+		v := v
+		if v.Skip || v.Input.Channel != "brc40/mergeExisting" {
+			continue
+		}
+		t.Run(v.ID, func(t *testing.T) {
+			switch v.Input.Entity {
+			case "transactions":
+				runMergeExistingTransaction(t, v)
+			case "outputs":
+				runMergeExistingOutput(t, v)
+			case "provenTxs":
+				runMergeExistingProvenTx(t, v)
+			default:
+				t.Skipf("unsupported entity %q", v.Input.Entity)
+			}
+		})
+	}
+}
+
+func runMergeExistingTransaction(t *testing.T, v brc40Vector) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	)
+	require.NoError(t, err)
+
+	existing := v.Input.Existing
+	incoming := v.Input.Incoming
+
+	// Use vector's transactionId encoded into a stable reference per row.
+	reference := "vector-tx-" + asString(existing["transactionId"])
+
+	// Map vector.provenTxId → Go Transaction.TxID. The regression vectors pin
+	// that a stale incoming with provenTxId=null MUST NOT clear the existing
+	// row's proven-tx pointer; mirroring that in Go means TxID must not flip
+	// from non-nil to nil.
+	existingStatus := wdk.TxStatus(asString(existing["status"]))
+	existingTxID := provenTxIDToTxIDPtr(existing["provenTxId"], "existing")
+	_, _, err = repos.UpsertTransactionForSync(t.Context(), &entity.Transaction{
+		CreatedAt:  parseISO(t, asString(existing["created_at"])),
+		UpdatedAt:  parseISO(t, asString(existing["updated_at"])),
+		UserID:     user.ID,
+		Status:     existingStatus,
+		Reference:  reference,
+		IsOutgoing: false,
+		Satoshis:   1,
+		TxID:       existingTxID,
+	})
+	require.NoError(t, err)
+
+	incomingStatus := wdk.TxStatus(asString(incoming["status"]))
+	incomingTxID := provenTxIDToTxIDPtr(incoming["provenTxId"], "incoming")
+	_, _, err = repos.UpsertTransactionForSync(t.Context(), &entity.Transaction{
+		CreatedAt:  parseISO(t, asString(incoming["created_at"])),
+		UpdatedAt:  parseISO(t, asString(incoming["updated_at"])),
+		UserID:     user.ID,
+		Status:     incomingStatus,
+		Reference:  reference,
+		IsOutgoing: false,
+		Satoshis:   1,
+		TxID:       incomingTxID,
+	})
+	require.NoError(t, err)
+
+	var got models.Transaction
+	require.NoError(t, d.DB.Where("user_id = ? AND reference = ?", user.ID, reference).First(&got).Error)
+	assertMergeAction(t, v, gotTxFields(got, existingStatus, incomingStatus, existingTxID, incomingTxID))
+}
+
+func runMergeExistingOutput(t *testing.T, v brc40Vector) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	)
+	require.NoError(t, err)
+
+	// Seed the parent transaction (status=completed so output UTXO path is exercised).
+	reference := "vector-out-tx-" + asString(v.Input.Existing["transactionId"])
+	txID := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	_, txnDBID, err := repos.UpsertTransactionForSync(t.Context(), &entity.Transaction{
+		CreatedAt:  parseISO(t, asString(v.Input.Existing["created_at"])),
+		UpdatedAt:  parseISO(t, asString(v.Input.Existing["updated_at"])),
+		UserID:     user.ID,
+		Status:     wdk.TxStatusCompleted,
+		Reference:  reference,
+		IsOutgoing: true,
+		Satoshis:   asInt64(v.Input.Existing["satoshis"]),
+		TxID:       &txID,
+	})
+	require.NoError(t, err)
+
+	basket := "default"
+	existingSpentBy := asOptionalUint(v.Input.Existing["spentBy"])
+	_, outID, err := repos.UpsertOutputForSync(t.Context(), &entity.Output{
+		CreatedAt:     parseISO(t, asString(v.Input.Existing["created_at"])),
+		UpdatedAt:     parseISO(t, asString(v.Input.Existing["updated_at"])),
+		UserID:        user.ID,
+		TransactionID: txnDBID,
+		SpentBy:       existingSpentBy,
+		Satoshis:      asInt64(v.Input.Existing["satoshis"]),
+		Vout:          uint32(asInt64(v.Input.Existing["vout"])),
+		BasketName:    &basket,
+		Spendable:     asBool(v.Input.Existing["spendable"]),
+		Description:   "existing",
+	})
+	require.NoError(t, err)
+
+	// Drive incoming.
+	incomingSpentBy := asOptionalUint(v.Input.Incoming["spentBy"])
+	_, _, err = repos.UpsertOutputForSync(t.Context(), &entity.Output{
+		CreatedAt:     parseISO(t, asString(v.Input.Incoming["created_at"])),
+		UpdatedAt:     parseISO(t, asString(v.Input.Incoming["updated_at"])),
+		UserID:        user.ID,
+		TransactionID: txnDBID,
+		SpentBy:       incomingSpentBy,
+		Satoshis:      asInt64(v.Input.Incoming["satoshis"]),
+		Vout:          uint32(asInt64(v.Input.Incoming["vout"])),
+		BasketName:    &basket,
+		Spendable:     asBool(v.Input.Incoming["spendable"]),
+		Description:   "incoming",
+	})
+	require.NoError(t, err)
+
+	var got models.Output
+	require.NoError(t, d.DB.First(&got, outID).Error)
+
+	expectUpdate := v.Expected.Action == "update"
+	if expectUpdate {
+		require.Equal(t, "incoming", got.Description, "vector %s expects update", v.ID)
+		require.Equal(t, asBool(v.Input.Incoming["spendable"]), got.Spendable)
+		assertOptionalUintEqual(t, incomingSpentBy, got.SpentBy)
+	} else {
+		require.Equal(t, "existing", got.Description, "vector %s expects skip", v.ID)
+		require.Equal(t, asBool(v.Input.Existing["spendable"]), got.Spendable,
+			"stale chunk MUST NOT regress spendable")
+		assertOptionalUintEqual(t, existingSpentBy, got.SpentBy)
+	}
+}
+
+func runMergeExistingProvenTx(t *testing.T, v brc40Vector) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	existing := v.Input.Existing
+	incoming := v.Input.Incoming
+	txid := asString(existing["txid"])
+
+	existingMerkle := []byte(asString(existing["merklePath"]))
+	existingHeight := uint32(asInt64(existing["height"]))
+	existingRoot := "root-existing"
+	existingHash := "hash-existing"
+	_, err := repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+		CreatedAt:   parseISO(t, asString(existing["created_at"])),
+		UpdatedAt:   parseISO(t, asString(existing["updated_at"])),
+		TxID:        txid,
+		Status:      wdk.ProvenTxStatusCompleted,
+		MerklePath:  existingMerkle,
+		MerkleRoot:  &existingRoot,
+		BlockHash:   &existingHash,
+		BlockHeight: &existingHeight,
+	})
+	require.NoError(t, err)
+
+	incomingMerkle := []byte(asString(incoming["merklePath"]))
+	incomingHeight := uint32(asInt64(incoming["height"]))
+	incomingRoot := "root-incoming"
+	incomingHash := "hash-incoming"
+	_, err = repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+		CreatedAt:   parseISO(t, asString(incoming["created_at"])),
+		UpdatedAt:   parseISO(t, asString(incoming["updated_at"])),
+		TxID:        txid,
+		Status:      wdk.ProvenTxStatusCompleted,
+		MerklePath:  incomingMerkle,
+		MerkleRoot:  &incomingRoot,
+		BlockHash:   &incomingHash,
+		BlockHeight: &incomingHeight,
+	})
+	require.NoError(t, err)
+
+	var got models.KnownTx
+	require.NoError(t, d.DB.First(&got, "tx_id = ?", txid).Error)
+
+	if v.Expected.Action == "update" {
+		require.NotNil(t, got.MerkleRoot)
+		require.Equal(t, incomingRoot, *got.MerkleRoot, "vector %s expects update", v.ID)
+	} else {
+		require.NotNil(t, got.MerkleRoot)
+		require.Equal(t, existingRoot, *got.MerkleRoot,
+			"stale chunk MUST NOT overwrite proven tx (vector %s)", v.ID)
+	}
+}
+
+type txAssertCtx struct {
+	got            models.Transaction
+	existingStatus wdk.TxStatus
+	incomingStatus wdk.TxStatus
+	existingTxID   *string
+	incomingTxID   *string
+}
+
+func gotTxFields(got models.Transaction, e, i wdk.TxStatus, eTxID, iTxID *string) txAssertCtx {
+	return txAssertCtx{got: got, existingStatus: e, incomingStatus: i, existingTxID: eTxID, incomingTxID: iTxID}
+}
+
+func assertMergeAction(t *testing.T, v brc40Vector, ctx txAssertCtx) {
+	t.Helper()
+	if v.Expected.Action == "update" {
+		require.Equal(t, ctx.incomingStatus, ctx.got.Status, "vector %s expects update", v.ID)
+		assertOptionalStringEqual(t, ctx.incomingTxID, ctx.got.TxID)
+	} else {
+		require.Equal(t, ctx.existingStatus, ctx.got.Status,
+			"stale chunk MUST NOT regress status (vector %s)", v.ID)
+		assertOptionalStringEqual(t, ctx.existingTxID, ctx.got.TxID)
+	}
+}
+
+// TestBRC40Conformance_FlowRegression iterates each brc40/flow vector with
+// `messages[]` + `expected.finalState`, replays each syncChunk against syncrepo,
+// then asserts the final per-natural-key state matches expected.finalState.
+// Pins sync.brc40.flow.regression.1 (the two-chunk replay from #853).
+func TestBRC40Conformance_FlowRegression(t *testing.T) {
+	f := loadBRC40Vectors(t)
+	for _, v := range f.Vectors {
+		v := v
+		if v.Skip || v.Input.Channel != "brc40/flow" || v.Expected.FinalState == nil {
+			continue
+		}
+		t.Run(v.ID, func(t *testing.T) {
+			runFlowReplay(t, v)
+		})
+	}
+}
+
+func runFlowReplay(t *testing.T, v brc40Vector) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	)
+	require.NoError(t, err)
+
+	// Replay messages in order.
+	for _, msg := range v.Input.Messages {
+		sc := asMap(msg["syncChunk"])
+		if txs, ok := sc["transactions"].([]any); ok {
+			for _, r := range txs {
+				row := asMap(r)
+				replayTransactionChunk(t, repos, user.ID, row)
+			}
+		}
+		// (other entity arrays can be added here as further vectors require)
+	}
+
+	// Verify finalState per entity.
+	if txs, ok := v.Expected.FinalState["transactions"].([]any); ok {
+		for _, r := range txs {
+			row := asMap(r)
+			ref := "vector-flow-tx-" + asString(row["transactionId"])
+			var got models.Transaction
+			require.NoError(t, d.DB.
+				Where("user_id = ? AND reference = ?", user.ID, ref).
+				First(&got).Error)
+			require.Equal(t, wdk.TxStatus(asString(row["status"])), got.Status,
+				"vector %s: final status for transactionId=%v", v.ID, row["transactionId"])
+		}
+	}
+}
+
+func replayTransactionChunk(t *testing.T, repos *repo.Repositories, userID int, row map[string]any) {
+	t.Helper()
+	reference := "vector-flow-tx-" + asString(row["transactionId"])
+	status := wdk.TxStatus(asString(row["status"]))
+	_, _, err := repos.UpsertTransactionForSync(t.Context(), &entity.Transaction{
+		CreatedAt:  parseISO(t, asString(row["created_at"])),
+		UpdatedAt:  parseISO(t, asString(row["updated_at"])),
+		UserID:     userID,
+		Status:     status,
+		Reference:  reference,
+		IsOutgoing: false,
+		Satoshis:   1,
+	})
+	require.NoError(t, err)
+}
+
+// ── small json helpers ────────────────────────────────────────────────────────
+
+func asString(v any) string {
+	if v == nil {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+
+func asBool(v any) bool {
+	b, _ := v.(bool)
+	return b
+}
+
+func asInt64(v any) int64 {
+	switch x := v.(type) {
+	case float64:
+		return int64(x)
+	case int64:
+		return x
+	case int:
+		return int64(x)
+	}
+	return 0
+}
+
+func asOptionalUint(v any) *uint {
+	if v == nil {
+		return nil
+	}
+	u := uint(asInt64(v))
+	return &u
+}
+
+func asMap(v any) map[string]any {
+	m, _ := v.(map[string]any)
+	return m
+}
+
+// provenTxIDToTxIDPtr maps a vector's provenTxId field (number or null) to a
+// Go Transaction.TxID pointer. A null/missing provenTxId becomes nil; any
+// non-null value becomes a stable synthesized string. The skip regression
+// vectors pin that a stale chunk with provenTxId=null MUST NOT clear an
+// existing row's TxID.
+func provenTxIDToTxIDPtr(provenTxID any, tag string) *string {
+	if provenTxID == nil {
+		return nil
+	}
+	s := "ptx-" + asString(toJSON(provenTxID)) + "-" + tag
+	return &s
+}
+
+func toJSON(v any) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+func assertOptionalStringEqual(t *testing.T, want, got *string) {
+	t.Helper()
+	if want == nil {
+		require.Nil(t, got)
+		return
+	}
+	require.NotNil(t, got)
+	require.Equal(t, *want, *got)
+}
+
+func assertOptionalUintEqual(t *testing.T, want, got *uint) {
+	t.Helper()
+	if want == nil {
+		require.Nil(t, got)
+		return
+	}
+	require.NotNil(t, got)
+	require.Equal(t, *want, *got)
+}

--- a/pkg/internal/storage/repo/syncrepo/brc40_conformance_test.go
+++ b/pkg/internal/storage/repo/syncrepo/brc40_conformance_test.go
@@ -2,6 +2,7 @@ package syncrepo_test
 
 import (
 	"encoding/json"
+	"math"
 	"os"
 	"testing"
 	"time"
@@ -16,6 +17,8 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/dbfixtures"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 )
+
+const defaultBasket = "default"
 
 // BRC-40 conformance vector runner.
 //
@@ -40,23 +43,23 @@ import (
 // against an unreleased upstream version.
 
 type brc40Vector struct {
-	ID          string            `json:"id"`
-	Description string            `json:"description"`
-	Input       brc40Input        `json:"input"`
-	Expected    brc40Expected     `json:"expected"`
-	Tags        []string          `json:"tags"`
-	Skip        bool              `json:"skip"`
+	ID          string        `json:"id"`
+	Description string        `json:"description"`
+	Input       brc40Input    `json:"input"`
+	Expected    brc40Expected `json:"expected"`
+	Tags        []string      `json:"tags"`
+	Skip        bool          `json:"skip"`
 }
 
 type brc40Input struct {
-	Channel  string                   `json:"channel"`
-	Entity   string                   `json:"entity"`
-	Existing map[string]any           `json:"existing"`
-	Incoming map[string]any           `json:"incoming"`
-	Messages []map[string]any         `json:"messages"`
-	Message  map[string]any           `json:"message"`
-	Request  map[string]any           `json:"request"`
-	Response map[string]any           `json:"response"`
+	Channel  string           `json:"channel"`
+	Entity   string           `json:"entity"`
+	Existing map[string]any   `json:"existing"`
+	Incoming map[string]any   `json:"incoming"`
+	Messages []map[string]any `json:"messages"`
+	Message  map[string]any   `json:"message"`
+	Request  map[string]any   `json:"request"`
+	Response map[string]any   `json:"response"`
 }
 
 type brc40Expected struct {
@@ -67,15 +70,18 @@ type brc40Expected struct {
 }
 
 type brc40File struct {
-	ID      string         `json:"id"`
-	Name    string         `json:"name"`
-	Vectors []brc40Vector  `json:"vectors"`
+	ID      string        `json:"id"`
+	Name    string        `json:"name"`
+	Vectors []brc40Vector `json:"vectors"`
 }
 
 func loadBRC40Vectors(t *testing.T) brc40File {
 	t.Helper()
 	data := conformancevectors.BRC40UserState
 	if p := os.Getenv("BRC40_VECTORS_FILE"); p != "" {
+		// #nosec G304 -- developer-supplied override path for ad-hoc upstream
+		// testing; only consulted when the env var is explicitly set in a dev
+		// shell, never in CI.
 		override, err := os.ReadFile(p)
 		require.NoError(t, err, "BRC40_VECTORS_FILE=%s unreadable", p)
 		data = override
@@ -105,7 +111,6 @@ func TestBRC40Conformance_MergeExisting(t *testing.T) {
 	f := loadBRC40Vectors(t)
 
 	for _, v := range f.Vectors {
-		v := v
 		if v.Skip || v.Input.Channel != "brc40/mergeExisting" {
 			continue
 		}
@@ -129,8 +134,9 @@ func runMergeExistingTransaction(t *testing.T, v brc40Vector) {
 	defer cleanup()
 	repos := d.CreateRepositories()
 
-	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
-		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	user, err := repos.CreateUser(
+		t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: defaultBasket, NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
 	)
 	require.NoError(t, err)
 
@@ -182,8 +188,9 @@ func runMergeExistingOutput(t *testing.T, v brc40Vector) {
 	defer cleanup()
 	repos := d.CreateRepositories()
 
-	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
-		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	user, err := repos.CreateUser(
+		t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: defaultBasket, NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
 	)
 	require.NoError(t, err)
 
@@ -202,8 +209,8 @@ func runMergeExistingOutput(t *testing.T, v brc40Vector) {
 	})
 	require.NoError(t, err)
 
-	basket := "default"
-	existingSpentBy := asOptionalUint(v.Input.Existing["spentBy"])
+	basket := defaultBasket
+	existingSpentBy := asOptionalUint(t, v.Input.Existing["spentBy"])
 	_, outID, err := repos.UpsertOutputForSync(t.Context(), &entity.Output{
 		CreatedAt:     parseISO(t, asString(v.Input.Existing["created_at"])),
 		UpdatedAt:     parseISO(t, asString(v.Input.Existing["updated_at"])),
@@ -211,7 +218,7 @@ func runMergeExistingOutput(t *testing.T, v brc40Vector) {
 		TransactionID: txnDBID,
 		SpentBy:       existingSpentBy,
 		Satoshis:      asInt64(v.Input.Existing["satoshis"]),
-		Vout:          uint32(asInt64(v.Input.Existing["vout"])),
+		Vout:          asUint32(t, v.Input.Existing["vout"]),
 		BasketName:    &basket,
 		Spendable:     asBool(v.Input.Existing["spendable"]),
 		Description:   "existing",
@@ -219,7 +226,7 @@ func runMergeExistingOutput(t *testing.T, v brc40Vector) {
 	require.NoError(t, err)
 
 	// Drive incoming.
-	incomingSpentBy := asOptionalUint(v.Input.Incoming["spentBy"])
+	incomingSpentBy := asOptionalUint(t, v.Input.Incoming["spentBy"])
 	_, _, err = repos.UpsertOutputForSync(t.Context(), &entity.Output{
 		CreatedAt:     parseISO(t, asString(v.Input.Incoming["created_at"])),
 		UpdatedAt:     parseISO(t, asString(v.Input.Incoming["updated_at"])),
@@ -227,7 +234,7 @@ func runMergeExistingOutput(t *testing.T, v brc40Vector) {
 		TransactionID: txnDBID,
 		SpentBy:       incomingSpentBy,
 		Satoshis:      asInt64(v.Input.Incoming["satoshis"]),
-		Vout:          uint32(asInt64(v.Input.Incoming["vout"])),
+		Vout:          asUint32(t, v.Input.Incoming["vout"]),
 		BasketName:    &basket,
 		Spendable:     asBool(v.Input.Incoming["spendable"]),
 		Description:   "incoming",
@@ -260,7 +267,7 @@ func runMergeExistingProvenTx(t *testing.T, v brc40Vector) {
 	txid := asString(existing["txid"])
 
 	existingMerkle := []byte(asString(existing["merklePath"]))
-	existingHeight := uint32(asInt64(existing["height"]))
+	existingHeight := asUint32(t, existing["height"])
 	existingRoot := "root-existing"
 	existingHash := "hash-existing"
 	_, err := repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
@@ -276,7 +283,7 @@ func runMergeExistingProvenTx(t *testing.T, v brc40Vector) {
 	require.NoError(t, err)
 
 	incomingMerkle := []byte(asString(incoming["merklePath"]))
-	incomingHeight := uint32(asInt64(incoming["height"]))
+	incomingHeight := asUint32(t, incoming["height"])
 	incomingRoot := "root-incoming"
 	incomingHash := "hash-incoming"
 	_, err = repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
@@ -335,7 +342,6 @@ func assertMergeAction(t *testing.T, v brc40Vector, ctx txAssertCtx) {
 func TestBRC40Conformance_FlowRegression(t *testing.T) {
 	f := loadBRC40Vectors(t)
 	for _, v := range f.Vectors {
-		v := v
 		if v.Skip || v.Input.Channel != "brc40/flow" || v.Expected.FinalState == nil {
 			continue
 		}
@@ -350,8 +356,9 @@ func runFlowReplay(t *testing.T, v brc40Vector) {
 	defer cleanup()
 	repos := d.CreateRepositories()
 
-	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
-		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	user, err := repos.CreateUser(
+		t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: defaultBasket, NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
 	)
 	require.NoError(t, err)
 
@@ -425,12 +432,23 @@ func asInt64(v any) int64 {
 	return 0
 }
 
-func asOptionalUint(v any) *uint {
+func asOptionalUint(t *testing.T, v any) *uint {
+	t.Helper()
 	if v == nil {
 		return nil
 	}
-	u := uint(asInt64(v))
+	n := asInt64(v)
+	require.GreaterOrEqual(t, n, int64(0), "negative value %d cannot fit in uint", n)
+	u := uint(n) //nolint:gosec // bounded by GreaterOrEqual check above
 	return &u
+}
+
+func asUint32(t *testing.T, v any) uint32 {
+	t.Helper()
+	n := asInt64(v)
+	require.GreaterOrEqual(t, n, int64(0), "negative value %d cannot fit in uint32", n)
+	require.LessOrEqual(t, n, int64(math.MaxUint32), "value %d overflows uint32", n)
+	return uint32(n) //nolint:gosec // bounded by LessOrEqual check above
 }
 
 func asMap(v any) map[string]any {
@@ -443,17 +461,20 @@ func asMap(v any) map[string]any {
 // non-null value becomes a stable synthesized string. The skip regression
 // vectors pin that a stale chunk with provenTxId=null MUST NOT clear an
 // existing row's TxID.
+//
+// JSON-encoded for stable formatting across number / string variants the
+// upstream vectors may use for provenTxId.
 func provenTxIDToTxIDPtr(provenTxID any, tag string) *string {
 	if provenTxID == nil {
 		return nil
 	}
-	s := "ptx-" + asString(toJSON(provenTxID)) + "-" + tag
+	b, err := json.Marshal(provenTxID)
+	if err != nil {
+		// JSON-decoded any is always re-encodable; this is unreachable.
+		panic("provenTxIDToTxIDPtr: json.Marshal failed: " + err.Error())
+	}
+	s := "ptx-" + string(b) + "-" + tag
 	return &s
-}
-
-func toJSON(v any) string {
-	b, _ := json.Marshal(v)
-	return string(b)
 }
 
 func assertOptionalStringEqual(t *testing.T, want, got *string) {

--- a/pkg/internal/storage/repo/syncrepo/brc40_conformance_test.go
+++ b/pkg/internal/storage/repo/syncrepo/brc40_conformance_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"math"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -79,11 +80,12 @@ func loadBRC40Vectors(t *testing.T) brc40File {
 	t.Helper()
 	data := conformancevectors.BRC40UserState
 	if p := os.Getenv("BRC40_VECTORS_FILE"); p != "" {
-		// #nosec G304 -- developer-supplied override path for ad-hoc upstream
+		clean := filepath.Clean(p)
+		// #nosec G304 G703 -- developer-supplied override path for ad-hoc upstream
 		// testing; only consulted when the env var is explicitly set in a dev
 		// shell, never in CI.
-		override, err := os.ReadFile(p)
-		require.NoError(t, err, "BRC40_VECTORS_FILE=%s unreadable", p)
+		override, err := os.ReadFile(clean)
+		require.NoError(t, err, "BRC40_VECTORS_FILE=%s unreadable", clean)
 		data = override
 	}
 	require.NotEmpty(t, data, "embedded BRC-40 vectors empty — refresh via ./conformance/scripts/refresh-vectors.sh")

--- a/pkg/internal/storage/repo/syncrepo/brc40_guard_test.go
+++ b/pkg/internal/storage/repo/syncrepo/brc40_guard_test.go
@@ -1,0 +1,493 @@
+package syncrepo_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/entity"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/dbfixtures"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+)
+
+// These tests pin the BRC-40 stale-chunk guard required by go-wallet-toolbox#853
+// and the ts-stack conformance vectors at conformance/vectors/sync/brc40-user-state.json.
+// Reference TS semantics: strict `if (incoming.updated_at > existing.updated_at)`.
+
+func TestBRC40Guard_KnownTx_StaleSkip(t *testing.T) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	tNewer := time.Date(2026, 4, 23, 13, 30, 0, 0, time.UTC)
+	tStale := time.Date(2026, 4, 23, 12, 30, 0, 0, time.UTC)
+
+	txID := "f4b3d8e3b27e3e6d2c1b1aebf2d2f3e1c4a9f0eedc7a8b1f2e3d4c5b6a7f8e9d"
+	merklePath := []byte{0xfe, 0x83, 0xdf, 0x0c}
+	merkleRoot := "root-newer"
+	blockHash := "hash-newer"
+	var blockHeight uint32 = 845123
+
+	// Seed newer (proven) record
+	isNew, err := repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+		CreatedAt:   tNewer,
+		UpdatedAt:   tNewer,
+		TxID:        txID,
+		Status:      wdk.ProvenTxStatusCompleted,
+		MerklePath:  merklePath,
+		MerkleRoot:  &merkleRoot,
+		BlockHash:   &blockHash,
+		BlockHeight: &blockHeight,
+	})
+	require.NoError(t, err)
+	require.True(t, isNew)
+
+	// Stale incoming: older updated_at, attempts to overwrite with unknown/no-merkle
+	isNew, err = repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+		CreatedAt:  tStale,
+		UpdatedAt:  tStale,
+		TxID:       txID,
+		Status:     wdk.ProvenTxStatusUnknown,
+		MerklePath: nil,
+		MerkleRoot: nil,
+		BlockHash:  nil,
+	})
+	require.NoError(t, err)
+	require.False(t, isNew)
+
+	// Verify state preserved
+	var got models.KnownTx
+	require.NoError(t, d.DB.First(&got, "tx_id = ?", txID).Error)
+	require.Equal(t, wdk.ProvenTxStatusCompleted, got.Status,
+		"stale chunk MUST NOT regress status (sync.brc40.merge.proventx.error.regression.1)")
+	require.NotNil(t, got.MerkleRoot)
+	require.Equal(t, merkleRoot, *got.MerkleRoot, "merkle proof MUST NOT be cleared by stale chunk")
+	require.NotNil(t, got.BlockHash)
+	require.Equal(t, blockHash, *got.BlockHash)
+	require.NotNil(t, got.BlockHeight)
+	require.Equal(t, blockHeight, *got.BlockHeight)
+	require.Equal(t, tNewer.UTC(), got.UpdatedAt.UTC())
+}
+
+func TestBRC40Guard_KnownTx_EqualSkip(t *testing.T) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	t0 := time.Date(2026, 4, 23, 13, 0, 0, 0, time.UTC)
+	txID := "a1b2c3d4e5f60718293a4b5c6d7e8f9001112233445566778899aabbccddeeff0"
+	merklePath := []byte{0xab, 0xcd}
+	merkleRoot := "root-equal"
+	blockHash := "hash-equal"
+	var blockHeight uint32 = 100
+
+	_, err := repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+		CreatedAt:   t0,
+		UpdatedAt:   t0,
+		TxID:        txID,
+		Status:      wdk.ProvenTxStatusCompleted,
+		MerklePath:  merklePath,
+		MerkleRoot:  &merkleRoot,
+		BlockHash:   &blockHash,
+		BlockHeight: &blockHeight,
+	})
+	require.NoError(t, err)
+
+	// Equal updated_at — strict `>` boundary: MUST skip
+	_, err = repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+		CreatedAt:  t0,
+		UpdatedAt:  t0,
+		TxID:       txID,
+		Status:     wdk.ProvenTxStatusUnknown,
+		MerklePath: nil,
+	})
+	require.NoError(t, err)
+
+	var got models.KnownTx
+	require.NoError(t, d.DB.First(&got, "tx_id = ?", txID).Error)
+	require.Equal(t, wdk.ProvenTxStatusCompleted, got.Status,
+		"equal updated_at MUST NOT trigger update (sync.brc40.merge.tx.error.regression.2 boundary)")
+	require.NotNil(t, got.MerkleRoot)
+	require.Equal(t, merkleRoot, *got.MerkleRoot)
+}
+
+func TestBRC40Guard_KnownTx_HappyUpdate(t *testing.T) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	tOld := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	tNew := time.Date(2026, 4, 23, 13, 0, 0, 0, time.UTC)
+	txID := "0011223344556677889900aabbccddeeff00112233445566778899aabbccddee"
+
+	_, err := repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+		CreatedAt: tOld,
+		UpdatedAt: tOld,
+		TxID:      txID,
+		Status:    wdk.ProvenTxStatusUnknown,
+	})
+	require.NoError(t, err)
+
+	merklePath := []byte{0xfe}
+	merkleRoot := "root"
+	blockHash := "hash"
+	var blockHeight uint32 = 10
+	_, err = repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+		CreatedAt:   tOld,
+		UpdatedAt:   tNew,
+		TxID:        txID,
+		Status:      wdk.ProvenTxStatusCompleted,
+		MerklePath:  merklePath,
+		MerkleRoot:  &merkleRoot,
+		BlockHash:   &blockHash,
+		BlockHeight: &blockHeight,
+	})
+	require.NoError(t, err)
+
+	var got models.KnownTx
+	require.NoError(t, d.DB.First(&got, "tx_id = ?", txID).Error)
+	require.Equal(t, wdk.ProvenTxStatusCompleted, got.Status)
+	require.NotNil(t, got.MerkleRoot)
+	require.Equal(t, merkleRoot, *got.MerkleRoot)
+}
+
+func TestBRC40Guard_Transaction_StaleSkip(t *testing.T) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	)
+	require.NoError(t, err)
+
+	tNewer := time.Date(2026, 4, 23, 13, 0, 0, 0, time.UTC)
+	tStale := time.Date(2026, 4, 23, 12, 30, 0, 0, time.UTC)
+
+	reference := "ref-brc40-tx-1"
+	txID := "tx-id-newer"
+
+	// Seed newer: status=completed, txID set
+	isNew, _, err := repos.UpsertTransactionForSync(t.Context(), &entity.Transaction{
+		CreatedAt:   tNewer,
+		UpdatedAt:   tNewer,
+		UserID:      user.ID,
+		Status:      wdk.TxStatusCompleted,
+		Reference:   reference,
+		IsOutgoing:  true,
+		Satoshis:    5000,
+		Description: "newer",
+		TxID:        &txID,
+	})
+	require.NoError(t, err)
+	require.True(t, isNew)
+
+	// Stale incoming: would regress status to unsigned, clear txID
+	isNew, _, err = repos.UpsertTransactionForSync(t.Context(), &entity.Transaction{
+		CreatedAt:   tNewer,
+		UpdatedAt:   tStale,
+		UserID:      user.ID,
+		Status:      wdk.TxStatusUnsigned,
+		Reference:   reference,
+		IsOutgoing:  true,
+		Satoshis:    5000,
+		Description: "stale",
+		TxID:        nil,
+	})
+	require.NoError(t, err)
+	require.False(t, isNew)
+
+	var got models.Transaction
+	require.NoError(t, d.DB.
+		Where("user_id = ? AND reference = ?", user.ID, reference).
+		First(&got).Error)
+	require.Equal(t, wdk.TxStatusCompleted, got.Status,
+		"stale chunk MUST NOT regress status completed→unsigned (sync.brc40.merge.tx.error.regression.1)")
+	require.NotNil(t, got.TxID, "stale chunk MUST NOT clear txID")
+	require.Equal(t, txID, *got.TxID)
+	require.Equal(t, "newer", got.Description)
+}
+
+func TestBRC40Guard_Transaction_EqualSkip(t *testing.T) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	)
+	require.NoError(t, err)
+
+	t0 := time.Date(2026, 4, 23, 13, 0, 0, 0, time.UTC)
+	reference := "ref-brc40-tx-equal"
+	txID := "tx-id-equal"
+
+	_, _, err = repos.UpsertTransactionForSync(t.Context(), &entity.Transaction{
+		CreatedAt: t0, UpdatedAt: t0,
+		UserID: user.ID, Status: wdk.TxStatusCompleted, Reference: reference,
+		IsOutgoing: false, Satoshis: 1, Description: "newer", TxID: &txID,
+	})
+	require.NoError(t, err)
+
+	// Equal updated_at — must SKIP
+	_, _, err = repos.UpsertTransactionForSync(t.Context(), &entity.Transaction{
+		CreatedAt: t0, UpdatedAt: t0,
+		UserID: user.ID, Status: wdk.TxStatusUnsigned, Reference: reference,
+		IsOutgoing: false, Satoshis: 1, Description: "equal-stale", TxID: nil,
+	})
+	require.NoError(t, err)
+
+	var got models.Transaction
+	require.NoError(t, d.DB.Where("user_id = ? AND reference = ?", user.ID, reference).First(&got).Error)
+	require.Equal(t, wdk.TxStatusCompleted, got.Status,
+		"equal updated_at MUST NOT trigger update (sync.brc40.merge.tx.error.regression.2)")
+	require.Equal(t, "newer", got.Description)
+}
+
+func TestBRC40Guard_Transaction_HappyUpdate(t *testing.T) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	)
+	require.NoError(t, err)
+
+	tOld := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	tNew := time.Date(2026, 4, 23, 13, 0, 0, 0, time.UTC)
+	reference := "ref-brc40-tx-happy"
+	txID := "tx-id-new"
+
+	_, _, err = repos.UpsertTransactionForSync(t.Context(), &entity.Transaction{
+		CreatedAt: tOld, UpdatedAt: tOld,
+		UserID: user.ID, Status: wdk.TxStatusUnsigned, Reference: reference,
+		IsOutgoing: true, Satoshis: 1, Description: "old",
+	})
+	require.NoError(t, err)
+
+	_, _, err = repos.UpsertTransactionForSync(t.Context(), &entity.Transaction{
+		CreatedAt: tOld, UpdatedAt: tNew,
+		UserID: user.ID, Status: wdk.TxStatusCompleted, Reference: reference,
+		IsOutgoing: true, Satoshis: 1, Description: "new", TxID: &txID,
+	})
+	require.NoError(t, err)
+
+	var got models.Transaction
+	require.NoError(t, d.DB.Where("user_id = ? AND reference = ?", user.ID, reference).First(&got).Error)
+	require.Equal(t, wdk.TxStatusCompleted, got.Status)
+	require.Equal(t, "new", got.Description)
+	require.NotNil(t, got.TxID)
+	require.Equal(t, txID, *got.TxID)
+}
+
+// TestBRC40Guard_Output_SpendableRegression mirrors sync.brc40.merge.output.error.regression.1:
+// existing has spendable=false (already spent), stale chunk attempts to flip true with cleared spent_by.
+// This is the double-spend hazard called out in go-wallet-toolbox#853.
+func TestBRC40Guard_Output_SpendableRegression(t *testing.T) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	)
+	require.NoError(t, err)
+
+	tNewer := time.Date(2026, 4, 23, 13, 30, 0, 0, time.UTC)
+	tStale := time.Date(2026, 4, 23, 13, 0, 0, 0, time.UTC)
+
+	reference := "ref-brc40-output-regression"
+	txID := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	_, txnDBID, err := repos.UpsertTransactionForSync(t.Context(), &entity.Transaction{
+		CreatedAt: tNewer, UpdatedAt: tNewer,
+		UserID: user.ID, Status: wdk.TxStatusCompleted, Reference: reference,
+		IsOutgoing: true, Satoshis: 5000, TxID: &txID,
+	})
+	require.NoError(t, err)
+
+	spentBy := uint(42)
+	basketName := "default"
+	// Seed newer: spendable=false (consumed), spent_by=42
+	isNew, outputID, err := repos.UpsertOutputForSync(t.Context(), &entity.Output{
+		CreatedAt:     tNewer,
+		UpdatedAt:     tNewer,
+		UserID:        user.ID,
+		TransactionID: txnDBID,
+		SpentBy:       &spentBy,
+		Satoshis:      5000,
+		Vout:          0,
+		BasketName:    &basketName,
+		Spendable:     false,
+		Description:   "newer",
+	})
+	require.NoError(t, err)
+	require.True(t, isNew)
+	require.NotZero(t, outputID)
+
+	// Stale incoming: would flip spendable→true and clear spent_by (double-spend hazard)
+	isNew, _, err = repos.UpsertOutputForSync(t.Context(), &entity.Output{
+		CreatedAt:     tNewer,
+		UpdatedAt:     tStale,
+		UserID:        user.ID,
+		TransactionID: txnDBID,
+		SpentBy:       nil,
+		Satoshis:      5000,
+		Vout:          0,
+		BasketName:    &basketName,
+		Spendable:     true,
+		Description:   "stale",
+	})
+	require.NoError(t, err)
+	require.False(t, isNew)
+
+	var got models.Output
+	require.NoError(t, d.DB.First(&got, outputID).Error)
+	require.False(t, got.Spendable,
+		"stale chunk MUST NOT flip spendable false→true (sync.brc40.merge.output.error.regression.1)")
+	require.NotNil(t, got.SpentBy,
+		"stale chunk MUST NOT clear spent_by (sync.brc40.merge.output.error.regression.2)")
+	require.Equal(t, spentBy, *got.SpentBy)
+	require.Equal(t, "newer", got.Description)
+}
+
+func TestBRC40Guard_Output_HappyUpdate(t *testing.T) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	)
+	require.NoError(t, err)
+
+	tOld := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	tNew := time.Date(2026, 4, 23, 13, 0, 0, 0, time.UTC)
+
+	reference := "ref-brc40-output-happy"
+	txID := "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+	_, txnDBID, err := repos.UpsertTransactionForSync(t.Context(), &entity.Transaction{
+		CreatedAt: tOld, UpdatedAt: tOld,
+		UserID: user.ID, Status: wdk.TxStatusCompleted, Reference: reference,
+		IsOutgoing: true, Satoshis: 5000, TxID: &txID,
+	})
+	require.NoError(t, err)
+
+	basketName := "default"
+	_, outputID, err := repos.UpsertOutputForSync(t.Context(), &entity.Output{
+		CreatedAt: tOld, UpdatedAt: tOld,
+		UserID: user.ID, TransactionID: txnDBID,
+		Satoshis: 5000, Vout: 0, BasketName: &basketName,
+		Spendable: true, Description: "old",
+	})
+	require.NoError(t, err)
+
+	spentBy := uint(99)
+	_, _, err = repos.UpsertOutputForSync(t.Context(), &entity.Output{
+		CreatedAt: tOld, UpdatedAt: tNew,
+		UserID: user.ID, TransactionID: txnDBID,
+		SpentBy:  &spentBy,
+		Satoshis: 5000, Vout: 0, BasketName: &basketName,
+		Spendable: false, Description: "new",
+	})
+	require.NoError(t, err)
+
+	var got models.Output
+	require.NoError(t, d.DB.First(&got, outputID).Error)
+	require.False(t, got.Spendable)
+	require.NotNil(t, got.SpentBy)
+	require.Equal(t, spentBy, *got.SpentBy)
+	require.Equal(t, "new", got.Description)
+}
+
+func TestBRC40Guard_Output_EqualSkip(t *testing.T) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	)
+	require.NoError(t, err)
+
+	t0 := time.Date(2026, 4, 23, 13, 0, 0, 0, time.UTC)
+	reference := "ref-brc40-output-equal"
+	txID := "aaaabbbbccccddddeeeeffff00001111aaaabbbbccccddddeeeeffff00001111"
+	_, txnDBID, err := repos.UpsertTransactionForSync(t.Context(), &entity.Transaction{
+		CreatedAt: t0, UpdatedAt: t0,
+		UserID: user.ID, Status: wdk.TxStatusCompleted, Reference: reference,
+		IsOutgoing: true, Satoshis: 5000, TxID: &txID,
+	})
+	require.NoError(t, err)
+
+	spentBy := uint(7)
+	basketName := "default"
+	_, outputID, err := repos.UpsertOutputForSync(t.Context(), &entity.Output{
+		CreatedAt: t0, UpdatedAt: t0,
+		UserID: user.ID, TransactionID: txnDBID,
+		SpentBy: &spentBy, Satoshis: 5000, Vout: 0,
+		BasketName: &basketName, Spendable: false, Description: "newer",
+	})
+	require.NoError(t, err)
+
+	// Equal timestamp — must SKIP
+	_, _, err = repos.UpsertOutputForSync(t.Context(), &entity.Output{
+		CreatedAt: t0, UpdatedAt: t0,
+		UserID: user.ID, TransactionID: txnDBID,
+		SpentBy: nil, Satoshis: 5000, Vout: 0,
+		BasketName: &basketName, Spendable: true, Description: "equal-stale",
+	})
+	require.NoError(t, err)
+
+	var got models.Output
+	require.NoError(t, d.DB.First(&got, outputID).Error)
+	require.False(t, got.Spendable,
+		"equal updated_at MUST NOT trigger update (boundary)")
+	require.NotNil(t, got.SpentBy)
+	require.Equal(t, spentBy, *got.SpentBy)
+}
+
+// TestBRC40Guard_Flow_Regression mirrors sync.brc40.flow.regression.1:
+// newer chunk arrives, then stale chunk for same row. Final state must reflect newer one.
+func TestBRC40Guard_Flow_Regression(t *testing.T) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	)
+	require.NoError(t, err)
+
+	tNewer := time.Date(2026, 4, 23, 13, 0, 0, 0, time.UTC)
+	tStale := time.Date(2026, 4, 23, 12, 30, 0, 0, time.UTC)
+
+	reference := "ref-brc40-flow"
+	txID := "1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff"
+
+	// Chunk 1: newer
+	_, _, err = repos.UpsertTransactionForSync(t.Context(), &entity.Transaction{
+		CreatedAt: tNewer, UpdatedAt: tNewer,
+		UserID: user.ID, Status: wdk.TxStatusCompleted, Reference: reference,
+		IsOutgoing: true, Satoshis: 1, TxID: &txID, Description: "newer",
+	})
+	require.NoError(t, err)
+
+	// Chunk 2: stale
+	_, _, err = repos.UpsertTransactionForSync(t.Context(), &entity.Transaction{
+		CreatedAt: tNewer, UpdatedAt: tStale,
+		UserID: user.ID, Status: wdk.TxStatusUnsigned, Reference: reference,
+		IsOutgoing: true, Satoshis: 1, Description: "stale",
+	})
+	require.NoError(t, err)
+
+	var got models.Transaction
+	require.NoError(t, d.DB.Where("user_id = ? AND reference = ?", user.ID, reference).First(&got).Error)
+	require.Equal(t, wdk.TxStatusCompleted, got.Status,
+		"after stale-after-newer replay, final state MUST reflect the newer write (sync.brc40.flow.regression.1)")
+	require.NotNil(t, got.TxID)
+	require.Equal(t, txID, *got.TxID)
+}

--- a/pkg/internal/storage/repo/syncrepo/brc40_guard_test.go
+++ b/pkg/internal/storage/repo/syncrepo/brc40_guard_test.go
@@ -159,8 +159,9 @@ func TestBRC40Guard_Transaction_StaleSkip(t *testing.T) {
 	defer cleanup()
 	repos := d.CreateRepositories()
 
-	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
-		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	user, err := repos.CreateUser(
+		t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: defaultBasket, NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
 	)
 	require.NoError(t, err)
 
@@ -216,8 +217,9 @@ func TestBRC40Guard_Transaction_EqualSkip(t *testing.T) {
 	defer cleanup()
 	repos := d.CreateRepositories()
 
-	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
-		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	user, err := repos.CreateUser(
+		t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: defaultBasket, NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
 	)
 	require.NoError(t, err)
 
@@ -252,8 +254,9 @@ func TestBRC40Guard_Transaction_HappyUpdate(t *testing.T) {
 	defer cleanup()
 	repos := d.CreateRepositories()
 
-	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
-		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	user, err := repos.CreateUser(
+		t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: defaultBasket, NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
 	)
 	require.NoError(t, err)
 
@@ -292,8 +295,9 @@ func TestBRC40Guard_Output_SpendableRegression(t *testing.T) {
 	defer cleanup()
 	repos := d.CreateRepositories()
 
-	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
-		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	user, err := repos.CreateUser(
+		t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: defaultBasket, NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
 	)
 	require.NoError(t, err)
 
@@ -310,7 +314,7 @@ func TestBRC40Guard_Output_SpendableRegression(t *testing.T) {
 	require.NoError(t, err)
 
 	spentBy := uint(42)
-	basketName := "default"
+	basketName := defaultBasket
 	// Seed newer: spendable=false (consumed), spent_by=42
 	isNew, outputID, err := repos.UpsertOutputForSync(t.Context(), &entity.Output{
 		CreatedAt:     tNewer,
@@ -359,8 +363,9 @@ func TestBRC40Guard_Output_HappyUpdate(t *testing.T) {
 	defer cleanup()
 	repos := d.CreateRepositories()
 
-	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
-		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	user, err := repos.CreateUser(
+		t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: defaultBasket, NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
 	)
 	require.NoError(t, err)
 
@@ -376,7 +381,7 @@ func TestBRC40Guard_Output_HappyUpdate(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	basketName := "default"
+	basketName := defaultBasket
 	_, outputID, err := repos.UpsertOutputForSync(t.Context(), &entity.Output{
 		CreatedAt: tOld, UpdatedAt: tOld,
 		UserID: user.ID, TransactionID: txnDBID,
@@ -408,8 +413,9 @@ func TestBRC40Guard_Output_EqualSkip(t *testing.T) {
 	defer cleanup()
 	repos := d.CreateRepositories()
 
-	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
-		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	user, err := repos.CreateUser(
+		t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: defaultBasket, NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
 	)
 	require.NoError(t, err)
 
@@ -424,7 +430,7 @@ func TestBRC40Guard_Output_EqualSkip(t *testing.T) {
 	require.NoError(t, err)
 
 	spentBy := uint(7)
-	basketName := "default"
+	basketName := defaultBasket
 	_, outputID, err := repos.UpsertOutputForSync(t.Context(), &entity.Output{
 		CreatedAt: t0, UpdatedAt: t0,
 		UserID: user.ID, TransactionID: txnDBID,
@@ -457,8 +463,9 @@ func TestBRC40Guard_Flow_Regression(t *testing.T) {
 	defer cleanup()
 	repos := d.CreateRepositories()
 
-	user, err := repos.CreateUser(t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
-		wdk.BasketConfiguration{Name: "default", NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	user, err := repos.CreateUser(
+		t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: defaultBasket, NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
 	)
 	require.NoError(t, err)
 

--- a/pkg/internal/storage/repo/syncrepo/sync_knowntx.go
+++ b/pkg/internal/storage/repo/syncrepo/sync_knowntx.go
@@ -3,6 +3,7 @@ package syncrepo
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/go-softwarelab/common/pkg/slices"
@@ -95,15 +96,33 @@ func (s *SyncKnownTx) UpsertKnownTxForSync(ctx context.Context, entity *entity.K
 	}
 
 	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		updateTx := tx.Model(&models.KnownTx{}).
+		// BRC-40 stale-chunk guard: only apply UPDATE when incoming is strictly newer.
+		// Equal updated_at must SKIP. TxNote delete/insert side-effects only fire
+		// inside the post-guard branch. See ts-stack EntityProvenTx.mergeExisting and
+		// conformance vector sync.brc40.merge.proventx.error.regression.1.
+		var existing models.KnownTx
+		existsErr := tx.Model(&models.KnownTx{}).
+			Select("tx_id, updated_at").
 			Where("tx_id = ?", entity.TxID).
-			Updates(model)
+			First(&existing).Error
 
-		if updateTx.Error != nil {
-			return fmt.Errorf("failed to update proven tx req: %w", updateTx.Error)
-		}
+		if existsErr == nil {
+			if !model.UpdatedAt.After(existing.UpdatedAt) {
+				return nil
+			}
 
-		if updateTx.RowsAffected > 0 {
+			updateTx := tx.Model(&models.KnownTx{}).
+				Where("tx_id = ? AND updated_at < ?", entity.TxID, model.UpdatedAt).
+				Updates(model)
+
+			if updateTx.Error != nil {
+				return fmt.Errorf("failed to update proven tx req: %w", updateTx.Error)
+			}
+
+			if updateTx.RowsAffected == 0 {
+				return nil
+			}
+
 			if deleteErr := tx.Delete(&models.TxNote{}, "tx_id = ?", entity.TxID).Error; deleteErr != nil {
 				return fmt.Errorf("failed to delete existing transaction notes: %w", deleteErr)
 			}
@@ -113,6 +132,10 @@ func (s *SyncKnownTx) UpsertKnownTxForSync(ctx context.Context, entity *entity.K
 			}
 
 			return nil
+		}
+
+		if !errors.Is(existsErr, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("failed to lookup existing known tx: %w", existsErr)
 		}
 
 		if err = tx.Create(&model).Error; err != nil {

--- a/pkg/internal/storage/repo/syncrepo/sync_output.go
+++ b/pkg/internal/storage/repo/syncrepo/sync_output.go
@@ -2,6 +2,7 @@ package syncrepo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-softwarelab/common/pkg/slices"
@@ -144,32 +145,44 @@ func (s *SyncOutput) upsertOutput(tx *gorm.DB, entity *entity.Output) (isNew boo
 		SenderIdentityKey:  entity.SenderIdentityKey,
 	}
 
-	updateTx := tx.Model(&model).
-		Clauses(clause.Returning{Columns: []clause.Column{{Name: "id"}}}).
+	// BRC-40 stale-chunk guard: only apply UPDATE when incoming is strictly newer
+	// than existing. Equal updated_at must SKIP. See:
+	// - ts-stack EntityOutput.mergeExisting (strict `>`)
+	// - conformance vector sync.brc40.merge.output.error.regression.{1,2}
+	var existing models.Output
+	existsErr := tx.Model(&models.Output{}).
+		Select("id, updated_at").
 		Where("user_id = ? AND transaction_id = ? AND vout = ?", model.UserID, model.TransactionID, model.Vout).
-		Select("*").
-		Updates(&model)
+		First(&existing).Error
 
-	// NOTE: We use `Select("*")` with `Updates()` to ensure that all fields are updated, including those that might be zero values (e.g., BasketName for relinquished outputs).
+	if existsErr == nil {
+		if !model.UpdatedAt.After(existing.UpdatedAt) {
+			// Stale or equal: preserve local state. Treat as no-op success.
+			outputID = existing.ID
+			return isNew, outputID, nil
+		}
 
-	if updateTx.Error != nil {
-		err = fmt.Errorf("failed to update output: %w", updateTx.Error)
-		return isNew, outputID, err
+		// Belt-and-braces: WHERE updated_at < ? also guards against TOCTOU.
+		updateTx := tx.Model(&model).
+			Where("id = ? AND updated_at < ?", existing.ID, model.UpdatedAt).
+			Select("*").
+			Updates(&model)
+
+		// NOTE: We use `Select("*")` with `Updates()` to ensure that all fields are updated, including those that might be zero values (e.g., BasketName for relinquished outputs).
+
+		if updateTx.Error != nil {
+			err = fmt.Errorf("failed to update output: %w", updateTx.Error)
+			return isNew, outputID, err
+		}
+
+		// RowsAffected == 0 here means a concurrent writer advanced updated_at past
+		// our incoming value between the lookup and the UPDATE. Treat as skip.
+		outputID = existing.ID
+		return isNew, outputID, nil
 	}
 
-	if updateTx.RowsAffected > 0 {
-		resultTxModel := models.Output{}
-		if err = updateTx.Scan(&resultTxModel).Error; err != nil {
-			err = fmt.Errorf("failed to scan updated output: %w", err)
-			return isNew, outputID, err
-		}
-
-		if resultTxModel.ID == 0 {
-			err = fmt.Errorf("output ID is zero after update, this should not happen")
-			return isNew, outputID, err
-		}
-
-		outputID = resultTxModel.ID
+	if !errors.Is(existsErr, gorm.ErrRecordNotFound) {
+		err = fmt.Errorf("failed to lookup existing output: %w", existsErr)
 		return isNew, outputID, err
 	}
 

--- a/pkg/internal/storage/repo/syncrepo/sync_transaction.go
+++ b/pkg/internal/storage/repo/syncrepo/sync_transaction.go
@@ -2,6 +2,7 @@ package syncrepo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-softwarelab/common/pkg/slices"
@@ -101,28 +102,38 @@ func (s *SyncTransaction) UpsertTransactionForSync(ctx context.Context, entity *
 	}
 
 	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		updateTx := tx.Model(&models.Transaction{}).
-			Clauses(clause.Returning{Columns: []clause.Column{{Name: "id"}}}).
+		// BRC-40 stale-chunk guard: only apply UPDATE when incoming is strictly newer.
+		// Equal updated_at must SKIP. See ts-stack EntityTransaction.mergeExisting and
+		// conformance vector sync.brc40.merge.tx.error.regression.{1,2}.
+		var existing models.Transaction
+		existsErr := tx.Model(&models.Transaction{}).
+			Select("id, updated_at").
 			Scopes(scopes.UserID(entity.UserID)).
 			Where("reference = ?", entity.Reference).
-			Updates(model)
+			First(&existing).Error
 
-		if updateTx.Error != nil {
-			return fmt.Errorf("failed to update transaction: %w", updateTx.Error)
+		if existsErr == nil {
+			if !model.UpdatedAt.After(existing.UpdatedAt) {
+				transactionID = existing.ID
+				return nil
+			}
+
+			updateTx := tx.Model(&models.Transaction{}).
+				Where("id = ? AND updated_at < ?", existing.ID, model.UpdatedAt).
+				Updates(model)
+
+			if updateTx.Error != nil {
+				return fmt.Errorf("failed to update transaction: %w", updateTx.Error)
+			}
+
+			// RowsAffected == 0 means a concurrent writer advanced updated_at past
+			// our incoming value between the lookup and the UPDATE. Treat as skip.
+			transactionID = existing.ID
+			return nil
 		}
 
-		if updateTx.RowsAffected > 0 {
-			resultTxModel := models.Transaction{}
-			if err = updateTx.Scan(&resultTxModel).Error; err != nil {
-				return fmt.Errorf("failed to scan updated transaction: %w", err)
-			}
-
-			if resultTxModel.ID == 0 {
-				return fmt.Errorf("transaction ID is zero after update, this should not happen")
-			}
-
-			transactionID = resultTxModel.ID
-			return nil
+		if !errors.Is(existsErr, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("failed to lookup existing transaction: %w", existsErr)
 		}
 
 		if err = tx.Create(&model).Error; err != nil {

--- a/plans/brc40-stale-chunk-guard.md
+++ b/plans/brc40-stale-chunk-guard.md
@@ -1,0 +1,176 @@
+# BRC-40 stale-chunk guard — `updated_at` monotonicity on sync upserts
+
+**Issue:** [bsv-blockchain/go-wallet-toolbox#853](https://github.com/bsv-blockchain/go-wallet-toolbox/issues/853)
+**Conformance vectors:** `conformance/vectors/sync/brc40-user-state.json` in [bsv-blockchain/ts-stack](https://github.com/bsv-blockchain/ts-stack) (added in main branch; spec ref BRC-40)
+**Severity:** High — data regression with double-spend hazard on `output.spendable`.
+
+---
+
+## Context for a fresh session
+
+You are picking up a fix for a sync correctness bug. The Go upsert paths in `syncrepo` unconditionally apply incoming sync chunks to existing rows. The TypeScript reference impl (`wallet-toolbox`) gates the UPDATE on strict `incoming.updated_at > existing.updated_at`. Without that guard, an older chunk arriving after a newer local write silently regresses mutable fields.
+
+A new BRC-40 conformance vector set in ts-stack now pins the expected behaviour. After fixing this issue you must wire the Go runner at those vectors so the regression cannot return.
+
+---
+
+## Files to change
+
+All three sit in `pkg/internal/storage/repo/syncrepo/`:
+
+| File | Function | Composite key used | Mutable fields at risk |
+|------|----------|--------------------|-----------------------|
+| `sync_output.go` | `upsertOutput` (~L123–191) | `(user_id, transaction_id, vout)` | `spendable`, `spent_by`, `basket_name`, `description`, `custom_instructions` |
+| `sync_transaction.go` | `UpsertTransactionForSync` (~L85–146) | `(user_id, reference)` | `status`, `proven_tx_id` (via known_tx join), `is_outgoing`, `description` |
+| `sync_knowntx.go` | `UpsertKnownTxForSync` (~L79–135) | `tx_id` | `status`, `block_height`, `merkle_path`, `merkle_root`, `block_hash`, `was_broadcast` |
+
+---
+
+## Reference TypeScript semantics
+
+From `wallet-toolbox` (ts-stack):
+- `packages/wallet/wallet-toolbox/src/storage/schema/entities/EntityTransaction.ts` — `mergeExisting`
+- `.../EntityOutput.ts` — `mergeExisting`
+- `.../EntityProvenTx.ts` — `mergeExisting`
+
+Each follows the pattern:
+
+```ts
+if (ei.updated_at > this.updated_at) {
+  // apply update
+}
+```
+
+Strict greater-than. Equal timestamps → **no update**. This is intentional: equal `updated_at` means the incoming chunk is not strictly newer than what we already have, and the local write wins on a tie.
+
+---
+
+## Recommended fix
+
+Add `WHERE updated_at < ?` to the UPDATE branch of each upsert. On `RowsAffected == 0` you must distinguish two cases:
+
+1. **No row exists** → fall through to `INSERT` (current behaviour).
+2. **Row exists but is newer-or-equal than incoming** → return success without inserting.
+
+You need a second lookup (or a `RETURNING` trick) to tell these apart. Suggested shape using `gorm`:
+
+```go
+// Pre-flight: check if row exists at all under the composite key
+var existing models.Output
+existsErr := tx.Model(&models.Output{}).
+    Where("user_id = ? AND transaction_id = ? AND vout = ?",
+        model.UserID, model.TransactionID, model.Vout).
+    Select("id, updated_at").
+    First(&existing).Error
+
+if existsErr == nil {
+    // Row exists — only update if incoming is strictly newer.
+    if !model.UpdatedAt.After(existing.UpdatedAt) {
+        // Stale chunk: skip, preserve local state. Return existing ID.
+        outputID = existing.ID
+        return false, outputID, nil
+    }
+    // Apply guarded update
+    updateTx := tx.Model(&model).
+        Clauses(clause.Returning{Columns: []clause.Column{{Name: "id"}}}).
+        Where("id = ? AND updated_at < ?", existing.ID, model.UpdatedAt).
+        Select("*").
+        Updates(&model)
+    // ... existing success path ...
+    return false, existing.ID, nil
+}
+
+if !errors.Is(existsErr, gorm.ErrRecordNotFound) {
+    return false, 0, fmt.Errorf("lookup failed: %w", existsErr)
+}
+
+// No row → INSERT (existing branch unchanged)
+```
+
+The `WHERE updated_at < ?` clause on the UPDATE itself is **belt-and-braces** — it prevents a TOCTOU race between the existence check and the UPDATE when two sync workers process chunks concurrently for the same user.
+
+### Subtle: strict `<` vs `<=`
+
+TypeScript uses strict `>`. The mirror in SQL is `WHERE existing.updated_at < incoming.updated_at`. **Do not** use `<=` — equal timestamps must not trigger an update. The conformance vector `sync.brc40.merge.tx.error.regression.2` directly asserts this boundary.
+
+### Same-second timestamp collisions
+
+DB column precision matters. If `updated_at` is stored at second precision but the application generates sub-second timestamps, two genuine writes can compare equal after truncation. Confirm the schema precision (milliseconds in `gorm.Model` defaults vs `DATETIME(3)` on MySQL). If you find truncation, raise it as a separate issue — the fix here assumes column precision matches the application's clock precision.
+
+---
+
+## Conformance vectors that pin this fix
+
+File: `conformance/vectors/sync/brc40-user-state.json` (in ts-stack `main`)
+Dispatcher: `conformance/runner/ts/dispatchers/sync.ts` (category `brc40-user-state`, channel `brc40/mergeExisting`, channel `brc40/flow` with `finalState`)
+
+The vectors that fail today against the unguarded Go code and must pass after the fix:
+
+| Vector ID | Asserts |
+|-----------|---------|
+| `sync.brc40.merge.tx.1` | newer incoming → UPDATE (happy-path baseline; must still work) |
+| `sync.brc40.merge.tx.error.regression.1` | older incoming MUST NOT regress `status` completed→unsigned and MUST NOT clear `proven_tx_id` |
+| `sync.brc40.merge.tx.error.regression.2` | equal `updated_at` → SKIP (strict `>` boundary) |
+| `sync.brc40.merge.output.error.regression.1` | output MUST NOT flip `spendable` false→true via stale chunk (double-spend hazard) |
+| `sync.brc40.merge.output.error.regression.2` | output MUST NOT clear `spent_by` via stale chunk |
+| `sync.brc40.merge.proventx.error.regression.1` | proven tx (knownTx) MUST NOT be overwritten by stale chunk |
+| `sync.brc40.flow.regression.1` | two-chunk replay: newer chunk arrives first then stale chunk; final consumer state must reflect the newer one |
+
+Each vector has `tags` including `go-wallet-toolbox-853` for easy filtering.
+
+The vector file is currently `parity_class: intended` in ts-stack — that means CI skips it. Once both TS and Go pass, promote to `required` in a coordinated PR.
+
+---
+
+## Test strategy
+
+### Unit tests (Go side, before wiring the conformance runner)
+
+Add tests in `pkg/internal/storage/repo/syncrepo/sync_output_test.go`, `sync_transaction_test.go`, `sync_knowntx_test.go`:
+
+1. **Happy update** — seed row with `updated_at = T`, upsert with `updated_at = T+1m`, assert mutable fields updated.
+2. **Stale skip** — seed row with `updated_at = T+1m`, upsert with `updated_at = T`, assert mutable fields **unchanged** and `isNew == false`.
+3. **Equal-timestamp skip** — seed row with `updated_at = T`, upsert with `updated_at = T`, assert mutable fields **unchanged**.
+4. **Output spendable regression** — specific test: existing `spendable=false, spent_by=42, updated_at=T+1m`; incoming `spendable=true, spent_by=null, updated_at=T`; assert post-state still has `spendable=false, spent_by=42`.
+5. **Transaction status regression** — existing `status=completed, proven_tx_id=1001, updated_at=T+1m`; incoming `status=unsigned, proven_tx_id=null, updated_at=T`; assert post-state still has `status=completed, proven_tx_id=1001`.
+6. **No-row insert** — empty table, upsert anything, assert `isNew == true` and row inserted.
+7. **Concurrent upsert** (optional, integration) — two goroutines upsert the same composite key with different `updated_at`; final state must equal the newer row regardless of arrival order. Mirrors vector `sync.brc40.flow.regression.1`.
+
+### Cross-impl conformance run
+
+After the unit tests pass, wire the Go conformance runner at the new vector file:
+
+- Mirror the dispatcher contract from `conformance/runner/ts/dispatchers/sync.ts` — channels: `brc40/requestSyncChunk`, `brc40/syncChunk`, `brc40/flow`, `brc40/mergeExisting`.
+- For `brc40/mergeExisting`, parse `existing` and `incoming`, compute the merge action against the Go upsert (`update` vs `skip`), and assert it matches `expected.action`.
+- For `brc40/flow` with `messages[]` and `expected.finalState`, replay the chunks against an in-memory `syncrepo` and assert the final DB state matches the expected rows.
+- Go runner location (planned, per `conformance/VECTOR-FORMAT.md`): `conformance/runner/runner.go`.
+
+---
+
+## Acceptance criteria
+
+- [ ] All three upsert paths in `syncrepo` reject stale chunks under their respective composite keys.
+- [ ] Equal-timestamp incoming chunk is treated as stale (no update).
+- [ ] Brand-new rows still insert when no existing row matches the composite key.
+- [ ] Unit tests cover happy update, stale skip, equal-skip, and the explicit field-regression cases listed above.
+- [ ] Go conformance runner wired at `sync.brc40` vectors; all `merge.*` and `flow.regression.*` vectors pass.
+- [ ] Vector file in ts-stack promoted from `parity_class: intended` to `required` once both impls green (separate coordinated PR).
+- [ ] Existing tests for `syncrepo` still pass (no regression of the happy path).
+
+---
+
+## Useful cross-references
+
+- TS reference impl shape: `packages/wallet/wallet-toolbox/src/sdk/WalletStorage.interfaces.ts` (lines ~480-575 define `RequestSyncChunkArgs`, `SyncChunk`, `ProcessSyncChunkResult`, `SyncProtocolVersion = '0.1.0'`).
+- TS sync chunker: `packages/wallet/wallet-toolbox/src/storage/methods/getSyncChunk.ts`.
+- TS merge entities: `packages/wallet/wallet-toolbox/src/storage/schema/entities/Entity{Transaction,Output,ProvenTx,ProvenTxReq,OutputBasket,...}.ts`.
+- BRC-40 spec: <https://bsv.brc.dev/outpoints/0040>.
+- ts-stack conformance META.json `regression_index` carries the entry `"brc40-stale-chunk-regress": "go-wallet-toolbox#853"`.
+
+---
+
+## Notes / gotchas
+
+- The output upsert uses `Select("*")` precisely so that zero-valued fields (e.g. cleared `basket_name`) are applied. After the fix, that semantic only applies when the incoming row is strictly newer — which is correct.
+- The transaction upsert composite key is `(user_id, reference)`, not `(user_id, tx_id)`. Newly created (unsigned) transactions have `reference` but no `tx_id` yet, which is why `reference` is the natural key.
+- `sync_knowntx.go` also deletes and re-inserts `TxNote` rows on every successful update. After the fix, those side-effects must only fire when the UPDATE actually applies — keep them inside the post-guard branch.


### PR DESCRIPTION
## Summary

- Adds strict `incoming.updated_at > existing.updated_at` guard to all three sync upserts in `pkg/internal/storage/repo/syncrepo/` — `sync_output.go`, `sync_transaction.go`, `sync_knowntx.go`. Equal timestamps SKIP. Belt-and-braces `WHERE updated_at < ?` on the UPDATE guards TOCTOU between two concurrent sync workers.
- Mirrors TS reference semantics from `wallet-toolbox` (`EntityTransaction.mergeExisting`, `EntityOutput.mergeExisting`, `EntityProvenTx.mergeExisting`).
- KnownTx TxNote delete/insert side-effects now only fire inside the post-guard branch.

Closes [#853](https://github.com/bsv-blockchain/go-wallet-toolbox/issues/853).

## Why it matters

Without the guard, an older sync chunk arriving after a newer local write silently regresses mutable fields. The output upsert's `Select("*")` semantic applies all fields including zero values, so a stale chunk with `spendable=true, spent_by=null` would flip a row that was already marked `spendable=false, spent_by=42` — a double-spend hazard. Transaction status regressions (`completed → unsigned`) and proven-tx clears are equally bad.

## Conformance vectors

Vendored from [`bsv-blockchain/ts-stack`](https://github.com/bsv-blockchain/ts-stack) at commit `1920a9c1b34010ff7ede34e424f0fca19b2ed3e6`:

- `conformance/vectors/sync/brc40-user-state.json` — corpus
- `conformance/vectors/sync/sync.go` — `go:embed` wrapper so tests stay hermetic
- `conformance/SOURCE` — pinned upstream SHA
- `conformance/scripts/refresh-vectors.sh` — refresh helper (resolves ref → 40-char SHA, downloads from `raw.githubusercontent.com`, rewrites `SOURCE`)
- `conformance/README.md` — rationale + refresh instructions

The Go runner in `brc40_conformance_test.go` drives the actual `syncrepo` upsert paths against every `merge.*` and `flow.regression.*` vector.

## Vectors that pass after this fix

| Vector ID | Asserts |
|-----------|---------|
| `sync.brc40.merge.tx.1` | newer incoming → UPDATE (happy baseline) |
| `sync.brc40.merge.tx.error.regression.1` | older incoming MUST NOT regress `status` completed→unsigned or clear `proven_tx_id` |
| `sync.brc40.merge.tx.error.regression.2` | equal `updated_at` → SKIP (strict `>` boundary) |
| `sync.brc40.merge.output.error.regression.1` | output MUST NOT flip `spendable` false→true via stale chunk (double-spend hazard) |
| `sync.brc40.merge.output.error.regression.2` | output MUST NOT clear `spent_by` via stale chunk |
| `sync.brc40.merge.proventx.error.regression.1` | proven tx (knownTx) MUST NOT be overwritten by stale chunk |
| `sync.brc40.flow.regression.1` | two-chunk replay: newer arrives first then stale; final state must equal newer write |

## Unit tests added

`pkg/internal/storage/repo/syncrepo/brc40_guard_test.go` — 10 tests covering happy update, stale skip, equal-timestamp skip, and explicit field-regression cases across all three upsert paths plus a two-chunk flow replay.

## Test plan

- [x] `go test ./pkg/internal/storage/repo/syncrepo/... -v -run TestBRC40Guard` — 10/10 pass
- [x] `go test ./pkg/internal/storage/repo/syncrepo/... -v -run TestBRC40Conformance` — 7/7 vectors pass
- [x] `go test ./...` — full repo green, no happy-path regression
- [ ] Coordinated follow-up PR in ts-stack to flip `parity_class: intended` → `required` once Go side merges

## Notes for review

- `Select("*")` on the output UPDATE is preserved — that semantic is still needed for clearing fields like `basket_name` when the incoming row is genuinely newer.
- No schema/migration changes.
- The TS dispatcher contract this mirrors is `ts-stack/conformance/runner/ts/dispatchers/sync.ts`, `mergeAction()` function: strict `>` only.