### PR TITLE
fix: validate single leaf tx in BEEF

### DIFF
--- a/pkg/internal/txutils/to_ef_hex.go
+++ b/pkg/internal/txutils/to_ef_hex.go
@@ -23,12 +23,10 @@ func ValidateSingleLeafTx(beef *transaction.Beef) error {
 	// inDegree will contain the number of transactions for which the given tx is a parent
 	inDegree := seq2.CollectToMap(seq2.MapValues(idToTx, func(tx *transaction.BeefTx) int { return 0 }))
 
-	// txsNotMined we are not interested in inputs of mined transactions
-	txsNotMined := seq.Filter(seq2.Values(idToTx), func(tx *transaction.BeefTx) bool {
-		return tx.Transaction.MerklePath == nil
-	})
-
-	inputs := seq.FlattenSlices(seq.Map(txsNotMined, func(tx *transaction.BeefTx) []*transaction.TransactionInput {
+	// Walk inputs of ALL transactions (including mined ones), because a mined tx can be
+	// an input to another mined tx, and skipping it would leave the first mined tx with
+	// in-degree 0, making it appear as a subject tx candidate alongside the real subject tx.
+	inputs := seq.FlattenSlices(seq.Map(seq2.Values(idToTx), func(tx *transaction.BeefTx) []*transaction.TransactionInput {
 		return tx.Transaction.Inputs
 	}))
 
@@ -38,7 +36,8 @@ func ValidateSingleLeafTx(beef *transaction.Beef) error {
 
 	seq.ForEach(inputsIds, func(inputTxID chainhash.Hash) {
 		if _, ok := inDegree[inputTxID]; !ok {
-			panic(fmt.Sprintf("unexpected input txid %s, this shouldn't ever happen", inputTxID))
+			// External anchor not included in this BEEF — valid for mined transactions, skip it.
+			return
 		}
 		inDegree[inputTxID]++
 	})


### PR DESCRIPTION
## The Bug

The current code only iterates inputs of **unmined** transactions when computing in-degree:

```go
// txsNotMined we are not interested in inputs of mined transactions
txsNotMined := seq.Filter(seq2.Values(idToTx), func(tx *transaction.BeefTx) bool {
    return tx.Transaction.MerklePath == nil
})
```

**The scenario:**

Consider a BEEF with:
- `TxA` — mined (has MerklePath), provides output consumed by `TxB`
- `TxB` — mined (has MerklePath), provides output consumed by `TxC` (subject)
- `TxC` — unmined, subject tx

In-degree calculation:
- `TxA` starts at 0. Since only unmined tx inputs are walked, **`TxB`'s input pointing to `TxA` is never counted**. `TxA` stays at in-degree 0.
- `TxB` starts at 0. `TxC`'s input pointing to `TxB` is counted (TxC is unmined). `TxB` gets in-degree 1.
- `TxC` starts at 0. Nobody points to it. Stays at 0.

Leaves (in-degree = 0): **both `TxA` and `TxC`** → `len(subjectTxs) == 2` → validation **incorrectly fails**.

## The Fix

1. Remove the `txsNotMined` filter — iterate over all txs when collecting inputs.
2. Change the panic on unknown input TXIDs to a `continue`/`return` — those are valid external anchors for mined transactions.

The comment `// we are not interested in inputs of mined transactions` was the wrong assumption. The correct invariant is: **the subject tx is the unique transaction in the DAG that no other transaction in the BEEF depends on as an input.**