### PR TITLE
feat: fix outputs with dust change reject tx during broadcast

### DIFF
--- a/pkg/internal/storage/funder/sql.go
+++ b/pkg/internal/storage/funder/sql.go
@@ -269,6 +269,33 @@ func newCollector(txSats satoshi.Value, txSize, outputCount uint64, numberOfDesi
 }
 
 func (c *utxoCollector) remaining() satoshi.Value {
+	if c.outputCount == 0 {
+		change := c.change()
+		if c.changeOutputsCount > 0 && change < c.dustFloor {
+			feeWithNextInput, err := c.feeCalculator.Calculate(c.txSize + txutils.P2PKHEstimatedInputSize)
+			if err != nil {
+				panic(fmt.Errorf("failed to calculate fee for next change input: %w", err))
+			}
+
+			toCover := satoshi.MustAdd(satoshi.MustAdd(c.txSats, feeWithNextInput), c.dustFloor)
+			if toCover > c.satsCovered {
+				return satoshi.MustSubtract(toCover, c.satsCovered)
+			}
+		}
+
+		if c.changeOutputsCount == 0 {
+			feeWithFirstChangeOutput, err := c.feeCalculator.Calculate(c.txSize + txutils.P2PKHEstimatedInputSize + changeOutputSize)
+			if err != nil {
+				panic(fmt.Errorf("failed to calculate fee for first change output: %w", err))
+			}
+
+			toCover := satoshi.MustAdd(satoshi.MustAdd(c.txSats, feeWithFirstChangeOutput), c.dustFloor)
+			if toCover > c.satsCovered {
+				return satoshi.MustSubtract(toCover, c.satsCovered)
+			}
+		}
+	}
+
 	return satoshi.MustSubtract(c.satsToCover(), c.satsCovered)
 }
 
@@ -276,9 +303,8 @@ func (c *utxoCollector) IsFunded() bool {
 	// A valid Bitcoin transaction must have at least one output.
 	// If no outputs are defined and no change outputs will be created,
 	// we must continue allocating UTXOs to ensure at least one change output exists.
-	totalOutputs := c.outputCount + c.changeOutputsCount
-	if totalOutputs == 0 {
-		return c.satsCovered > c.satsToCover()
+	if c.outputCount == 0 {
+		return c.changeOutputsCount > 0 && c.change() >= c.dustFloor
 	}
 
 	if c.isSweep {

--- a/pkg/internal/storage/funder/sql_test.go
+++ b/pkg/internal/storage/funder/sql_test.go
@@ -210,6 +210,51 @@ func TestFunderSQLFund(t *testing.T) {
 		})
 	}
 
+	t.Run("burn transaction funded exactly to fee still gets a change output", func(t *testing.T) {
+		// given:
+		given, then, cleanup := testabilities.New(t)
+		defer cleanup()
+
+		// and:
+		funder := given.NewFunderService()
+
+		// and:
+		basket := given.BasketFor(testusers.Alice).ThatPrefersSingleChange()
+
+		// and: the fixed input covers the fee exactly, but a no-output transaction is invalid.
+		given.UTXO().InBasket(basket).OwnedBy(testusers.Alice).WithSatoshis(2).P2PKH().Stored()
+
+		// when:
+		result, err := funder.Fund(ctx, -1, smallTransactionSize, noOutputs, basket, testusers.Alice.ID, nil, nil, false, false)
+
+		// then:
+		then.Result(result).WithoutError(err).
+			HasAllocatedUTXOs().ForTotalAmount(2).
+			HasChangeCount(1).ForAmount(2).
+			HasFee(1)
+	})
+
+	t.Run("burn transaction funded exactly to fee errors when no viable change output can be funded", func(t *testing.T) {
+		// given:
+		given, then, cleanup := testabilities.New(t)
+		defer cleanup()
+
+		// and:
+		funder := given.NewFunderService()
+
+		// and:
+		basket := given.BasketFor(testusers.Alice).ThatPrefersSingleChange()
+
+		// and: one extra satoshi is still below the dust floor for a change output.
+		given.UTXO().InBasket(basket).OwnedBy(testusers.Alice).WithSatoshis(1).P2PKH().Stored()
+
+		// when:
+		result, err := funder.Fund(ctx, -1, smallTransactionSize, noOutputs, basket, testusers.Alice.ID, nil, nil, false, false)
+
+		// then:
+		then.Result(result).WithError(err)
+	})
+
 	testCasesFundWholeTransaction := map[string]struct {
 		havingUTXOsInDB func(testabilities.FunderFixture, *entity.OutputBasket)
 		targetSatoshis  satoshi.Value


### PR DESCRIPTION
## What Changed
- Updated the Go funder logic to prevent burn-style transactions from finalizing with inputs but no outputs.
- For transactions with `outputCount == 0`, funding now requires a viable change output that is at least `dustFloor`.
- Adjusted `remaining()` so coin selection asks for enough value to fund the first/next valid change output, including the fee impact of adding another input.
- Added regression tests for exact-fee burn transactions and sub-dust change cases.

## Why It Was Necessary
- A burn transaction can have fixed inputs and no fixed outputs.
- If the provided input value exactly covers the fee, or only leaves sub-dust change, the transaction could otherwise end up with zero outputs.
- Arc/WoC reject transactions with inputs but no outputs, so the funder must either create a valid change output or fail instead of returning a result that builds an invalid transaction.

## Testing Performed
- tests

## Impact / Risk
- Low risk, scoped to Go funder behavior for zero-output transactions.
- Normal transactions with existing outputs can still donate sub-dust change to miner fees.
- Zero-output burn transactions now require valid change or return insufficient funds.
