### PR TITLE
docs(openspec): Option B — RPC-only ultra-performance storage

### DIFF
--- a/openspec/changes/optionb-rpc-only-ultra-perf/design.md
+++ b/openspec/changes/optionb-rpc-only-ultra-perf/design.md
@@ -1,0 +1,200 @@
+# Design — Option B RPC-only ultra-performance storage
+
+## Goals
+
+1. Conform only to BRC-100 JSON-RPC wallet contract.
+2. Run on a $5 VPS at 10 tps with sub-50ms p99.
+3. Scale to 100K tps on a 10-node cluster with sub-15ms p99.
+4. One Go binary; backend selected by runtime config.
+5. Operational cost grows roughly linearly with throughput.
+
+## Non-goals
+
+1. BRC-40 sync protocol compatibility.
+2. Internal schema portability with `ts-stack/wallet-toolbox`.
+3. Direct SQL introspection of storage state.
+4. Backwards-compatible data migration from existing Go storage.
+
+## Architecture
+
+### Layered model
+
+```
+┌─────────────────────────────────────────────────────┐
+│ BRC-100 JSON-RPC server (HTTP/2)                    │
+├─────────────────────────────────────────────────────┤
+│ Wallet domain layer (createAction, signAction, ...) │
+├─────────────────────────────────────────────────────┤
+│ Storage interface (Go: pkg/storage/backend)         │
+├─────────────────────────────────────────────────────┤
+│ Backend driver: embedded | single | hot | extreme   │
+├──────────┬────────────┬──────────────┬──────────────┤
+│ BadgerDB │ Aerospike  │ Redpanda     │ ClickHouse   │
+│ (KV)     │ (cluster   │ (event log)  │ (analytics)  │
+│          │  KV)       │              │              │
+├──────────┴────────────┴──────────────┴──────────────┤
+│ S3 / MinIO (blob)                                   │
+└─────────────────────────────────────────────────────┘
+```
+
+### Why each technology
+
+**BadgerDB (embedded backend):** pure Go, no CGo, LSM-tree on SSD. Sustains 100K+ writes/s/core on commodity NVMe. Single-process embedded. Zero ops cost. Reasonable replacement for SQLite at higher write rates, with built-in compression and snapshots.
+
+**Aerospike (cluster KV):** sub-ms p99 reads from SSD via hybrid memory architecture. Linear scaling to billions of records per node. Per-record CAS via generation counter. Proven >1M ops/s/node in production at financial-services scale. License-free community edition for our scale.
+
+**Redpanda (event log):** Kafka-API compatible but written in C++ with thread-per-core architecture. No JVM. Sustains 1GB/s writes per node. Replaces Kafka without operational overhead.
+
+**ClickHouse (analytics):** columnar, vectorized. Billions of rows per node for aggregate queries (listActions filtered by label across years). Read-replica of the event log keeps it fresh.
+
+**S3 / MinIO (blobs):** large blobs (BEEF, raw txs > 4KB) never belong in hot KV. Object store with lifecycle policies handles cold storage cheaply.
+
+### Why not other choices
+
+- **ScyllaDB**: comparable to Aerospike; C++/Seastar, thread-per-core. Acceptable alternative. Aerospike preferred for primary-index sub-ms latency, ScyllaDB preferred for very wide rows. Decision deferred to Phase 8 bench.
+- **FoundationDB**: strong serializable ACID, beautiful interface, but lower raw throughput per node and tighter transaction-size limits. Better fit for relational workloads, worse for our KV pattern.
+- **DynamoDB**: managed, comparable perf, but vendor lock-in and unpredictable costs at scale.
+- **Postgres**: caps at ~10K writes/s/node. Defeats the purpose.
+- **etcd / Consul**: optimized for config, not throughput. Out.
+
+### Sharding strategy
+
+Per-user sharding. Consistent hash on `identityKey` selects a shard. All writes for a user go to the owning shard. Reads for a user go to the owning shard. Cross-user operations (global proven_tx, headers, settings) are rare; they use Aerospike's per-record CAS or eventual-consistency via event log.
+
+This means **a single user is bounded by single-shard throughput** (~50K ops/s in `cluster-hot`). For wallets that need >50K ops/s for one user, that user's state would need to be partitioned (e.g. by basket) — out of scope until a customer asks.
+
+### Single-writer-per-user
+
+Worker pool sized to shard count × some multiplier. Each user is consistently routed to one worker. That worker is the sole writer for the user's state. No locks needed. Reads can happen on any worker (KV is eventually consistent across replicas).
+
+### Event log as source of truth
+
+Every state-mutating RPC produces an event in Redpanda before responding to the caller. KV is a materialized projection.
+
+- Crash of a KV node → rebuild from event log replay.
+- Migration to a new backend → consume event log into new backend.
+- Audit / debugging → replay log into a test environment.
+- BRC-40 sync replacement (multi-device) → second storage subscribes to user's event partition.
+
+Trade-off: event log adds latency. Mitigated by:
+- Co-locating Redpanda with KV in same datacenter (sub-ms write).
+- Returning to caller after event log ack, before KV materialization. KV gets caught up by materializer goroutine.
+
+### Materializer pipeline
+
+Goroutine per shard reads local event log partition, applies events to KV. Checkpoint per shard at `materializer:cursor:<shard>`. Crash-safe: resume from checkpoint.
+
+Throughput target: 200K events/sec per core. At 100K tps RPC, average 2 events per RPC = 200K events/s, fits one core per shard. Backpressure if a shard falls > 5s behind.
+
+### Read-path tiering
+
+| Query pattern | Tier | Latency budget |
+|---------------|------|----------------|
+| getUTXO, getUser, getCert, getBasket | Aerospike (RAM-resident hot set) | < 2ms p99 |
+| listOutputs paginated | Aerospike scan | < 5ms p99 |
+| listActions last 7 days | Aerospike scan | < 10ms p99 |
+| listActions older than 7 days | ClickHouse | < 100ms p99 |
+| listTransactions with proof status | Aerospike join client-side | < 10ms p99 |
+| BEEF / raw tx | S3 (with KV cache for hot txs) | < 50ms p99 cold |
+
+### Coin selection at scale
+
+Naive `outputs WHERE spendable = true ORDER BY satoshis` does not scale past 100K UTXOs per user. Replacement: bucketed sorted set.
+
+Buckets indexed by satoshi range (log scale: 0-1K, 1K-10K, 10K-100K, etc.). For a target amount T, scan buckets descending from the largest bucket ≤ T, then pick smallest fit. O(bucket count) ≈ O(log T).
+
+Per-basket-per-user bucket maintenance happens in materializer when outputs are added/spent. KV key: `user:<id>:basket:<name>:bucket:<idx>` → SortedSet of outpoints by satoshi.
+
+### Cost model
+
+Approximate $/month per backend at target throughput, assuming 1M active users with ~10 ops/user/day:
+
+- **embedded (10 tps)**: $5/mo (1 small VPS). User pays only their VPS bill.
+- **single-node (5K tps)**: $50/mo (1 medium VPS + S3 storage).
+- **cluster-hot (50K tps)**: $1K/mo (3 Aerospike nodes m6gd.2xlarge + 3 Redpanda nodes + S3 + ClickHouse single).
+- **cluster-extreme (100K tps)**: $5K/mo (10 Aerospike nodes + 5 Redpanda nodes + 3-node ClickHouse + S3).
+
+Cost dominated by RAM at high tiers (Aerospike). SSD-only mode halves RAM cost at ~30% latency penalty; available via Aerospike config.
+
+## Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| BRC-100 method leaks internal-state assumption | Medium | High | Phase 0 audit; design around per method |
+| Event-log replay can't fully replace BRC-40 sync for multi-device | Medium | Medium | Phase 0 prototype; if blocked, document limitation |
+| Aerospike per-record gen CAS conflicts at hot global keys | Medium | Medium | Partition global keys (e.g. shard headers by height range); use Aerospike CDT for set-of-references |
+| Materializer lag visible to user as "I created an action but listOutputs doesn't show it yet" | High | Medium | Read-your-writes guarantee: post-write returns include a cursor, listOutputs accepts cursor and waits until materializer caught up |
+| BadgerDB embedded mode disk endurance on Raspberry Pi SD cards | Medium | Low | Document SSD requirement; provide memory-only mode for ephemeral wallets |
+| ClickHouse ingester lag means historical reads miss recent data | Low | Low | Document 7-day window; reads in transition zone consult both KV and ClickHouse |
+| Aerospike licensing terms change | Low | High | Backend abstraction allows swap to ScyllaDB with bounded effort |
+| Operational complexity scares off small operators | High | Medium | Embedded + single-node tiers don't need cluster ops; same code |
+| Sharding hot-key (whale wallet) | Low | High | Document per-user shard ceiling; provide guidance for partitioned-user mode |
+| Crypto throughput becomes bottleneck before storage | Medium | Medium | Profile; cache derived keys; use hardware acceleration (AES-NI, AVX) |
+| GC pauses in Go at high allocation rates | Medium | Medium | Pool buffers; sync.Pool for hot allocations; consider GOGC tuning |
+| JSON parsing CPU at 100K tps | High | Medium | Use sonic or go-json; consider switching to msgpack on RPC for high-tier deployments |
+
+## Decision log
+
+### D1: Drop BRC-40 sync entirely
+
+Rationale: sync is a hard correctness requirement when storage shape is part of the contract (Option A). Option B's contract is RPC only, so users replicate state by subscribing to the event log, not by walking sync chunks. Removing sync deletes ~40% of repo complexity and removes a major performance hazard (sync upserts have to be transactional across many tables).
+
+### D2: One binary, runtime-configured backend
+
+Rationale: operators want to start small and scale up without rewriting. Single binary means deployment and CI are simple. Backend interface forces every driver to satisfy the same contract, so behavioural conformance is uniform.
+
+### D3: Aerospike over ScyllaDB by default
+
+Rationale: sub-ms p99 reads. Aerospike's strong consistency mode covers our CAS needs. Community license is free at our expected scale. ScyllaDB remains as a fallback if licensing or operational concerns surface.
+
+### D4: Event log as source of truth, KV as projection
+
+Rationale: lets us swap KV backends, rebuild on crash, replay for audit, support multi-device replication. The classic event-sourcing trade-off: write latency slightly higher but failure recovery and flexibility much better. At 100K tps the marginal latency from a Redpanda ack is ~0.5ms — affordable.
+
+### D5: No data migration from existing storage
+
+Rationale: schema is unrecognizable to current storage. Migration tooling would cost weeks and bound the design (have to keep some semblance of relational state). Since no production users exist on Go yet, throw it away. Operators who want migration take Option A.
+
+### D6: Bucketed UTXO selection by satoshi range
+
+Rationale: O(log) selection regardless of UTXO count is mandatory at 100K tps. Sorted-set-by-bucket fits Aerospike's CDT operations naturally and embedded BadgerDB's prefix scans.
+
+### D7: S3-compatible blob layer
+
+Rationale: keeps hot KV records small (bytes per record matters for Aerospike RAM). S3-compatible is the universal blob protocol — operators pick AWS S3, Cloudflare R2, GCS, or self-host MinIO without code change.
+
+### D8: ClickHouse for historical reads, not Aerospike
+
+Rationale: aggregate queries (count actions, sum satoshis, filter by label across years) over billions of rows are columnar OLAP territory. Aerospike is row-store KV; running OLAP on it would be both slow and expensive. ClickHouse is the right tool. Separation also isolates analytical load from hot-path KV.
+
+### D9: Backpressure via 503 with Retry-After
+
+Rationale: the alternative — silent latency creep when materializer falls behind — produces a worse user experience than an explicit "try again in 200ms." RPC clients can retry; standardized via HTTP Retry-After header.
+
+### D10: Per-user single-writer worker model
+
+Rationale: eliminates locks entirely on the hot path. Sharded routing means each user maps to exactly one worker; that worker is the sole mutator. Latency floor is the worker's queue depth, not lock contention.
+
+## What is the actual bottleneck at 100K tps?
+
+In rough order, anticipated bottlenecks (numbers approximate):
+
+1. **JSON-RPC parsing** — ~3μs per call with `encoding/json`, ~1μs with sonic. At 100K rps that's 100ms-300ms of CPU per second of wall time. Solvable with sonic + maybe msgpack at the highest tier.
+2. **Signature verification** — ECDSA verify ~200μs without optimization. Cached pre-computed pubkeys + batch verification gets this to ~20μs. Critical to hit.
+3. **Event-log write fsync** — Redpanda batched. Sub-ms p99 on NVMe with batching. Not a bottleneck if batched.
+4. **KV write to Aerospike** — sub-ms p99 on hybrid mem-SSD. Not a bottleneck.
+5. **Coin selection** — O(log) with bucketing. Sub-100μs. Not a bottleneck.
+6. **Network RTT** — 0.1-1ms intra-DC. Bounded.
+7. **GC pauses** — Go GC pauses can hit ms scale at high allocation rates. Pool buffers; goal < 100μs pause budget.
+
+The real ceiling for `cluster-extreme` is likely **Aerospike client throughput per Go process**, around 50-100K ops/s/process. Solution: multiple worker processes per node behind a load balancer; horizontal scale.
+
+Network bandwidth at 100K tps with ~1KB BEEF payloads = 100MB/s ingress. Single 10G NIC handles this with headroom. At 1Gbps deployments, this is a hard ceiling; document accordingly.
+
+## Open architectural questions
+
+1. **Do we expose a streaming RPC variant?** WebSocket or gRPC streaming for `listActions` over deep history could halve client-perceived latency. Defer until customer asks.
+2. **In-memory mode for ephemeral wallets?** Test wallets, integration tests, CI fixtures don't need durability. `embedded` driver with `--memory-only` flag is cheap to add.
+3. **Read-replica fan-out for `listOutputs` heavy clients?** Aerospike supports read replicas; do we expose a "read from any replica" hint for analytics-like consumers? Defer.
+4. **Encryption at rest** beyond what the storage backend provides? Wallets store sensitive material. Consider per-user envelope encryption with KMS. Defer to security review.
+5. **Multi-region active-active**? Event log can be mirrored; KV state can be regional. Out of scope until customer asks.

--- a/openspec/changes/optionb-rpc-only-ultra-perf/design.md
+++ b/openspec/changes/optionb-rpc-only-ultra-perf/design.md
@@ -175,6 +175,10 @@ Rationale: the alternative — silent latency creep when materializer falls behi
 
 Rationale: eliminates locks entirely on the hot path. Sharded routing means each user maps to exactly one worker; that worker is the sole mutator. Latency floor is the worker's queue depth, not lock contention.
 
+### D11: No encryption at rest in the storage layer
+
+Rationale: transaction data is public — it lives on the blockchain. All wallet-private metadata (descriptions, labels, derivation tweaks) is already encrypted client-side by the wallet's BRC key derivation before reaching the storage RPC. Storage-layer encryption would re-encrypt already-encrypted ciphertext for no added confidentiality, while burning CPU on AES on the hot path. Operators who require disk-level protection use backend-native mechanisms (Aerospike enterprise encryption, AWS EBS volume encryption, dm-crypt, LUKS) which are transparent to this codebase.
+
 ## What is the actual bottleneck at 100K tps?
 
 In rough order, anticipated bottlenecks (numbers approximate):
@@ -196,5 +200,5 @@ Network bandwidth at 100K tps with ~1KB BEEF payloads = 100MB/s ingress. Single 
 1. **Do we expose a streaming RPC variant?** WebSocket or gRPC streaming for `listActions` over deep history could halve client-perceived latency. Defer until customer asks.
 2. **In-memory mode for ephemeral wallets?** Test wallets, integration tests, CI fixtures don't need durability. `embedded` driver with `--memory-only` flag is cheap to add.
 3. **Read-replica fan-out for `listOutputs` heavy clients?** Aerospike supports read replicas; do we expose a "read from any replica" hint for analytics-like consumers? Defer.
-4. **Encryption at rest** beyond what the storage backend provides? Wallets store sensitive material. Consider per-user envelope encryption with KMS. Defer to security review.
+4. **Encryption at rest** — resolved as out of scope (see D11). Tx data is public; metadata is encrypted client-side. No storage-layer encryption added.
 5. **Multi-region active-active**? Event log can be mirrored; KV state can be regional. Out of scope until customer asks.

--- a/openspec/changes/optionb-rpc-only-ultra-perf/design.md
+++ b/openspec/changes/optionb-rpc-only-ultra-perf/design.md
@@ -179,6 +179,22 @@ Rationale: eliminates locks entirely on the hot path. Sharded routing means each
 
 Rationale: transaction data is public — it lives on the blockchain. All wallet-private metadata (descriptions, labels, derivation tweaks) is already encrypted client-side by the wallet's BRC key derivation before reaching the storage RPC. Storage-layer encryption would re-encrypt already-encrypted ciphertext for no added confidentiality, while burning CPU on AES on the hot path. Operators who require disk-level protection use backend-native mechanisms (Aerospike enterprise encryption, AWS EBS volume encryption, dm-crypt, LUKS) which are transparent to this codebase.
 
+### D12: Aerospike enterprise license at scale; no ScyllaDB fallback
+
+Rationale: Aerospike CE caps at 5 nodes / 4TB. Beyond that, operators pay for enterprise. Supporting both Aerospike and ScyllaDB drivers doubles the cluster backend surface area, doubles the bench matrix, and forces every change to be tested against two distinct systems. The clean design committed Aerospike-only. Operators uncomfortable with that license posture take Option A or fork.
+
+### D13: Read-your-writes is strict
+
+Rationale: a configurable RYW mode adds complexity to client code and to the RPC contract. Always-strict means clients never have to reason about consistency boundaries. The cost — blocking up to 500ms during materializer catch-up — is acceptable because materializer lag is itself bounded by backpressure (D9). When backpressure trips, callers see 503; otherwise lag is sub-100ms.
+
+### D14: gRPC + protobuf for cluster-internal RPC; HTTP/2 JSON-RPC at the edge
+
+Rationale: JSON parsing at 100K rps consumes 100-300ms of CPU per wall-second of serving — significant. Worker-to-worker traffic dominates intra-cluster bytes at the top tier. Switching internal protocol to gRPC + protobuf cuts that cost ~5x. External clients keep JSON-RPC for BRC-100 compatibility; the gateway worker translates once per request.
+
+### D15: In-memory mode for embedded driver
+
+Rationale: tests, CI, ephemeral wallets, and integration suites don't need durability. A `--memory-only` flag on the `embedded` driver runs BadgerDB with `InMemory: true`, avoiding disk I/O entirely. Speeds tests; provides clean teardown; documents zero-durability semantics for callers who explicitly want them.
+
 ## What is the actual bottleneck at 100K tps?
 
 In rough order, anticipated bottlenecks (numbers approximate):
@@ -197,8 +213,12 @@ Network bandwidth at 100K tps with ~1KB BEEF payloads = 100MB/s ingress. Single 
 
 ## Open architectural questions
 
-1. **Do we expose a streaming RPC variant?** WebSocket or gRPC streaming for `listActions` over deep history could halve client-perceived latency. Defer until customer asks.
-2. **In-memory mode for ephemeral wallets?** Test wallets, integration tests, CI fixtures don't need durability. `embedded` driver with `--memory-only` flag is cheap to add.
-3. **Read-replica fan-out for `listOutputs` heavy clients?** Aerospike supports read replicas; do we expose a "read from any replica" hint for analytics-like consumers? Defer.
-4. **Encryption at rest** — resolved as out of scope (see D11). Tx data is public; metadata is encrypted client-side. No storage-layer encryption added.
-5. **Multi-region active-active**? Event log can be mirrored; KV state can be regional. Out of scope until customer asks.
+All resolved:
+
+1. **Streaming RPC variant** — out of scope for Option B v1.
+2. **In-memory mode for ephemeral wallets** — in scope (D15); `embedded` driver supports `--memory-only`.
+3. **Read-replica fan-out hint** — out of scope for Option B v1.
+4. **Encryption at rest** — out of scope (D11); tx data public, metadata client-encrypted.
+5. **Multi-region active-active** — out of scope for Option B v1.
+
+Out-of-scope items can be revisited in a future Option B v2 if customer demand surfaces.

--- a/openspec/changes/optionb-rpc-only-ultra-perf/proposal.md
+++ b/openspec/changes/optionb-rpc-only-ultra-perf/proposal.md
@@ -208,6 +208,7 @@ Targets are aspirational; Phase 0 baseline + Phase 14 bench confirm.
 6. **Event log as canonical replay.** All state mutations land in Redpanda; KV is a materialized projection. Cluster restart rebuilds from event log if needed.
 7. **ClickHouse for historical reads.** OLAP queries get separate engine; KV stays narrow-fast.
 8. **Blobs in S3.** Raw tx > 4KB never live in hot KV.
+9. **Encryption at rest is out of scope.** Transaction data is public (on-chain). All sensitive metadata is already encrypted client-side before reaching storage. Storage-layer encryption would add CPU cost with no added confidentiality. Operators who still want disk-level encryption use the backend's native mechanism (Aerospike enterprise, EBS encryption, dm-crypt, etc.) without changes to this codebase.
 
 ## Open questions
 

--- a/openspec/changes/optionb-rpc-only-ultra-perf/proposal.md
+++ b/openspec/changes/optionb-rpc-only-ultra-perf/proposal.md
@@ -209,14 +209,21 @@ Targets are aspirational; Phase 0 baseline + Phase 14 bench confirm.
 7. **ClickHouse for historical reads.** OLAP queries get separate engine; KV stays narrow-fast.
 8. **Blobs in S3.** Raw tx > 4KB never live in hot KV.
 9. **Encryption at rest is out of scope.** Transaction data is public (on-chain). All sensitive metadata is already encrypted client-side before reaching storage. Storage-layer encryption would add CPU cost with no added confidentiality. Operators who still want disk-level encryption use the backend's native mechanism (Aerospike enterprise, EBS encryption, dm-crypt, etc.) without changes to this codebase.
+10. **Aerospike enterprise license is the scale path.** Community edition serves up to 5 nodes / 4TB. Beyond that, operators pay for enterprise. No ScyllaDB fallback path; backend interface stays clean rather than supporting both.
+11. **Read-your-writes is strict.** Post-write reads block on materializer catch-up with a bounded timeout (500ms default). No best-effort mode, no per-request opt-out. Simpler contract beats configurable correctness.
+12. **Cluster-internal RPC is gRPC + protobuf; edge is JSON-RPC.** External BRC-100 clients see HTTP/2 JSON-RPC unchanged. Worker-to-worker and worker-to-materializer use gRPC for ~5x lower per-call CPU cost.
+13. **In-memory mode for embedded driver is in scope.** `embedded` backend supports `--memory-only` flag for test/CI/ephemeral wallets. No durability. Cheap to add; useful immediately.
+14. **Out of scope:** streaming RPC for deep listActions; read-replica fan-out hint; multi-region active-active. Revisit in a future Option B v2 if customer demand surfaces.
 
 ## Open questions
 
-1. Does the BRC-100 JSON-RPC contract leak any internal-state assumption (e.g., a method that returns an internal table row)? Phase 0 audit.
-2. Multi-device wallets historically rely on BRC-40 sync. What replication primitive replaces it for users who need multi-storage state? Candidate: event-log subscribe + materialize on second storage. Phase 0 prototype.
-3. Cost ceiling for `embedded` mode if BadgerDB I/O exceeds Raspberry-Pi SD-card endurance — consider EROFS or memory-only mode for ephemeral wallets.
-4. Aerospike vs ScyllaDB final decision. Bench both at Phase 4.
-5. Whether to support a `postgres` backend as a fifth driver for orgs that mandate SQL. Likely no — adds complexity and undermines the perf story.
+None outstanding. Items previously open are now resolved:
+
+1. **BRC-100 internal-state leakage:** Phase 0 audit task still runs, but is verification, not a decision.
+2. **Multi-device replication:** locked to event-log subscribe + materialize.
+3. **Embedded SD-card endurance:** in-memory mode (D13) covers ephemeral cases; SSD is documented requirement for durable embedded.
+4. **Aerospike vs ScyllaDB:** Aerospike committed (D10); enterprise license is the scale path. No ScyllaDB driver.
+5. **Postgres fifth driver:** out — would undermine the performance story.
 
 ## Alternatives considered
 

--- a/openspec/changes/optionb-rpc-only-ultra-perf/proposal.md
+++ b/openspec/changes/optionb-rpc-only-ultra-perf/proposal.md
@@ -1,0 +1,226 @@
+# Option B — RPC-only conformance, ultra-performance storage
+
+**Status:** Proposed
+**Branch:** `feat/storage-optionb-ultra-perf`
+**Author:** Deggen
+**Date:** 2026-05-21
+
+## Why
+
+`go-wallet-toolbox` was built to mirror `ts-stack/wallet-toolbox` table-for-table, then layered BRC-40 sync on top so a wallet's state could replicate across storage backends. That coupling caps throughput at single-Postgres-node ceilings (~5-10K writes/s, hot-read latency rising with history length) and bakes in joins on every list call.
+
+A class of operators want a Go wallet storage that:
+- Scales linearly from a Raspberry Pi single-tenant deploy (10 tps target) to a sharded cluster (100K tps ceiling) without rewriting application code.
+- Costs cents/month at 10 tps.
+- Doesn't pay the price of BRC-40 sync compatibility when they don't use sync.
+- Only conforms to the BRC-100 wallet JSON-RPC contract — internal state shape is an implementation detail.
+
+This change rebuilds the storage layer from the ground up to those constraints. Internal schema is unrecognizable to `ts-stack/wallet-toolbox`. BRC-40 sync is removed. The only conformance bar is the BRC-100 JSON-RPC interface and a wallet behavioural test suite.
+
+## What changes
+
+### Conformance scope
+
+- **In scope**: BRC-100 wallet JSON-RPC method contract (createAction, signAction, internalizeAction, listActions, listOutputs, listTransactions, listCertificates, acquireCertificate, proveCertificate, relinquishCertificate, abortAction, revealCounterpartyKeyLinkage, revealSpecificKeyLinkage, getPublicKey, encrypt, decrypt, createHmac, verifyHmac, createSignature, verifySignature, getHeight, getHeaderForHeight, getNetwork, getVersion, waitForAuthentication, isAuthenticated, discoverByIdentityKey, discoverByAttributes).
+- **Out of scope**: BRC-40 sync. No `findUserById`, no chunked sync exports, no merge logic.
+- **Out of scope**: Internal schema portability with TS. No conformance against `ts-stack/wallet-toolbox` storage shape.
+- **Out of scope**: Direct SQL access. External tools that read storage tables are not supported; consumers use RPC.
+
+### Storage backend abstraction
+
+Define a `Storage` Go interface that exposes domain operations, not tables. Concrete implementations:
+
+| Backend | Target deploy size | Backend tech |
+|---------|--------------------|--------------|
+| `embedded` | Single tenant, 1–100 tps | BadgerDB (pure Go, LSM on local SSD) |
+| `single-node` | 100–5K tps, low-cost ops | BadgerDB + optional ClickHouse for historical queries |
+| `cluster-hot` | 5K–50K tps | Aerospike (primary KV) + Redpanda (event log) + S3 (blobs) |
+| `cluster-extreme` | 50K–100K tps | Aerospike (sharded) + Redpanda (sharded) + ClickHouse (replicated) + S3 |
+
+All four backends implement the same `Storage` interface. Application code is backend-agnostic. Config picks the driver at startup.
+
+### Data model — KV-shaped, not relational
+
+Every entity is keyed by a deterministic byte key. No joins. No surrogate IDs. No foreign keys.
+
+```
+user:<identityKey>                                  → User
+user:<identityKey>:settings                         → UserSettings
+user:<identityKey>:basket:<basketName>              → Basket
+user:<identityKey>:utxo-set                         → SortedSet of OutpointRefs by satoshi-range bucket
+user:<identityKey>:utxo:<txid>:<vout>               → Output
+user:<identityKey>:tx:<txid>                        → Transaction (status snapshot)
+user:<identityKey>:tx-by-ref:<reference>            → txid pointer
+user:<identityKey>:action-log:<seqno>               → Action event (append-only)
+user:<identityKey>:label:<labelName>:<txid>         → label map entry
+user:<identityKey>:tag:<tagName>:<outpoint>         → tag map entry
+user:<identityKey>:cert:<certifier>:<type>:<serial> → Certificate
+tx-proof:<txid>                                     → ProvenTx (global, deduped across users)
+tx-pursuit:<txid>                                   → PursuitState (global, monitor-owned)
+header:<height>                                     → BlockHeader
+header-by-hash:<hash>                               → height pointer
+chaintip                                            → current tip header ref
+```
+
+All per-user keys share the `user:<identityKey>:` prefix. Aerospike partitions on the prefix; a user's entire state lives on one node (one shard). No cross-shard transactions on the hot path.
+
+### Hot-path operations
+
+#### createAction (write path)
+
+1. RPC enters worker pool. Load `user:<identityKey>` (single KV get, sub-ms).
+2. Coin-select from `user:<identityKey>:utxo-set` using pre-bucketed sorted set. O(log n) on bucket count, not on UTXO count.
+3. Build tx in-memory. Sign via cached derived keys.
+4. Append `action-log:<seqno>` event with full tx + selected inputs. Single KV put.
+5. Return BEEF to caller.
+6. **Async, post-response:** materializer goroutine consumes `action-log`, updates `utxo-set` (mark spent inputs, add new outputs), updates `tx`, updates labels/tags. Reply has already returned to caller.
+
+Latency target: <2ms p50, <10ms p99 at 100K tps per node.
+
+#### listOutputs (read path)
+
+1. Load `user:<identityKey>:basket:<basketName>` (single KV get).
+2. Stream cursor over `user:<identityKey>:utxo:` prefix filtered by basket. Paginate via KV scan.
+3. Return.
+
+Latency target: <5ms p99 for 100-entry pages, regardless of history length.
+
+#### listActions (read path)
+
+1. Stream cursor over `user:<identityKey>:action-log:` prefix in reverse-seqno order. Filter by status / labels in-memory per page.
+2. Return.
+
+For deep history scans (rare): hand off to ClickHouse replica that materializes action-log into a columnar store. Background ingester keeps it within seconds of fresh.
+
+#### Broadcast pursuit + proof tracking
+
+- Pursuit is a global concern, not per-user. `tx-pursuit:<txid>` is a single KV entry per txid, mutated by the monitor goroutine. References (transaction IDs that care) are stored as a set within the entry. No per-user duplication.
+- When proof arrives: write `tx-proof:<txid>` (immutable proof facts). Fan-out notifications to each user with a pending reference.
+
+### Concurrency model
+
+- Worker pool per shard. RPC calls land on the worker for the requested user (consistent hash on identityKey).
+- Single-writer per user → no per-user locks. All user state mutations serialized through the owning worker.
+- Cross-user state (global pursuit, headers, settings) uses optimistic CAS via Aerospike's per-record version (generation) field.
+- Event log (Redpanda) gives durable ordering across all shards for replay/audit. Worker writes are mirrored to event log async; backpressure signal halts new RPC if log lag exceeds budget.
+
+### Read scalability
+
+- KV reads scale horizontally with shard count. 50K reads/s/node × 10 nodes = 500K reads/s ceiling on Aerospike alone.
+- Historical-range queries (listActions older than 7 days, listTransactions across years) go to ClickHouse replica. ClickHouse handles billions of rows per node on aggregate queries.
+- Hot working set (active wallets last 24h) stays in Aerospike RAM. Cold data evicts to SSD or to S3 + ClickHouse.
+
+### Blob storage
+
+- BEEF blobs, raw tx bytes, merkle paths over ~4KB: store in S3-compatible object store (R2, GCS, MinIO for self-host).
+- KV records hold blob references + ETag.
+- Small blobs (<4KB) inline in KV record for one-RTT fetch.
+
+### Configuration
+
+Config file selects backend:
+
+```yaml
+storage:
+  backend: embedded | single-node | cluster-hot | cluster-extreme
+  embedded:
+    path: ./data
+  aerospike:
+    seeds: ["aero-1:3000", "aero-2:3000"]
+    namespace: wallet
+  redpanda:
+    brokers: ["kafka-1:9092"]
+    topic: wallet-action-log
+  clickhouse:
+    url: clickhouse://...
+  blobs:
+    s3:
+      bucket: wallet-blobs
+      region: us-east-1
+```
+
+The Go binary is one artifact. The backend choice is runtime config. A user on a $5 VPS runs `embedded` with one process. An exchange runs `cluster-extreme` with the same binary.
+
+### Migration from existing Go schema
+
+None. Existing data is discarded. No migration path is provided. Operators wishing to retain existing storage stay on Option A (or fork pre-Option-B Go).
+
+### RPC compatibility
+
+The BRC-100 JSON-RPC wire format does not change. Wallet clients (BRC-100 SDKs, MetaNet apps) continue to work without modification. Only the storage backend implementation is replaced.
+
+## Impact
+
+### Affected capabilities
+
+- `storage-rpc` (primary spec, see delta)
+- `storage-schema` (deleted; no longer the conformance bar)
+- `storage-sync` (deleted; BRC-40 sync removed)
+- `wallet-actions` (rewired to KV ops)
+- `chaintracks-storage` (kept in storage; switches to KV-shaped headers)
+
+### Affected code surfaces
+
+Effectively a rewrite of `pkg/storage/`, `pkg/internal/storage/`, `pkg/wallet/` data-access paths. Estimated 60-70% of LOC under `pkg/` rewritten or deleted.
+
+### Deletions
+
+- `pkg/internal/storage/database/` — all gorm models + genquery output
+- `pkg/internal/storage/repo/syncrepo/` — BRC-40 sync implementation
+- `pkg/internal/storage/repo/migrator.go` — replaced by per-backend init
+- Any code path that depends on SQL transactions
+
+### Additions
+
+- `pkg/storage/backend/` — `Storage` interface + 4 driver packages (`embedded`, `singlenode`, `clusterhot`, `clusterextreme`)
+- `pkg/storage/keys/` — key-builder helpers (deterministic byte keys)
+- `pkg/storage/eventlog/` — Redpanda producer/consumer
+- `pkg/storage/blobs/` — S3-compatible blob store driver
+- `pkg/storage/materializer/` — async state materializer goroutines
+- `pkg/storage/coinpick/` — bucketed UTXO selection
+- `pkg/storage/clickhouse/` — historical query driver
+
+### Performance targets
+
+| Backend | tps | p50 latency | p99 latency | Storage cost/month for 1M users |
+|---------|-----|-------------|-------------|----------------------------------|
+| `embedded` | 100 | <5ms | <50ms | $5 (VPS) |
+| `single-node` | 5K | <3ms | <30ms | $50 (1 EC2 + S3) |
+| `cluster-hot` | 50K | <2ms | <10ms | $1K (3-node Aerospike + Redpanda + S3) |
+| `cluster-extreme` | 100K | <2ms | <15ms | $5K (10-node Aerospike + sharded Redpanda + ClickHouse + S3) |
+
+Targets are aspirational; Phase 0 baseline + Phase 14 bench confirm.
+
+### Breaking changes
+
+- All existing Go storage data is discarded on adoption.
+- BRC-40 sync no longer supported — any deployment that relies on sync must stay on Option A.
+- `pkg/storage/`'s public Go API is rewritten. Library consumers must migrate.
+- SQL-level introspection no longer possible.
+
+## Decisions confirmed by author
+
+1. **Drop BRC-40 sync entirely.** Multi-storage replication, if needed, is achieved by replaying the Redpanda event log, not by sync protocol.
+2. **Conformance bar = BRC-100 JSON-RPC only.** No TS schema parity.
+3. **Aerospike as the high-scale KV.** Alternatives (Scylla, FoundationDB, DynamoDB) considered; Aerospike chosen for sub-ms p99 on SSD and proven >1M ops/s/node.
+4. **One binary, runtime-config backend.** No build tags, no separate distros. Same code runs Pi → cluster.
+5. **No data migration.** Existing data is discarded.
+6. **Event log as canonical replay.** All state mutations land in Redpanda; KV is a materialized projection. Cluster restart rebuilds from event log if needed.
+7. **ClickHouse for historical reads.** OLAP queries get separate engine; KV stays narrow-fast.
+8. **Blobs in S3.** Raw tx > 4KB never live in hot KV.
+
+## Open questions
+
+1. Does the BRC-100 JSON-RPC contract leak any internal-state assumption (e.g., a method that returns an internal table row)? Phase 0 audit.
+2. Multi-device wallets historically rely on BRC-40 sync. What replication primitive replaces it for users who need multi-storage state? Candidate: event-log subscribe + materialize on second storage. Phase 0 prototype.
+3. Cost ceiling for `embedded` mode if BadgerDB I/O exceeds Raspberry-Pi SD-card endurance — consider EROFS or memory-only mode for ephemeral wallets.
+4. Aerospike vs ScyllaDB final decision. Bench both at Phase 4.
+5. Whether to support a `postgres` backend as a fifth driver for orgs that mandate SQL. Likely no — adds complexity and undermines the perf story.
+
+## Alternatives considered
+
+- **Option A — TS schema conformance.** Different goal. Lives in parallel; orgs pick A or B.
+- **Hybrid (RPC conformance + Postgres backend).** Cheap to ship, doesn't reach 100K tps. Defeats Option B's purpose.
+- **Fork Postgres-only Option A and add caching layer.** Postpones the throughput cliff but doesn't eliminate it. Joins still bottleneck.
+- **Pure event-sourcing without materialized KV.** Read latency unbounded; rejected.
+- **Single-node SQLite with WAL.** Caps at ~1K tps. Not in target range.

--- a/openspec/changes/optionb-rpc-only-ultra-perf/rpc-methods.md
+++ b/openspec/changes/optionb-rpc-only-ultra-perf/rpc-methods.md
@@ -1,0 +1,67 @@
+# BRC-100 JSON-RPC conformance method list
+
+Phase 0 task: confirm each method against the BRC-100 spec and against existing Go RPC handlers. This file is the authoritative method list for Option B.
+
+## Action lifecycle
+
+- [ ] `createAction`
+- [ ] `signAction`
+- [ ] `abortAction`
+- [ ] `internalizeAction`
+- [ ] `listActions`
+
+## Outputs
+
+- [ ] `listOutputs`
+- [ ] `relinquishOutput`
+
+## Transactions
+
+- [ ] `listTransactions` (Go-added; ensure BRC-100 alignment)
+
+## Certificates
+
+- [ ] `acquireCertificate`
+- [ ] `proveCertificate`
+- [ ] `relinquishCertificate`
+- [ ] `listCertificates`
+- [ ] `discoverByIdentityKey`
+- [ ] `discoverByAttributes`
+
+## Identity / authentication
+
+- [ ] `isAuthenticated`
+- [ ] `waitForAuthentication`
+- [ ] `getPublicKey`
+- [ ] `revealCounterpartyKeyLinkage`
+- [ ] `revealSpecificKeyLinkage`
+
+## Cryptographic ops
+
+- [ ] `encrypt`
+- [ ] `decrypt`
+- [ ] `createHmac`
+- [ ] `verifyHmac`
+- [ ] `createSignature`
+- [ ] `verifySignature`
+
+## Chain / network info
+
+- [ ] `getHeight`
+- [ ] `getHeaderForHeight`
+- [ ] `getNetwork`
+- [ ] `getVersion`
+
+## Audit / known issues (Phase 0)
+
+For each method below, audit:
+
+1. Does the request shape leak internal state (e.g. surrogate IDs returned in a prior call)?
+2. Does the response include any field that requires a particular storage shape to compute?
+3. Is there an implicit ordering requirement that depends on storage layout?
+
+Findings go in this file under `## Phase 0 audit findings` once Phase 0 begins.
+
+## Phase 0 audit findings
+
+(To be filled in during Phase 0.)

--- a/openspec/changes/optionb-rpc-only-ultra-perf/specs/storage-rpc/spec.md
+++ b/openspec/changes/optionb-rpc-only-ultra-perf/specs/storage-rpc/spec.md
@@ -108,6 +108,57 @@ When any of {materializer lag, event-log producer lag, backend client queue dept
 - **THEN** the server SHALL respond with 503
 - **AND** the response SHALL include `Retry-After` with a value derived from current lag
 
+### Requirement: Cluster-internal RPC is gRPC + protobuf
+
+For `cluster-hot` and `cluster-extreme` backends, worker-to-worker and worker-to-materializer RPC SHALL use gRPC over HTTP/2 with protobuf-encoded messages. External BRC-100 JSON-RPC SHALL be the only edge protocol; the gateway worker SHALL translate each incoming BRC-100 call into internal gRPC calls exactly once.
+
+#### Scenario: Edge protocol unchanged
+
+- **GIVEN** an external BRC-100 client speaking JSON-RPC over HTTP/2
+- **WHEN** the client invokes a method against a `cluster-hot` deployment
+- **THEN** the client SHALL observe BRC-100 JSON-RPC semantics exactly
+- **AND** the use of gRPC internally SHALL not leak to the client
+
+#### Scenario: Internal traffic uses gRPC
+
+- **GIVEN** two worker nodes in the same cluster
+- **WHEN** one worker dispatches a cross-shard operation to another
+- **THEN** the wire format SHALL be gRPC + protobuf
+- **AND** the connection SHALL use mTLS for authentication
+
+### Requirement: In-memory mode for embedded driver
+
+The `embedded` driver SHALL support a `--memory-only` flag that initializes BadgerDB with `Options.InMemory = true`. In this mode, no data persists across process restarts.
+
+#### Scenario: In-memory mode
+
+- **GIVEN** the `embedded` driver started with `--memory-only`
+- **WHEN** state-mutating RPCs are processed
+- **THEN** state SHALL be held only in process memory
+- **AND** all behavioural conformance tests SHALL pass against this mode
+- **AND** process termination SHALL discard all state
+
+### Requirement: Aerospike is the sole cluster KV
+
+Cluster backends SHALL use Aerospike as the primary KV. No alternative KV driver (ScyllaDB, FoundationDB, DynamoDB, etc.) SHALL be included in Option B v1.
+
+#### Scenario: Backend tier inspection
+
+- **GIVEN** any `cluster-hot` or `cluster-extreme` deployment
+- **WHEN** the backend driver is inspected
+- **THEN** the underlying KV SHALL be Aerospike
+
+### Requirement: Read-your-writes is strict
+
+The RPC contract SHALL guarantee that any read issued by a caller after a successful write from the same caller observes the effect of that write. Implementations SHALL block reads on materializer catch-up with a bounded timeout (default 500ms). On timeout, the read SHALL return 503.
+
+#### Scenario: Sequential write then read
+
+- **GIVEN** a caller invokes `createAction` and receives 200 OK
+- **WHEN** the same caller immediately invokes `listOutputs`
+- **THEN** the response SHALL include the outputs from the just-created action
+- **AND** if materializer catch-up exceeds 500ms, the response SHALL be 503 with `Retry-After`
+
 ### Requirement: Performance budgets per tier
 
 Each backend tier SHALL meet the following budgets under steady-state load at its target tps:

--- a/openspec/changes/optionb-rpc-only-ultra-perf/specs/storage-rpc/spec.md
+++ b/openspec/changes/optionb-rpc-only-ultra-perf/specs/storage-rpc/spec.md
@@ -1,0 +1,152 @@
+# Spec delta — `storage-rpc` capability
+
+Adds Option B's RPC-only conformance bar and the storage backend interface contract. Removes BRC-40 sync.
+
+## ADDED Requirements
+
+### Requirement: BRC-100 JSON-RPC as the sole conformance bar
+
+The wallet storage layer SHALL conform to the BRC-100 JSON-RPC wallet method contract. No internal-state shape, no schema layout, and no storage backend choice is part of the conformance bar.
+
+#### Scenario: BRC-100 method invocation
+
+- **GIVEN** a wallet client that speaks BRC-100 JSON-RPC
+- **WHEN** the client calls any method in the BRC-100 surface area (e.g. `createAction`, `listOutputs`, `internalizeAction`)
+- **THEN** the response SHALL match the BRC-100 contract exactly
+- **AND** no observable behaviour SHALL depend on which backend driver the storage layer uses
+
+#### Scenario: Backend swap is transparent
+
+- **GIVEN** a wallet client connected to a Go wallet storage running the `embedded` backend
+- **WHEN** the operator switches the backend to `cluster-extreme` and replays the user's event log
+- **THEN** subsequent client calls SHALL return identical results to the embedded run for any deterministic method
+
+### Requirement: `Storage` interface as backend abstraction
+
+A single `Storage` Go interface in `pkg/storage/backend/storage.go` SHALL define every operation the wallet domain needs. Every backend driver SHALL implement this interface exactly.
+
+The interface SHALL be expressed in domain terms (`SelectCoins`, `AppendActionLog`, `GetUTXO`, `MaterializeAction`) and SHALL NOT expose tables, columns, joins, or transactions.
+
+#### Scenario: Driver pluggability
+
+- **GIVEN** a Go package implementing the `Storage` interface
+- **WHEN** the wallet domain layer is initialized with that driver
+- **THEN** all wallet RPC behaviour SHALL work without any change to the domain layer
+
+#### Scenario: Behavioural conformance test
+
+- **GIVEN** the wallet behavioural test suite under `test/storage-conformance/`
+- **WHEN** the suite is run against any `Storage` driver
+- **THEN** all tests SHALL pass
+
+### Requirement: Backend tiers
+
+Four backend drivers SHALL be provided, each implementing the `Storage` interface:
+
+| Driver name | Target deploy | Backing tech |
+|-------------|---------------|--------------|
+| `embedded` | 10–100 tps | BadgerDB |
+| `single-node` | 100–5K tps | BadgerDB + optional ClickHouse |
+| `cluster-hot` | 5K–50K tps | Aerospike + Redpanda + S3 |
+| `cluster-extreme` | 50K–100K tps | Sharded Aerospike + sharded Redpanda + ClickHouse + S3 |
+
+#### Scenario: Backend selected by config
+
+- **GIVEN** a `config.yaml` with `storage.backend = "cluster-hot"`
+- **WHEN** the wallet starts
+- **THEN** the `cluster-hot` driver SHALL be loaded
+- **AND** no other driver SHALL be initialized
+
+### Requirement: Event log as canonical replay
+
+Every state-mutating RPC call SHALL produce an event in a durable, ordered event log (Redpanda for cluster tiers; embedded log file for `embedded` and `single-node`). The KV state SHALL be a materialized projection of the event log.
+
+#### Scenario: Crash recovery
+
+- **GIVEN** a wallet storage node whose KV backend has lost data
+- **WHEN** the node restarts with the event log intact
+- **THEN** the materializer SHALL rebuild KV state by replaying events from the last checkpoint
+- **AND** the rebuilt state SHALL be functionally identical to pre-crash state
+
+#### Scenario: Multi-device replication via event log
+
+- **GIVEN** two wallet storage nodes serving the same user
+- **WHEN** one node writes events to the user's event log partition
+- **THEN** the other node's materializer SHALL consume those events
+- **AND** the second node's KV state SHALL converge to the first node's state
+
+### Requirement: Bucketed UTXO selection
+
+UTXO coin selection SHALL achieve O(log) complexity in the UTXO count, via per-user, per-basket bucket indexes keyed by satoshi range.
+
+#### Scenario: Selection scales with UTXO count
+
+- **GIVEN** a user with 10K UTXOs
+- **AND** the same user later with 100K UTXOs
+- **WHEN** coin selection runs for an arbitrary target amount
+- **THEN** p99 selection latency SHALL be within 2× across both scenarios
+
+### Requirement: Read-your-writes via cursor
+
+The RPC contract SHALL preserve read-your-writes semantics: a write that has returned to the caller SHALL be visible on subsequent reads from the same caller.
+
+#### Scenario: Write then read
+
+- **GIVEN** a caller invokes `createAction` and receives a successful response
+- **WHEN** the caller invokes `listOutputs` immediately afterward
+- **THEN** the outputs from the just-created action SHALL appear in results
+- **AND** the read SHALL block (up to a bounded timeout) on materializer catch-up if needed
+
+### Requirement: Backpressure as 503 with Retry-After
+
+When any of {materializer lag, event-log producer lag, backend client queue depth} exceeds a per-backend threshold, the RPC server SHALL respond with HTTP 503 and a `Retry-After` header.
+
+#### Scenario: Materializer falls behind
+
+- **GIVEN** the materializer is > 5 seconds behind the event log
+- **WHEN** a new state-mutating RPC arrives
+- **THEN** the server SHALL respond with 503
+- **AND** the response SHALL include `Retry-After` with a value derived from current lag
+
+### Requirement: Performance budgets per tier
+
+Each backend tier SHALL meet the following budgets under steady-state load at its target tps:
+
+| Tier | tps | p50 | p99 |
+|------|-----|-----|-----|
+| `embedded` | 100 | < 5ms | < 50ms |
+| `single-node` | 5K | < 3ms | < 30ms |
+| `cluster-hot` | 50K | < 2ms | < 10ms |
+| `cluster-extreme` | 100K | < 2ms | < 15ms |
+
+#### Scenario: Tier meets budget
+
+- **GIVEN** a deploy of any tier at its target tps
+- **WHEN** sustained load is applied for 30 minutes
+- **THEN** measured p50 and p99 latencies SHALL meet the budget for that tier
+
+## REMOVED Requirements
+
+### Requirement: BRC-40 sync protocol
+
+**Reason:** Option B does not implement BRC-40 sync. Multi-storage replication is achieved by event-log subscription instead. Operators who need BRC-40 sync compatibility take Option A.
+
+**Migration:** No migration. Existing BRC-40 sync code is deleted.
+
+### Requirement: Schema portability with `ts-stack/wallet-toolbox`
+
+**Reason:** Option B's internal state is not a relational schema; it is a KV-shaped projection. No schema portability is offered or implied.
+
+**Migration:** Internal data tooling that expected SQL-level introspection is unsupported.
+
+### Requirement: SQL backend
+
+**Reason:** SQL backends cap throughput well below Option B's 100K tps target. No SQL driver is included.
+
+**Migration:** Operators who want SQL choose Option A.
+
+### Requirement: Direct table access from application code
+
+**Reason:** Option B exposes only the `Storage` interface. No application code touches tables, columns, or transactions directly.
+
+**Migration:** All application code is rewritten against the `Storage` interface during Phase 3.

--- a/openspec/changes/optionb-rpc-only-ultra-perf/tasks.md
+++ b/openspec/changes/optionb-rpc-only-ultra-perf/tasks.md
@@ -1,0 +1,137 @@
+# Tasks — Option B RPC-only ultra-performance storage
+
+Sequenced by risk. Each phase is independently mergeable. Early phases are foundational; later phases scale.
+
+## Phase 0 — Audit and baseline
+
+- [ ] Enumerate every BRC-100 JSON-RPC method consumed by the existing `pkg/storage/` and `pkg/wallet/`. Build the conformance method list in `rpc-methods.md`.
+- [ ] Audit each method for internal-state leakage (e.g., returns surrogate IDs the client must roundtrip). Flag any leaks; design around them.
+- [ ] Prototype event-log replay between two storage instances to confirm it can replace BRC-40 sync for multi-device users.
+- [ ] Capture baseline benchmark of the current `pkg/storage/provider.go` against a SQLite backend at 10/100/1000/5000 tps. Save to `bench/baseline-current-storage.md`.
+- [ ] Stand up a one-node Aerospike + one-node Redpanda + one-node ClickHouse + MinIO test environment via docker-compose. Document setup in `infra/optionb-dev/`.
+
+## Phase 1 — `Storage` interface and key-builder
+
+- [ ] Define `pkg/storage/backend/storage.go`: the canonical `Storage` interface exposing every domain operation the RPC layer needs. No table accessors. Operations are e.g. `GetUser`, `PutUser`, `SelectCoins(userID, amount, basket)`, `AppendActionLog(userID, event)`, `MaterializeAction(userID, txid)`, `GetUTXO(userID, outpoint)`, etc.
+- [ ] Define `pkg/storage/keys/keys.go`: deterministic byte-key builders for every entity. Functions like `UserKey(identityKey)`, `UTXOKey(identityKey, outpoint)`, `ActionLogKey(identityKey, seqno)`. All keys are byte slices; never strings post-encoding.
+- [ ] Write fuzz tests that confirm key builders produce sortable, prefix-scannable byte ranges for cursor iteration.
+- [ ] Write a `MemStorage` reference impl of `Storage` (in-memory map) for unit tests.
+
+## Phase 2 — Embedded BadgerDB driver
+
+- [ ] Implement `pkg/storage/backend/embedded/badger.go` against the `Storage` interface.
+- [ ] Wire BadgerDB lifecycle (open, close, GC, value log).
+- [ ] Implement prefix scans for list operations using BadgerDB iterators.
+- [ ] Add CAS via BadgerDB's `Txn` with conflict detection.
+- [ ] Conformance test suite: run a wallet RPC harness against the embedded backend. All BRC-100 methods must pass.
+- [ ] Bench embedded at 10/100/500/1000 tps. Save to `bench/embedded.md`.
+
+## Phase 3 — RPC layer rewire
+
+- [ ] Replace all `pkg/storage/provider.go` methods with calls to the `Storage` interface. Drop the gorm-backed implementation.
+- [ ] Delete `pkg/internal/storage/database/`.
+- [ ] Delete `pkg/internal/storage/repo/`.
+- [ ] Delete `pkg/internal/storage/repo/syncrepo/`.
+- [ ] Rewire `pkg/wallet/` and `pkg/storage/internal/actions/` to call `Storage`-interface methods.
+- [ ] Run existing wallet behavioural tests against `embedded` driver. Fix breakages.
+
+## Phase 4 — Bucketed UTXO selection
+
+- [ ] Design satoshi-range bucket scheme. Buckets are log-scale (e.g. `[0,1K)`, `[1K,10K)`, `[10K,100K)`, ...). Per-user, per-basket bucket index lives at `user:<id>:basket:<name>:bucket:<range>` → SortedSet of outpoints.
+- [ ] Implement `SelectCoins(userID, amount, basket)`: pick the smallest bucket whose total ≥ amount, scan within. Worst-case O(bucket count) ≈ O(log satoshi range).
+- [ ] Maintain bucket index on every UTXO add/spend in the materializer.
+- [ ] Bench selection latency vs naive scan at 10K/100K UTXOs per user. Confirm O(log) behaviour.
+
+## Phase 5 — Event log integration (Redpanda)
+
+- [ ] Implement `pkg/storage/eventlog/redpanda.go`: producer publishes every state-mutating RPC as an event. Topic per shard.
+- [ ] Implement consumer that materializes events into the local KV. Idempotent on seqno.
+- [ ] Define event schema: protobuf or msgpack, versioned.
+- [ ] Backpressure: if consumer lags > N seconds, RPC layer signals 503 with retry-after.
+- [ ] Single-node mode: in-process log file (`pkg/storage/eventlog/embedded.go`) for `embedded` and `single-node` backends.
+
+## Phase 6 — Async materializer
+
+- [ ] Implement `pkg/storage/materializer/materializer.go`: per-shard goroutine that consumes the local event log and updates KV projections.
+- [ ] Idempotency: every event carries (shard, seqno); materializer dedups by `materializer:cursor:<shard>` checkpoint.
+- [ ] Crash recovery: restart resumes from last checkpoint, replays missing events.
+- [ ] Bench: how many events/sec one materializer goroutine can absorb. Target 200K events/s per core.
+
+## Phase 7 — S3 blob driver
+
+- [ ] Implement `pkg/storage/blobs/s3.go`: read/write blobs by content hash (sha256).
+- [ ] Inline cutoff: blobs ≤ 4KB stay inline in KV record; > 4KB go to S3, KV stores reference.
+- [ ] Background uploader: KV writes can return before S3 upload completes; uploader retries with exponential backoff.
+- [ ] Local fallback driver for `embedded` mode: filesystem-backed blob store.
+- [ ] Bench: blob fetch latency from S3 at p50/p99. Establish if read-through caching is needed.
+
+## Phase 8 — Aerospike driver
+
+- [ ] Implement `pkg/storage/backend/aerospike/aerospike.go` against the `Storage` interface.
+- [ ] Configure namespace, set, indexes. Use Aerospike's per-record generation for CAS.
+- [ ] Prefix scans via Aerospike's `Scan` API or secondary indexes on key prefix.
+- [ ] Sharding: identityKey hash → Aerospike partition. Confirm hot-key avoidance (no single-bin hotspots).
+- [ ] Run wallet RPC harness against Aerospike backend.
+- [ ] Bench at 1K/5K/10K/25K/50K tps single-node Aerospike. Save to `bench/aerospike-single.md`.
+
+## Phase 9 — ClickHouse historical reads
+
+- [ ] Define historical schema: append-only `actions` table partitioned by date, ordered by `(userId, timestamp)`.
+- [ ] Background ingester: Redpanda consumer that writes events to ClickHouse in batched inserts.
+- [ ] `listActions` with deep-history filter routes to ClickHouse; recent (<7d) stays in KV.
+- [ ] Verify ClickHouse query latency for typical filters (userId + label + date range).
+- [ ] Bench historical query latency at 1M, 100M, 1B rows in ClickHouse.
+
+## Phase 10 — Sharding and consistent-hash routing
+
+- [ ] Implement consistent-hash router for `cluster-hot` and `cluster-extreme` backends: identityKey → shard ID.
+- [ ] Worker pool per shard; RPC dispatcher routes incoming calls to the owning worker.
+- [ ] Rebalancing: shard map versioned; rebalance moves a user's state by replaying their event log on the new shard.
+- [ ] Bench: routing overhead per RPC call. Target < 50μs.
+
+## Phase 11 — Cluster-hot backend wiring
+
+- [ ] Implement `pkg/storage/backend/clusterhot/cluster.go`: composes Aerospike + Redpanda + S3 + materializer + router.
+- [ ] Conformance test against full wallet RPC suite.
+- [ ] Bench end-to-end at 5K/10K/25K/50K tps on a 3-node test cluster.
+
+## Phase 12 — Cluster-extreme backend wiring
+
+- [ ] Implement `pkg/storage/backend/clusterextreme/cluster.go`: composes sharded Aerospike + sharded Redpanda + ClickHouse + S3 + materializer + router.
+- [ ] Conformance test.
+- [ ] Bench at 50K/75K/100K tps on a 10-node test cluster.
+- [ ] Tail-latency profile under sustained load. Document p99/p99.9.
+
+## Phase 13 — Backpressure and graceful degradation
+
+- [ ] RPC entrypoint reads three signals: materializer lag, event-log producer lag, Aerospike client queue depth.
+- [ ] When any signal trips threshold: return 503 with `Retry-After`. Define thresholds per backend.
+- [ ] Test under intentional partition: kill an Aerospike node, kill a Redpanda broker, verify graceful degradation.
+
+## Phase 14 — Observability
+
+- [ ] Prometheus metrics on every backend driver: ops/s, p50/p99 latency, error rate, queue depth.
+- [ ] OpenTelemetry tracing on RPC path.
+- [ ] Per-shard tps dashboards.
+- [ ] Alerting rules for materializer lag, ClickHouse ingester lag, S3 upload failure rate.
+
+## Phase 15 — Cost optimization sweep
+
+- [ ] At each backend tier, measure $/1K-ops. Document in `cost-curve.md`.
+- [ ] Tune Aerospike write-block size, hash-table memory, defrag-startup-minimum to lower RAM footprint.
+- [ ] Tune ClickHouse compression codecs, partition pruning.
+- [ ] Tune S3 storage class (Standard → IA → Glacier) per blob age.
+- [ ] Validate "10 tps for $5/month" claim end to end.
+
+## Phase 16 — Documentation and rollout
+
+- [ ] `docs/storage-optionb.md` — operator guide for each backend tier.
+- [ ] Migration guide: there is no migration path; document expected discard.
+- [ ] Decision tree: when to pick Option B over Option A.
+- [ ] Update CHANGELOG with breaking notice.
+
+## Phase 17 — Archive change
+
+- [ ] Verify all phases merged.
+- [ ] Run `openspec archive` to merge deltas into main specs.
+- [ ] Tag release.

--- a/openspec/changes/optionb-rpc-only-ultra-perf/tasks.md
+++ b/openspec/changes/optionb-rpc-only-ultra-perf/tasks.md
@@ -23,7 +23,8 @@ Sequenced by risk. Each phase is independently mergeable. Early phases are found
 - [ ] Wire BadgerDB lifecycle (open, close, GC, value log).
 - [ ] Implement prefix scans for list operations using BadgerDB iterators.
 - [ ] Add CAS via BadgerDB's `Txn` with conflict detection.
-- [ ] Conformance test suite: run a wallet RPC harness against the embedded backend. All BRC-100 methods must pass.
+- [ ] **In-memory mode**: support `--memory-only` flag; initialize BadgerDB with `Options.InMemory = true`. Zero-durability semantics documented. Tests and ephemeral wallets use this mode.
+- [ ] Conformance test suite: run a wallet RPC harness against the embedded backend, both durable and in-memory modes. All BRC-100 methods must pass.
 - [ ] Bench embedded at 10/100/500/1000 tps. Save to `bench/embedded.md`.
 
 ## Phase 3 — RPC layer rewire
@@ -88,6 +89,16 @@ Sequenced by risk. Each phase is independently mergeable. Early phases are found
 - [ ] Worker pool per shard; RPC dispatcher routes incoming calls to the owning worker.
 - [ ] Rebalancing: shard map versioned; rebalance moves a user's state by replaying their event log on the new shard.
 - [ ] Bench: routing overhead per RPC call. Target < 50μs.
+
+## Phase 10a — Cluster-internal gRPC layer
+
+- [ ] Define protobuf schema (`pkg/storage/internalrpc/proto/`) for every worker-to-worker and worker-to-materializer call. Mirror the `Storage` interface where applicable.
+- [ ] Generate Go stubs via `buf generate` or `protoc-gen-go-grpc`.
+- [ ] Implement gRPC server on each worker; expose only intra-cluster operations on a separate listener from the BRC-100 JSON-RPC edge.
+- [ ] Implement gRPC client wrapper that the router uses for cross-shard dispatch.
+- [ ] Edge gateway: translates incoming BRC-100 JSON-RPC into internal gRPC calls. One translation per request.
+- [ ] Bench: per-call CPU cost JSON-RPC vs gRPC for the same operation. Target ≥4x reduction.
+- [ ] Secure intra-cluster traffic: mTLS between workers; cert rotation strategy documented.
 
 ## Phase 11 — Cluster-hot backend wiring
 


### PR DESCRIPTION
## Summary

- Rebuilds storage layer from the ground up for extreme throughput.
- Conformance bar = BRC-100 JSON-RPC only. Drops BRC-40 sync entirely. Internal schema is implementation detail.
- One Go binary; four backend tiers selected by runtime config.
- Planning artifacts only — no code changes in this PR.

## Targets

| Tier | tps | p99 | Cost/mo |
|------|-----|-----|---------|
| `embedded` (BadgerDB) | 100 | <50ms | $5 |
| `single-node` (BadgerDB + opt ClickHouse) | 5K | <30ms | $50 |
| `cluster-hot` (Aerospike + Redpanda + S3) | 50K | <10ms | $1K |
| `cluster-extreme` (sharded Aerospike + Redpanda + ClickHouse + S3) | 100K | <15ms | $5K |

## Architecture

- **Event log** (Redpanda or embedded) is canonical; KV is a materialized projection.
- **Single-writer per user** worker model — no per-user locks.
- **Consistent-hash sharding** on identityKey.
- **Bucketed UTXO selection** by satoshi range — O(log) coin pick regardless of UTXO count.
- **S3 blobs** for BEEF / raw tx > 4KB; KV stays narrow-fast.
- **ClickHouse** for historical aggregate queries (listActions over deep history).
- **Backpressure** via HTTP 503 + Retry-After when materializer or log producer lags.

## What's in the PR

```
openspec/changes/optionb-rpc-only-ultra-perf/
├── proposal.md       # why, what, locked decisions, alternatives
├── tasks.md          # 17-phase task list
├── design.md         # arch, tech choice rationale, risk register, bottleneck analysis
├── rpc-methods.md    # BRC-100 method conformance list (Phase 0 fills audit)
└── specs/storage-rpc/spec.md   # ADDED + REMOVED requirements
```

## Locked decisions

- Drop BRC-40 sync; multi-device replication via event log subscription.
- BRC-100 JSON-RPC is the only conformance bar.
- Aerospike default for cluster KV; ScyllaDB as fallback if Phase 8 bench surfaces issues.
- One binary, runtime-configured backend.
- No data migration from existing Go storage.
- Event log as source of truth, KV as projection.

## Anticipated bottlenecks at 100K tps

1. JSON-RPC parsing → sonic / msgpack at top tier.
2. ECDSA verify → cached pre-computed pubkeys + batch.
3. Aerospike client throughput per Go process → fan out via multi-process.
4. GC pauses → pool buffers, tune GOGC.

## Test plan

- [ ] Reviewers validate BRC-100 method list completeness in `rpc-methods.md`
- [ ] Reviewers confirm 17-phase sequencing is reasonable
- [ ] Reviewers stress-test the "no BRC-40 sync, use event log instead" replacement strategy
- [ ] Phase 0 (audit + baseline + dev-env stand-up) lands before any code change

## Related

- Option A (TS schema conformance) lives in parallel on `feat/schema-conformance-optiona` (PR #895). Operators pick A or B based on whether they need sync portability vs throughput.

🤖 Generated with [Claude Code](https://claude.com/claude-code)