### PR TITLE
feat: conformance tests relinquish outputs

### DIFF
--- a/pkg/wallet/brc100_conformance_test.go
+++ b/pkg/wallet/brc100_conformance_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/bsv-blockchain/go-sdk/transaction"
 	sdk "github.com/bsv-blockchain/go-sdk/wallet"
 
 	brc100vectors "github.com/bsv-blockchain/go-wallet-toolbox/conformance/vectors/wallet/brc100"
@@ -231,6 +232,81 @@ func TestBRC100Conformance_ListOutputs(t *testing.T) {
 			}
 			require.Equal(t, expTotal, res.TotalOutputs, "totalOutputs mismatch for %s", v.ID)
 			require.Empty(t, res.Outputs, "outputs should be empty for %s", v.ID)
+		})
+	}
+}
+
+// TestBRC100Conformance_RelinquishOutput covers all 8 BRC-100 relinquishOutput vectors.
+//
+// Vectors 1, 6, 8 (basket "default"): seeded via faucet — the placeholder txid in the
+// vector is replaced with the real outpoint from the faucet transaction.
+//
+// Vectors 2, 3, 7 (baskets "tokens", "payments", "invoices"): seeded via InternalizeAction
+// with BasketInsertion protocol — the placeholder txid is replaced with the real outpoint.
+//
+// Vector 4 (output not found): error path, runs on a fresh wallet.
+// Vector 5 (invalid outpoint format): the SDK's Outpoint.UnmarshalJSON rejects
+// "invalid-outpoint" before the wallet is called; this is the expected error behaviour.
+func TestBRC100Conformance_RelinquishOutput(t *testing.T) {
+	vectors := loadBRC100Vectors(t, brc100vectors.RelinquishOutputVectors)
+	for _, v := range vectors {
+		t.Run(v.ID, func(t *testing.T) {
+			given, cleanup := testabilities.Given(t)
+			defer cleanup()
+
+			argsJSON, err := json.Marshal(v.Input.Args)
+			require.NoError(t, err)
+
+			var args sdk.RelinquishOutputArgs
+			if err := json.Unmarshal(argsJSON, &args); err != nil {
+				// Vector 5: "invalid-outpoint" is rejected by OutpointFromString before
+				// reaching the wallet — invalid input causing an error is the expected behaviour.
+				t.Logf("note: %s — args unmarshal failed as expected (invalid outpoint format): %v", v.ID, err)
+				return
+			}
+
+			originator := v.Input.Originator
+			if originator == "" {
+				originator = "brc100-test.example.com"
+			}
+
+			// Vectors with a skip_reason require a pre-existing output in storage.
+			if v.SkipReason != "" {
+				aliceWallet := given.AliceWalletWithStorage(testabilities.StorageTypeSQLite)
+
+				if args.Basket == "default" {
+					// Seed "default" basket via faucet; replace the placeholder txid with the real one.
+					txSpec, _ := given.Faucet(aliceWallet).TopUp(99904)
+					args.Output = transaction.Outpoint{
+						Txid:  *txSpec.TX().TxID(),
+						Index: 0,
+					}
+				} else {
+					// Seed a named basket via InternalizeAction with BasketInsertion protocol.
+					internalizeArgs := fixtures.DefaultWalletInternalizeActionArgs(t, sdk.InternalizeProtocolBasketInsertion)
+					internalizeArgs.Outputs[0].InsertionRemittance.Basket = args.Basket
+					internalizedTx, txErr := transaction.NewTransactionFromBEEF(internalizeArgs.Tx)
+					require.NoError(t, txErr)
+					_, internalizeErr := aliceWallet.InternalizeAction(context.Background(), internalizeArgs, originator)
+					require.NoError(t, internalizeErr)
+					args.Output = transaction.Outpoint{
+						Txid:  *internalizedTx.TxID(),
+						Index: 0,
+					}
+				}
+
+				res, err := aliceWallet.RelinquishOutput(context.Background(), args, originator)
+				require.NoError(t, err)
+				require.NotNil(t, res)
+				require.True(t, res.Relinquished, "relinquished mismatch for %s", v.ID)
+				return
+			}
+
+			// Error-path vectors (no skip_reason): fresh wallet, expect an error.
+			aliceWallet := given.AliceWalletWithStorage(testabilities.StorageTypeSQLite)
+			res, err := aliceWallet.RelinquishOutput(context.Background(), args, originator)
+			require.Error(t, err, "expected error for %s", v.ID)
+			require.Nil(t, res)
 		})
 	}
 }

--- a/pkg/wallet/brc100_conformance_test.go
+++ b/pkg/wallet/brc100_conformance_test.go
@@ -368,7 +368,7 @@ func TestBRC100Conformance_ProveCertificate(t *testing.T) {
 //
 // Vector 4 (output not found): error path, runs on a fresh wallet.
 // Vector 5 (invalid outpoint format): the SDK's Outpoint.UnmarshalJSON rejects
-// "invalid-outpoint" before the wallet is called; this is the expected error behaviour.
+// "invalid-outpoint" before the wallet is called; this is the expected error behavior.
 func TestBRC100Conformance_RelinquishOutput(t *testing.T) {
 	vectors := loadBRC100Vectors(t, brc100vectors.RelinquishOutputVectors)
 	for _, v := range vectors {
@@ -380,10 +380,10 @@ func TestBRC100Conformance_RelinquishOutput(t *testing.T) {
 			require.NoError(t, err)
 
 			var args sdk.RelinquishOutputArgs
-			if err := json.Unmarshal(argsJSON, &args); err != nil {
+			if unmarshalErr := json.Unmarshal(argsJSON, &args); unmarshalErr != nil {
 				// Vector 5: "invalid-outpoint" is rejected by OutpointFromString before
-				// reaching the wallet — invalid input causing an error is the expected behaviour.
-				t.Logf("note: %s — args unmarshal failed as expected (invalid outpoint format): %v", v.ID, err)
+				// reaching the wallet — invalid input causing an error is the expected behavior.
+				t.Logf("note: %s — args unmarshal failed as expected (invalid outpoint format): %v", v.ID, unmarshalErr)
 				return
 			}
 
@@ -417,10 +417,10 @@ func TestBRC100Conformance_RelinquishOutput(t *testing.T) {
 					}
 				}
 
-				res, err := aliceWallet.RelinquishOutput(context.Background(), args, originator)
-				require.NoError(t, err)
-				require.NotNil(t, res)
-				require.True(t, res.Relinquished, "relinquished mismatch for %s", v.ID)
+				relinquishRes, relinquishErr := aliceWallet.RelinquishOutput(context.Background(), args, originator)
+				require.NoError(t, relinquishErr)
+				require.NotNil(t, relinquishRes)
+				require.True(t, relinquishRes.Relinquished, "relinquished mismatch for %s", v.ID)
 				return
 			}
 


### PR DESCRIPTION
## What Changed
  - Added `TestBRC100Conformance_RelinquishOutput` in `pkg/wallet/brc100_conformance_test.go` covering all 8 BRC-100 `relinquishOutput` vectors
  - Vectors 1, 6, 8 (`"default"` basket): seeded via `Faucet.TopUp`, placeholder txid replaced with real faucet outpoint
  - Vectors 2, 3, 7 (custom baskets `"tokens"`, `"payments"`, `"invoices"`): seeded via `InternalizeAction` with `BasketInsertion` protocol, txid extracted from BEEF via
   `transaction.NewTransactionFromBEEF`
  - Vector 4 (output not found): error-path on a fresh wallet
  - Vector 5 (invalid outpoint format): `OutpointFromString` rejects `"invalid-outpoint"` during JSON unmarshalling — expected behaviour, no wallet call made

  ## Why It Was Necessary
  - Completes the `relinquishOutput` coverage started in the BRC-100 conformance test suite
  - Previous iteration skipped vectors 2, 3, 7 because seeding outputs into non-default baskets had no test fixture support; this PR implements that seeding pattern via
  `InternalizeAction`

  ## Testing Performed
  - `go test ./pkg/wallet/... -run TestBRC100Conformance_RelinquishOutput -v` — all 8 vectors pass

  ## Impact / Risk
  - Test-only change, no production code modified
  - Low risk
