### PR TITLE
Prevent false double-spend verdicts from corrupting wallet UTXO state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/mock v0.6.0
+	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/datatypes v1.2.7
 	gorm.io/driver/mysql v1.6.0
@@ -257,7 +258,6 @@ require (
 	golang.org/x/telemetry v0.0.0-20260603145448-488200d49c17 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	gonum.org/v1/gonum v0.17.0 // indirect

--- a/pkg/defs/services.go
+++ b/pkg/defs/services.go
@@ -126,6 +126,7 @@ func DefaultServicesConfig(chain BSVNetwork) WalletServices {
 			},
 			RootForHeightRetryInterval: DefaultRootForHeightRetryInterval,
 			RootForHeightRetries:       DefaultRootForHeightRetries,
+			RequestsPerSecond:          DefaultWhatsOnChainRequestsPerSecond,
 		},
 		Bitails: Bitails{
 			Enabled:                    false, // NOTE: Bitails is disabled by default

--- a/pkg/defs/whats_on_chain.go
+++ b/pkg/defs/whats_on_chain.go
@@ -5,6 +5,10 @@ import (
 	"time"
 )
 
+// DefaultWhatsOnChainRequestsPerSecond is the WhatsOnChain rate limit for requests
+// without an API key.
+const DefaultWhatsOnChainRequestsPerSecond = 3
+
 // WhatsOnChain is a struct that configures WhatsOnChain service
 type WhatsOnChain struct {
 	Enabled                    bool            `mapstructure:"enabled"`
@@ -13,6 +17,13 @@ type WhatsOnChain struct {
 	BSVUpdateInterval          *time.Duration  `mapstructure:"bsv_update_interval"`
 	RootForHeightRetryInterval time.Duration   `mapstructure:"root_for_height_retry_interval"`
 	RootForHeightRetries       int             `mapstructure:"root_for_height_retries"`
+
+	// RequestsPerSecond throttles all requests to WhatsOnChain on the client side, so
+	// the service's rate limit is not exceeded (which would yield 429 responses and turn
+	// into broadcast failures). When 0, DefaultWhatsOnChainRequestsPerSecond is used -
+	// the limit WhatsOnChain applies to requests without an API key. With an API key the
+	// value should be set to the limit of the purchased plan (e.g. 10).
+	RequestsPerSecond float64 `mapstructure:"requests_per_second"`
 }
 
 // Validate checks if the WhatsOnChain configuration is valid
@@ -23,6 +34,10 @@ func (woc *WhatsOnChain) Validate() error {
 
 	if err := woc.BSVExchangeRate.Validate(); err != nil {
 		return fmt.Errorf("invalid BSV exchange rate: %w", err)
+	}
+
+	if woc.RequestsPerSecond < 0 {
+		return fmt.Errorf("requests per second cannot be negative")
 	}
 
 	return nil

--- a/pkg/internal/testabilities/fixture_provider.go
+++ b/pkg/internal/testabilities/fixture_provider.go
@@ -118,6 +118,8 @@ func (p *providerFixture) withServices() ProviderFixture {
 
 	config := defs.DefaultServicesConfig(p.network)
 	config.BHS.Enabled = true
+	// NOTE: tests should not be slowed down by the client-side WoC rate limiter
+	config.WhatsOnChain.RequestsPerSecond = 10000
 
 	p.services = services.New(p.logger, config, services.WithRestyClient(client))
 	return p

--- a/pkg/internal/testabilities/testservices/fixture_services.go
+++ b/pkg/internal/testabilities/testservices/fixture_services.go
@@ -70,6 +70,8 @@ func givenServicesWithNetwork(t testing.TB, network defs.BSVNetwork) ServicesFix
 	servicesConfig := defs.DefaultServicesConfig(network)
 	servicesConfig.WhatsOnChain.RootForHeightRetries = 1
 	servicesConfig.WhatsOnChain.RootForHeightRetryInterval = 0
+	// NOTE: tests should not be slowed down by the client-side WoC rate limiter
+	servicesConfig.WhatsOnChain.RequestsPerSecond = 10000
 
 	wocFx := NewWoCFixture(t, WithTransport(transport), WithNetwork(network))
 	arcFx := NewARCFixture(t, WithTransport(transport), WithNetwork(network))

--- a/pkg/internal/testabilities/testservices/fixture_woc.go
+++ b/pkg/internal/testabilities/testservices/fixture_woc.go
@@ -414,11 +414,15 @@ func (f *wocFixture) WillRespondOnTxStatusNotFound() {
 				return httpmock.NewStringResponse(http.StatusBadRequest, "bad request"), nil
 			}
 
+			const (
+				txidField  = "txid"
+				errorField = "error"
+			)
 			respItems := []map[string]interface{}{}
 			for _, txid := range body.Txids {
 				respItems = append(respItems, map[string]interface{}{
-					"txid":  txid,
-					"error": "unknown",
+					txidField:  txid,
+					errorField: "unknown",
 				})
 			}
 

--- a/pkg/internal/testabilities/testservices/fixture_woc.go
+++ b/pkg/internal/testabilities/testservices/fixture_woc.go
@@ -34,6 +34,7 @@ type WhatsOnChainFixture interface {
 	WhenQueryingBlockHeader(blockHash string) WhatsOnChainBlockHeaderQueryFixture
 	WillRespondWithBroadcast(status int, responseBody string)
 	WillRespondOnTxStatus(status int, tc TxStatusExpectation)
+	WillRespondOnTxStatusNotFound()
 	WillAlwaysReturnPostBEEFSuccess(txids ...string)
 	WillRespondWithChainInfo(status int, blocks uint32)
 	WillReturnMalformedBlockHeader(blockHash string)
@@ -393,6 +394,36 @@ func (f *wocFixture) WillRespondOnTxStatus(status int, tc TxStatusExpectation) {
 
 			respBytes, _ := json.Marshal(respItems)
 			resp := httpmock.NewStringResponse(status, string(respBytes))
+			resp.Header.Set("Content-Type", "application/json")
+			return resp, nil
+		})
+}
+
+// WillRespondOnTxStatusNotFound makes the /txs/status endpoint report every requested
+// txid as unknown to the network (the response WoC gives for unpropagated transactions).
+func (f *wocFixture) WillRespondOnTxStatusNotFound() {
+	f.Helper()
+
+	f.transport.RegisterResponder(http.MethodPost,
+		fmt.Sprintf("https://api.whatsonchain.com/v1/bsv/%s/txs/status", f.network),
+		func(req *http.Request) (*http.Response, error) {
+			var body struct {
+				Txids []string `json:"txids"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				return httpmock.NewStringResponse(http.StatusBadRequest, "bad request"), nil
+			}
+
+			respItems := []map[string]interface{}{}
+			for _, txid := range body.Txids {
+				respItems = append(respItems, map[string]interface{}{
+					"txid":  txid,
+					"error": "unknown",
+				})
+			}
+
+			respBytes, _ := json.Marshal(respItems)
+			resp := httpmock.NewStringResponse(http.StatusOK, string(respBytes))
 			resp.Header.Set("Content-Type", "application/json")
 			return resp, nil
 		})

--- a/pkg/services/internal/bitails/broadcast.go
+++ b/pkg/services/internal/bitails/broadcast.go
@@ -140,7 +140,11 @@ func (b *Bitails) classifyResponseError(resp broadcastResponse, result *wdk.Post
 		result.DoubleSpend = true
 		shouldReturnError = true
 	case ErrorCodeMissingInputs:
+		// Missing inputs is a possible double spend - flagged as a hint only; the
+		// verdict is verified against the network before the tx is failed
+		// (consistent with the WhatsOnChain classification).
 		result.Result = wdk.PostedTxIDResultMissingInputs
+		result.DoubleSpend = true
 		shouldReturnError = true
 	case ErrorTokenECONNREFUSED:
 		result.Result = wdk.PostedTxIDResultError

--- a/pkg/services/internal/bitails/service_test.go
+++ b/pkg/services/internal/bitails/service_test.go
@@ -262,7 +262,7 @@ func TestBitails_PostTX_ErrorCases(t *testing.T) {
 				given.Bitails().WillReturnTxInfo(givenTxID, "mocked-block-hash", 99999)
 			},
 			resultStatus: wdk.PostedTxIDResultMissingInputs,
-			doubleSpend:  false,
+			doubleSpend:  true,
 		},
 		"mismatched txid": {
 			setup: func(given testabilities.BitailsServiceFixture) {

--- a/pkg/services/internal/whatsonchain/broadcast.go
+++ b/pkg/services/internal/whatsonchain/broadcast.go
@@ -144,7 +144,12 @@ func (woc *WhatsOnChain) processSingleTx(ctx context.Context, rawTx []byte) wdk.
 
 	info, fetchErr := woc.tryFetchTxInfo(ctx, returnedTxid)
 	if fetchErr != nil {
-		return woc.errorPostedTxID(rawTx, returnedTxid, fmt.Errorf("failed to fetch tx info for %s: %w", returnedTxid, fetchErr))
+		// The tx has already been accepted by WoC - block info is optional enrichment,
+		// and right after a broadcast the tx may not be indexed yet (or the endpoint may
+		// be rate limited), so a fetch failure must not void the successful broadcast.
+		woc.logger.WarnContext(ctx, "failed to fetch tx info after successful broadcast",
+			"txid", returnedTxid, "error", fetchErr)
+		return result
 	}
 
 	if info != nil {

--- a/pkg/services/internal/whatsonchain/posttx_test.go
+++ b/pkg/services/internal/whatsonchain/posttx_test.go
@@ -52,6 +52,20 @@ func TestWhatsOnChain_PostTX(t *testing.T) {
 			resultStatus: wdk.PostedTxIDResultAlreadyKnown,
 			alreadyKnown: true,
 		},
+		"success - tx info fetch rate limited": {
+			setup: func(given testabilities.WoCServiceFixture) {
+				given.WhatsOnChain().WillRespondWithBroadcast(http.StatusOK, `{"txid":"`+givenTxID+`"}`)
+				given.WhatsOnChain().WillRespondOnTxStatus(http.StatusTooManyRequests, testservices.TxStatusExpectation{})
+			},
+			resultStatus: wdk.PostedTxIDResultSuccess,
+		},
+		"success - tx info fetch server error": {
+			setup: func(given testabilities.WoCServiceFixture) {
+				given.WhatsOnChain().WillRespondWithBroadcast(http.StatusOK, `{"txid":"`+givenTxID+`"}`)
+				given.WhatsOnChain().WillRespondOnTxStatus(http.StatusInternalServerError, testservices.TxStatusExpectation{})
+			},
+			resultStatus: wdk.PostedTxIDResultSuccess,
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/services/internal/whatsonchain/rate_limit_internal_test.go
+++ b/pkg/services/internal/whatsonchain/rate_limit_internal_test.go
@@ -1,0 +1,42 @@
+package whatsonchain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/time/rate"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+)
+
+func TestNewRequestLimiter(t *testing.T) {
+	tests := map[string]struct {
+		requestsPerSecond float64
+		expectedLimit     rate.Limit
+		expectedBurst     int
+	}{
+		"zero falls back to the no-API-key WoC limit": {
+			requestsPerSecond: 0,
+			expectedLimit:     rate.Limit(defs.DefaultWhatsOnChainRequestsPerSecond),
+			expectedBurst:     defs.DefaultWhatsOnChainRequestsPerSecond,
+		},
+		"configured limit for an API key plan": {
+			requestsPerSecond: 10,
+			expectedLimit:     rate.Limit(10),
+			expectedBurst:     10,
+		},
+		"fractional limit keeps a minimal burst": {
+			requestsPerSecond: 0.5,
+			expectedLimit:     rate.Limit(0.5),
+			expectedBurst:     1,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			limiter := newRequestLimiter(test.requestsPerSecond)
+
+			assert.Equal(t, test.expectedLimit, limiter.Limit())
+			assert.Equal(t, test.expectedBurst, limiter.Burst())
+		})
+	}
+}

--- a/pkg/services/internal/whatsonchain/rate_limit_internal_test.go
+++ b/pkg/services/internal/whatsonchain/rate_limit_internal_test.go
@@ -35,7 +35,7 @@ func TestNewRequestLimiter(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			limiter := newRequestLimiter(test.requestsPerSecond)
 
-			assert.Equal(t, test.expectedLimit, limiter.Limit())
+			assert.InDelta(t, float64(test.expectedLimit), float64(limiter.Limit()), 0)
 			assert.Equal(t, test.expectedBurst, limiter.Burst())
 		})
 	}

--- a/pkg/services/internal/whatsonchain/rate_limit_test.go
+++ b/pkg/services/internal/whatsonchain/rate_limit_test.go
@@ -1,0 +1,45 @@
+package whatsonchain_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	testvectors "github.com/bsv-blockchain/universal-test-vectors/pkg/testabilities"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/testservices"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/services/internal/whatsonchain/testabilities"
+)
+
+// All WoC requests must pass through the client-side rate limiter, so the WoC
+// service-side limit (3 rps without an API key) is never exceeded - exceeding it
+// yields 429 responses which under load turn into broadcast failures.
+func TestWhatsOnChain_RateLimiterThrottlesRequests(t *testing.T) {
+	// given:
+	txSpec := testvectors.GivenTX().
+		WithInput(100).
+		WithP2PKHOutput(90)
+	givenTxID := txSpec.TX().TxID().String()
+	rawTx := txSpec.TX().Bytes()
+
+	given := testabilities.Given(t)
+	woc := given.NewWoCService(testabilities.WithRequestsPerSecond(4))
+
+	given.WhatsOnChain().WillRespondWithBroadcast(http.StatusOK, `{"txid":"`+givenTxID+`"}`)
+	given.WhatsOnChain().WillRespondOnTxStatus(http.StatusOK, testservices.TxStatusExpectation{})
+
+	// when: 3 posts = 6 requests (each post makes a broadcast call and a tx-info call):
+	start := time.Now()
+	for range 3 {
+		result, err := woc.PostTX(t.Context(), rawTx)
+		require.NoError(t, err)
+		require.NoError(t, result.Error)
+	}
+	elapsed := time.Since(start)
+
+	// then: at 4 rps (burst 4), requests 5 and 6 wait for new tokens at 250ms intervals:
+	assert.GreaterOrEqual(t, elapsed, 400*time.Millisecond,
+		"requests must be throttled by the client-side rate limiter")
+}

--- a/pkg/services/internal/whatsonchain/service.go
+++ b/pkg/services/internal/whatsonchain/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-softwarelab/common/pkg/slices"
 	"github.com/go-softwarelab/common/pkg/to"
 	"go.opentelemetry.io/otel/attribute"
+	"golang.org/x/time/rate"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/history"
@@ -33,6 +34,7 @@ type WhatsOnChain struct {
 	url        string
 	apiKey     string
 	logger     *slog.Logger
+	limiter    *rate.Limiter
 
 	bsvExchangeRate            defs.BSVExchangeRate // TODO: possibly handle by some caching structure/redis
 	bsvUpdateInterval          time.Duration
@@ -65,17 +67,50 @@ func New(httpClient *resty.Client, logger *slog.Logger, network defs.BSVNetwork,
 		SetLogger(logging.RestyAdapter(logger)).
 		SetDebug(logging.IsDebug(logger))
 
-	return &WhatsOnChain{
+	woc := &WhatsOnChain{
 		httpClient:                 client,
 		apiKey:                     config.APIKey,
 		url:                        url,
 		logger:                     logger,
+		limiter:                    newRequestLimiter(config.RequestsPerSecond),
 		bsvExchangeRate:            config.BSVExchangeRate,
 		bsvUpdateInterval:          to.If(config.BSVUpdateInterval != nil, func() time.Duration { return *config.BSVUpdateInterval }).ElseThen(defs.DefaultBSVExchangeUpdateInterval),
 		rootForHeightRetryInterval: config.RootForHeightRetryInterval,
 		rootForHeightRetries:       config.RootForHeightRetries,
 		rootCache:                  make(map[uint32]*chainhash.Hash),
 	}
+
+	client.OnBeforeRequest(func(_ *resty.Client, req *resty.Request) error {
+		if err := woc.limiter.Wait(req.Context()); err != nil {
+			return fmt.Errorf("waiting for WoC rate limiter: %w", err)
+		}
+		return nil
+	})
+
+	return woc
+}
+
+// SetRequestsPerSecond reconfigures the client-side rate limiter.
+// Not safe for concurrent use with in-flight requests - call right after New.
+func (woc *WhatsOnChain) SetRequestsPerSecond(requestsPerSecond float64) {
+	woc.limiter = newRequestLimiter(requestsPerSecond)
+}
+
+// newRequestLimiter builds the client-side rate limiter for WhatsOnChain requests.
+// Exceeding the WoC limit yields 429 responses, which under load turn into broadcast
+// failures, so all requests are throttled to the configured requests-per-second
+// (defaulting to the limit WoC applies to requests without an API key).
+func newRequestLimiter(requestsPerSecond float64) *rate.Limiter {
+	if requestsPerSecond <= 0 {
+		requestsPerSecond = defs.DefaultWhatsOnChainRequestsPerSecond
+	}
+
+	burst := int(requestsPerSecond)
+	if burst < 1 {
+		burst = 1
+	}
+
+	return rate.NewLimiter(rate.Limit(requestsPerSecond), burst)
 }
 
 func (woc *WhatsOnChain) RawTx(ctx context.Context, txID string) (_ *wdk.RawTxResult, err error) {

--- a/pkg/services/internal/whatsonchain/testabilities/fixtures.go
+++ b/pkg/services/internal/whatsonchain/testabilities/fixtures.go
@@ -22,6 +22,13 @@ func Given(t testing.TB) WoCServiceFixture {
 	}
 }
 
+// WithRequestsPerSecond reconfigures the client-side rate limiter of the WoC service under test.
+func WithRequestsPerSecond(requestsPerSecond float64) func(*whatsonchain.WhatsOnChain) {
+	return func(service *whatsonchain.WhatsOnChain) {
+		service.SetRequestsPerSecond(requestsPerSecond)
+	}
+}
+
 type wocServiceFixture struct {
 	testservices.ServicesFixture
 
@@ -37,6 +44,8 @@ func (f *wocServiceFixture) NewWoCService(opts ...func(*whatsonchain.WhatsOnChai
 		BSVExchangeRate:            defs.BSVExchangeRate{},
 		RootForHeightRetryInterval: 0,
 		RootForHeightRetries:       1,
+		// NOTE: tests should not be slowed down by the client-side WoC rate limiter
+		RequestsPerSecond: 10000,
 	}
 
 	service := whatsonchain.New(client, logger, network, config)

--- a/pkg/storage/internal/actions/process.go
+++ b/pkg/storage/internal/actions/process.go
@@ -547,6 +547,7 @@ func (p *process) broadcastTxs(ctx context.Context, txIDs []string, isDelayed bo
 	)
 
 	aggregated := results.Aggregated(txIDs)
+	p.confirmDoubleSpends(ctx, aggregated)
 
 	logger.DebugContext(
 		ctx, "Processing individual transaction results",
@@ -861,6 +862,8 @@ func (p *process) BackgroundBroadcast(ctx context.Context, beef *transaction.Bee
 	}
 
 	aggregated := results.Aggregated(txIDs)
+	p.confirmDoubleSpends(ctx, aggregated)
+
 	bResults := make([]wdk.ReviewActionResult, 0, len(txIDs))
 	for _, broadcastedTxID := range txIDs {
 		aggBroadcastResult, ok := aggregated[broadcastedTxID]

--- a/pkg/storage/internal/actions/process_confirm_double_spends.go
+++ b/pkg/storage/internal/actions/process_confirm_double_spends.go
@@ -1,0 +1,130 @@
+package actions
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+	"time"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+)
+
+const (
+	confirmDoubleSpendAttempts  = 3
+	confirmDoubleSpendRetryWait = time.Second
+)
+
+// confirmDoubleSpends re-verifies every aggregated double-spend verdict before it becomes
+// a terminal failure, because failing a transaction releases its inputs back to spendable -
+// done on a false positive, this lets the wallet build REAL double spends afterwards.
+//
+// A single broadcaster can report a false double spend: e.g. WhatsOnChain answers
+// "missing inputs" for a freshly-chained tx whose parent has not reached its mempool yet,
+// or reports a conflict while another service has already accepted the very same tx.
+//
+// The verdict is downgraded as follows:
+//   - the network status check knows the tx -> the report was a false positive -> success
+//   - some broadcaster accepted the tx -> transient disagreement -> serviceError (retried later)
+//   - only "missing inputs" hints without competing txs -> no positive evidence of a
+//     double spend (indistinguishable from propagation lag) -> serviceError (retried later)
+//   - otherwise the double spend is considered confirmed and stays terminal.
+//
+// This mirrors confirmDoubleSpend in the TypeScript wallet-toolbox
+// (src/storage/methods/attemptToPostReqsToNetwork.ts).
+func (p *process) confirmDoubleSpends(ctx context.Context, aggregated wdk.AggregatedPostFromBEEF) {
+	var doubtful []string
+	for txID, agg := range aggregated {
+		if agg.Status == wdk.AggregatedPostedTxIDDoubleSpend {
+			doubtful = append(doubtful, txID)
+		}
+	}
+	if len(doubtful) == 0 {
+		return
+	}
+	slices.Sort(doubtful)
+
+	knownTxs := p.checkTxsKnownToNetwork(ctx, doubtful)
+
+	for _, txID := range doubtful {
+		agg := aggregated[txID]
+
+		logger := p.logger.With(
+			slog.String("txID", txID),
+			slog.Int("successCount", agg.SuccessCount),
+			slog.Int("doubleSpendCount", agg.DoubleSpendCount),
+		)
+
+		switch {
+		case knownTxs[txID]:
+			logger.InfoContext(ctx, "Double spend reported by a broadcaster but the tx is known to the network - treating broadcast as successful")
+			agg.Status = wdk.AggregatedPostedTxIDSuccess
+		case agg.SuccessCount > 0:
+			logger.InfoContext(ctx, "Broadcasters disagree on double spend - keeping the tx retryable instead of failing it")
+			agg.Status = wdk.AggregatedPostedTxIDServiceError
+		case !hasDoubleSpendEvidence(agg):
+			logger.InfoContext(ctx, "Double spend hint without evidence (missing inputs may be propagation lag) - keeping the tx retryable instead of failing it")
+			agg.Status = wdk.AggregatedPostedTxIDServiceError
+		default:
+			logger.WarnContext(ctx, "Double spend confirmed - failing the tx")
+		}
+	}
+}
+
+// checkTxsKnownToNetwork reports which of the given txs the network already knows
+// (mempool or mined), retrying a few times because a just-broadcast tx needs a moment
+// to propagate.
+func (p *process) checkTxsKnownToNetwork(ctx context.Context, txIDs []string) map[string]bool {
+	knownTxs := make(map[string]bool, len(txIDs))
+	remaining := txIDs
+
+	for attempt := 0; attempt < confirmDoubleSpendAttempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return knownTxs
+			case <-time.After(confirmDoubleSpendRetryWait):
+			}
+		}
+
+		statusResult, err := p.services.GetStatusForTxIDs(ctx, remaining)
+		if err != nil {
+			p.logger.WarnContext(ctx, "Failed to check tx statuses while verifying a double spend report",
+				slog.String("error", err.Error()))
+			continue
+		}
+		if statusResult == nil || statusResult.Status != wdk.GetStatusSuccess {
+			continue
+		}
+
+		for _, detail := range statusResult.Results {
+			if detail.Status != wdk.ResultStatusForTxIDNotFound.String() {
+				knownTxs[detail.TxID] = true
+			}
+		}
+
+		remaining = slices.DeleteFunc(slices.Clone(remaining), func(txID string) bool {
+			return knownTxs[txID]
+		})
+		if len(remaining) == 0 {
+			break
+		}
+	}
+
+	return knownTxs
+}
+
+// hasDoubleSpendEvidence reports whether any broadcaster provided positive evidence of a
+// double spend: a mempool-conflict-style rejection or competing transactions. A bare
+// "missing inputs" rejection carries no such evidence - for chained transactions it is
+// most often just the parent not having propagated to that service's mempool yet.
+func hasDoubleSpendEvidence(agg *wdk.AggregatedPostedTxID) bool {
+	for _, result := range agg.TxIDResults {
+		if !result.DoubleSpend {
+			continue
+		}
+		if result.Result != wdk.PostedTxIDResultMissingInputs || len(result.CompetingTxs) > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/storage/provider_broadcast_double_spend_test.go
+++ b/pkg/storage/provider_broadcast_double_spend_test.go
@@ -1,0 +1,137 @@
+package storage_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/testservices"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/randomizer"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/storage/internal/testabilities"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+)
+
+// These tests cover the aggregation of conflicting broadcast results.
+//
+// Reported scenario: when many chained transactions are broadcast in sequence,
+// WhatsOnChain (which receives the raw tx) answers "missing inputs" or
+// "txn-mempool-conflict" for a tx whose parent has not reached its mempool yet,
+// while ARC accepts the very same tx. Treating that single report as a terminal
+// double spend marks the tx as failed and releases its inputs back to spendable,
+// after which the wallet builds REAL double spends and the cascade corrupts the
+// wallet beyond repair.
+
+// When WoC rejects with "missing inputs" but ARC accepts the tx AND the network
+// status check confirms the tx is known, the double-spend verdict is a false
+// positive and the tx must be treated as successfully broadcast.
+func TestBroadcastConflict_MissingInputsButTxKnown_IsSuccess(t *testing.T) {
+	// given:
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+	activeStorage := given.Provider().
+		WithRandomizer(randomizer.NewTestRandomizer()).
+		GORM()
+
+	// and: ARC accepts the tx (default fixture behavior), WoC lags behind:
+	given.Provider().WhatsOnChain().WillRespondWithBroadcast(http.StatusInternalServerError, "unexpected response code 500: Missing inputs")
+	given.Provider().WhatsOnChain().WillRespondOnTxStatus(http.StatusOK, testservices.TxStatusExpectation{})
+
+	// when:
+	_, signedTx := given.Action(activeStorage).Processed()
+	txID := signedTx.TxID().String()
+
+	// then:
+	thenDBState := testabilities.ThenDBState(t, activeStorage)
+	thenDBState.HasKnownTX(txID).WithStatus(wdk.ProvenTxStatusUnmined)
+	thenDBState.HasUserTransactionByTxID(testusers.Alice, txID).WithStatus(wdk.TxStatusUnproven)
+}
+
+// When WoC rejects with "missing inputs", ARC accepts the tx, but the network
+// status check cannot (yet) see the tx, the result must stay retryable
+// (sending) instead of becoming a terminal failure that releases the inputs.
+// A later retry then completes the broadcast.
+func TestBroadcastConflict_MissingInputsWithSuccess_TxUnknown_IsRetryable(t *testing.T) {
+	// given:
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+	activeStorage := given.Provider().
+		WithRandomizer(randomizer.NewTestRandomizer()).
+		GORM()
+
+	// and: ARC accepts the tx (default fixture behavior), WoC lags behind and does not know the tx:
+	given.Provider().WhatsOnChain().WillRespondWithBroadcast(http.StatusInternalServerError, "unexpected response code 500: Missing inputs")
+	given.Provider().WhatsOnChain().WillRespondOnTxStatusNotFound()
+
+	// when:
+	_, signedTx := given.Action(activeStorage).Processed()
+	txID := signedTx.TxID().String()
+
+	// then: the tx is NOT failed, it stays in a retryable state:
+	thenDBState := testabilities.ThenDBState(t, activeStorage)
+	thenDBState.HasKnownTX(txID).WithStatus(wdk.ProvenTxStatusSending)
+	thenDBState.HasUserTransactionByTxID(testusers.Alice, txID).WithStatus(wdk.TxStatusSending)
+
+	// and when: WoC has caught up by the time of the retry:
+	given.Provider().WhatsOnChain().WillRespondWithBroadcast(http.StatusOK, `{"txid":"`+txID+`"}`)
+	given.Provider().WhatsOnChain().WillRespondOnTxStatus(http.StatusOK, testservices.TxStatusExpectation{})
+	_, err := activeStorage.SendWaitingTransactions(t.Context(), -time.Minute)
+
+	// then: the retry completes the broadcast:
+	require.NoError(t, err)
+	thenDBState.HasKnownTX(txID).WithStatus(wdk.ProvenTxStatusUnmined)
+	thenDBState.HasUserTransactionByTxID(testusers.Alice, txID).WithStatus(wdk.TxStatusUnproven)
+}
+
+// A "missing inputs" report with no competing transactions, no successful
+// broadcaster and an unknown network status carries no positive evidence of a
+// double spend - it is indistinguishable from propagation lag, so the tx must
+// stay retryable rather than be terminally failed.
+func TestBroadcastConflict_MissingInputsOnly_TxUnknown_IsRetryable(t *testing.T) {
+	// given:
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+	activeStorage := given.Provider().
+		WithRandomizer(randomizer.NewTestRandomizer()).
+		GORM()
+
+	// and: WoC reports missing inputs and does not know the tx:
+	given.Provider().WhatsOnChain().WillRespondWithBroadcast(http.StatusInternalServerError, "unexpected response code 500: Missing inputs")
+	given.Provider().WhatsOnChain().WillRespondOnTxStatusNotFound()
+
+	// when: ARC fails as well (WillFailOnBroadcast):
+	_, signedTx := given.Action(activeStorage).WillFailOnBroadcast().Processed()
+	txID := signedTx.TxID().String()
+
+	// then:
+	thenDBState := testabilities.ThenDBState(t, activeStorage)
+	thenDBState.HasKnownTX(txID).WithStatus(wdk.ProvenTxStatusSending)
+	thenDBState.HasUserTransactionByTxID(testusers.Alice, txID).WithStatus(wdk.TxStatusSending)
+}
+
+// A mempool conflict reported by WoC, with no successful broadcaster and the tx
+// unknown to the network, is a confirmed double spend and must keep failing the
+// transaction (the pre-existing terminal behavior).
+func TestBroadcastConflict_MempoolConflict_TxUnknown_StaysFailed(t *testing.T) {
+	// given:
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+	activeStorage := given.Provider().
+		WithRandomizer(randomizer.NewTestRandomizer()).
+		GORM()
+
+	// and: WoC reports a mempool conflict and does not know the tx:
+	given.Provider().WhatsOnChain().WillRespondWithBroadcast(http.StatusInternalServerError, "unexpected response code 500: 258: txn-mempool-conflict")
+	given.Provider().WhatsOnChain().WillRespondOnTxStatusNotFound()
+
+	// when: ARC fails as well (WillFailOnBroadcast):
+	_, signedTx := given.Action(activeStorage).WillFailOnBroadcast().Processed()
+	txID := signedTx.TxID().String()
+
+	// then:
+	thenDBState := testabilities.ThenDBState(t, activeStorage)
+	thenDBState.HasKnownTX(txID).WithStatus(wdk.ProvenTxStatusDoubleSpend)
+	thenDBState.HasUserTransactionByTxID(testusers.Alice, txID).WithStatus(wdk.TxStatusFailed)
+}

--- a/pkg/wallet/internal/testabilities/fixture_wallet_builder.go
+++ b/pkg/wallet/internal/testabilities/fixture_wallet_builder.go
@@ -122,6 +122,8 @@ func (w *walletBuilder) ForRootKey(rootKey string) *wallet.Wallet {
 	opts := slices.Clone(w.walletOpts)
 	if w.withServices {
 		serviceCfg := defs.DefaultServicesConfig(net)
+		// NOTE: tests should not be slowed down by the client-side WoC rate limiter
+		serviceCfg.WhatsOnChain.RequestsPerSecond = 10000
 		walletServices := services.New(slog.Default(), serviceCfg)
 		opts = append(opts, wallet.WithServices(walletServices))
 	}
@@ -175,6 +177,8 @@ func (w *walletBuilder) ForUser(user testusers.User) *wallet.Wallet {
 	}
 	if w.withServices {
 		serviceCfg := defs.DefaultServicesConfig(net)
+		// NOTE: tests should not be slowed down by the client-side WoC rate limiter
+		serviceCfg.WhatsOnChain.RequestsPerSecond = 10000
 		transport := w.givenStorage.Provider().Transport()
 		client := resty.New()
 		client.SetTransport(transport)


### PR DESCRIPTION
## What Changed
- **`confirmDoubleSpends` verification step** (`pkg/storage/internal/actions/process_confirm_double_spends.go`): every aggregated `doubleSpend` broadcast verdict is now re-verified against the network (batched `GetStatusForTxIDs`, 3 attempts, 1s apart) before it becomes a terminal failure. Downgrade rules:
  - tx is known to the network (mempool/mined) → treated as **success** (the report was a false positive)
  - at least one broadcaster accepted the tx → retryable **serviceError** (picked up by SendWaiting)
  - bare "missing inputs" hint with no competing txs and no success → retryable **serviceError** (indistinguishable from propagation lag)
  - evidenced conflicts (mempool-conflict / competing txs) with no success and tx unknown → stays terminal `doubleSpend`
  - Wired into both the synchronous (`broadcastTxs`) and background (`BackgroundBroadcast`) paths. Mirrors `confirmDoubleSpend` in the TS wallet-toolbox (`src/storage/methods/attemptToPostReqsToNetwork.ts`).
- **WhatsOnChain: accepted broadcast no longer voided by the follow-up tx-info fetch** (`whatsonchain/broadcast.go`): a 429/500 (or not-yet-indexed) response from `/txs/status` after a successful `/tx/raw` post used to rewrite the whole result to `error`, discarding the success.
- **WhatsOnChain: client-side rate limiter** (`whatsonchain/service.go`, `defs/whats_on_chain.go`): all WoC requests pass through a token-bucket limiter. Defaults to **3 req/s** (WoC's limit without an API key); configurable via `whats_on_chain.requests_per_second` for API-key plans (e.g. 10).
- **Bitails: "missing inputs" classified as a double-spend hint** (`DoubleSpend=true`), consistent with WhatsOnChain — previously it aggregated to terminal `invalidTx`.

## Why It Was Necessary
Load testing of an enterprise wallet (chained txs broadcast seconds apart, hitting WoC 429 rate limits) produced false `double_spend` / `missing_inputs` failures:

1. WoC receives the **raw tx** — for a freshly-chained tx whose parent hasn't reached WoC's mempool yet it answers "missing inputs", which was classified as `DoubleSpend=true`.
2. In aggregation a single double-spend report outranks any number of successes, so a tx **accepted by ARC** was still marked terminally failed.
3. Failing the tx runs `RecreateSpentOutputs`, releasing its inputs back to `spendable=true` with no chain verification — the wallet then builds **real** double spends from already-spent outputs and the corruption cascades until the wallet is unusable, with no repair path.
4. Additionally, a successful WoC broadcast followed by a rate-limited `/txs/status` lookup was counted as a broadcast failure, and the extra per-broadcast status call doubled WoC traffic, feeding the 429 storm.

The TS wallet-toolbox guards against exactly this with `confirmDoubleSpend`; the Go port was missing that step.

## Testing Performed
- New storage-level reproduction harness `pkg/storage/provider_broadcast_double_spend_test.go` (real GORM storage + mocked ARC/WoC over the shared httpmock transport), covering: false double-spend rescued via network status; conflict with unknown status stays retryable and completes on a later `SendWaitingTransactions` retry; missing-inputs-only stays retryable; evidenced mempool conflict still fails terminally (regression guard). All four were red before the fix.
- New WoC unit tests: accepted broadcast survives 429/500 on the follow-up tx-info fetch; rate limiter throttling and limiter defaults (`rate_limit_test.go`, `rate_limit_internal_test.go`).
- Full test suite green (`go test ./...`), `go vet` clean. Test fixtures set a high `RequestsPerSecond` so suites aren't throttled; the limiter itself is covered by dedicated tests.

## Impact / Risk
- A genuinely double-spent tx that some broadcaster accepted converges to terminal failure on a later retry (when no service accepts it anymore) instead of immediately — corruption-free at the cost of delayed finality for that edge case.
- Verification adds up to ~2s + a batched status query in the broadcast path, only when a double-spend verdict needs confirmation.
- Default WoC throughput is now capped at 3 req/s client-side; deployments with an API key should set `whats_on_chain.requests_per_second` to their plan's limit.
- Known remaining gaps (follow-up candidates): no background repair task akin to TS `TaskReviewDoubleSpends`; `unfail` doesn't restore the spent state of inputs; `updateSingleTx` writes aren't guarded against failing an already-mined tx.

## Notifications
- @pawellewandowski98

🤖 Generated with [Claude Code](https://claude.com/claude-code)