### PR TITLE
fix: mark created outputs as not spendable when tx fails

### DIFF
--- a/pkg/internal/storage/repo/outputs.go
+++ b/pkg/internal/storage/repo/outputs.go
@@ -861,6 +861,45 @@ func (o *Outputs) ShouldTxOutputsBeUnspent(ctx context.Context, transactionID ui
 	return fmt.Errorf("failed to check for spent outputs: %w", err)
 }
 
+func (o *Outputs) MarkCreatedOutputsAsNotSpendable(ctx context.Context, transactionID uint) error {
+	var err error
+	ctx, span := tracing.StartTracing(ctx, "Repository-Outputs-MarkCreatedOutputsAsNotSpendable", attribute.String("TransactionID", fmt.Sprintf("%d", transactionID)))
+	defer func() {
+		tracing.EndTracing(span, err)
+	}()
+
+	outTable := &o.query.Output
+	_, err = outTable.WithContext(ctx).
+		Where(outTable.TransactionID.Eq(transactionID)).
+		UpdateSimple(outTable.Spendable.Value(false))
+	if err != nil {
+		return fmt.Errorf("failed to mark created outputs as not spendable for transaction %d: %w", transactionID, err)
+	}
+
+	return nil
+}
+
+func (o *Outputs) MarkCreatedOutputsAsSpendableByTxID(ctx context.Context, txID string) error {
+	var err error
+	ctx, span := tracing.StartTracing(ctx, "Repository-Outputs-MarkCreatedOutputsAsSpendableByTxID", attribute.String("TxID", txID))
+	defer func() {
+		tracing.EndTracing(span, err)
+	}()
+
+	txTable := &o.query.Transaction
+	outTable := &o.query.Output
+	subquery := txTable.WithContext(ctx).Select(txTable.ID).Where(txTable.TxID.Eq(txID))
+
+	_, err = outTable.WithContext(ctx).
+		Where(field.ContainsSubQuery([]field.Expr{outTable.TransactionID}, subquery.UnderlyingDB())).
+		UpdateSimple(outTable.Spendable.Value(true))
+	if err != nil {
+		return fmt.Errorf("failed to mark created outputs as spendable for tx %s: %w", txID, err)
+	}
+
+	return nil
+}
+
 // AddOutput inserts a new output.
 func (o *Outputs) AddOutput(ctx context.Context, out *pkgentity.Output) error {
 	var err error

--- a/pkg/storage/internal/actions/abort.go
+++ b/pkg/storage/internal/actions/abort.go
@@ -115,6 +115,11 @@ func (a *abortAction) abortTx(ctx context.Context, id uint) error {
 		return fmt.Errorf("failed to recreate spent outputs for transaction: %w", err)
 	}
 
+	logger.DebugContext(ctx, "Marking created outputs as not spendable for transaction")
+	if err := a.outputsRepo.MarkCreatedOutputsAsNotSpendable(ctx, id); err != nil {
+		return fmt.Errorf("failed to mark created outputs as not spendable for transaction: %w", err)
+	}
+
 	logger.DebugContext(ctx, "Updating transaction status to 'failed'")
 	if err := a.transactionsRepo.UpdateTransactionStatusByID(ctx, id, wdk.TxStatusFailed); err != nil {
 		return fmt.Errorf("failed to update transaction status: %w", err)

--- a/pkg/storage/internal/actions/process.go
+++ b/pkg/storage/internal/actions/process.go
@@ -691,6 +691,10 @@ func (p *process) updateSingleTx(
 				err = fmt.Errorf("failed to restore spent outputs for failed tx %s: %w", txID, err)
 				return sendWithResult, reviewActionResult, err
 			}
+			if err = p.outputRepo.MarkCreatedOutputsAsNotSpendable(ctx, id); err != nil {
+				err = fmt.Errorf("failed to mark created outputs as not spendable for failed tx %s: %w", txID, err)
+				return sendWithResult, reviewActionResult, err
+			}
 		}
 	}
 

--- a/pkg/storage/internal/actions/process_unfail.go
+++ b/pkg/storage/internal/actions/process_unfail.go
@@ -114,6 +114,9 @@ func (p *process) unfailSingle(ctx context.Context, log *slog.Logger, txID strin
 		if err := p.outputRepo.RecreateSpentOutputs(ctx, id); err != nil {
 			log.ErrorContext(ctx, "Failed to restore spent outputs for failed tx", slog.String("txID", txID), logging.Error(err))
 		}
+		if err := p.outputRepo.MarkCreatedOutputsAsNotSpendable(ctx, id); err != nil {
+			log.ErrorContext(ctx, "Failed to mark created outputs as not spendable for failed tx", slog.String("txID", txID), logging.Error(err))
+		}
 	}
 }
 
@@ -127,6 +130,9 @@ func (p *process) markAsUnminedAndUnproven(ctx context.Context, log *slog.Logger
 		log.ErrorContext(ctx, "Failed to set tx to 'unproven'", slog.String("txID", txID), logging.Error(err))
 	} else {
 		log.InfoContext(ctx, "Transaction set to 'unproven'", slog.String("txID", txID))
+	}
+	if err := p.outputRepo.MarkCreatedOutputsAsSpendableByTxID(ctx, txID); err != nil {
+		log.ErrorContext(ctx, "Failed to mark created outputs as spendable for unfailed tx", slog.String("txID", txID), logging.Error(err))
 	}
 	if err := p.utxoRepo.CreateUTXOForSpendableOutputsByTxID(ctx, txID); err != nil {
 		log.ErrorContext(ctx, "Failed to create UTXOs for spendable outputs", slog.String("txID", txID), logging.Error(err))

--- a/pkg/storage/internal/actions/repos.interface.go
+++ b/pkg/storage/internal/actions/repos.interface.go
@@ -32,6 +32,8 @@ type OutputRepo interface {
 	SaveOutputs(ctx context.Context, output []*pkgentity.Output) error
 	RecreateSpentOutputs(ctx context.Context, spendingTransactionID uint) error
 	ShouldTxOutputsBeUnspent(ctx context.Context, transactionID uint) error
+	MarkCreatedOutputsAsNotSpendable(ctx context.Context, transactionID uint) error
+	MarkCreatedOutputsAsSpendableByTxID(ctx context.Context, txID string) error
 }
 
 type TransactionsRepo interface {

--- a/pkg/storage/internal/actions/synchronize_tx_statuses.go
+++ b/pkg/storage/internal/actions/synchronize_tx_statuses.go
@@ -498,6 +498,10 @@ func (s *synchronizeTxStatuses) reviewKnownTxStatuses(ctx context.Context) error
 				if err := s.outputRepo.RecreateSpentOutputs(ctx, transactionID); err != nil {
 					return fmt.Errorf("failed to restore spent outputs for terminal failed tx %s: %w", failedTx.TxID, err)
 				}
+
+				if err := s.outputRepo.MarkCreatedOutputsAsNotSpendable(ctx, transactionID); err != nil {
+					return fmt.Errorf("failed to mark created outputs as not spendable for terminal failed tx %s: %w", failedTx.TxID, err)
+				}
 			}
 		}
 

--- a/pkg/storage/provider_abort_action_test.go
+++ b/pkg/storage/provider_abort_action_test.go
@@ -3,6 +3,7 @@ package storage_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures"
@@ -302,4 +303,50 @@ func TestProcessAction_AbortUnprocessedTransaction_AndRecreateUTXOs(t *testing.T
 	// and:
 	testabilities.ThenFunds(t, testusers.Alice, activeStorage).
 		ShouldBeAbleToReserveSatoshis(satoshisToInternalize)
+}
+
+func TestAbortAction_CreatedOutputsAreMarkedNotSpendable(t *testing.T) {
+	// Regression test: outputs created by an aborted TX must be marked spendable=false.
+	// Before this fix, they remained spendable=true with a null tx_id, so ListOutputs
+	// could return them with a zero outpoint, causing "duplicate input" errors downstream.
+
+	// given:
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+
+	activeStorage := given.Provider().WithRandomizer(randomizer.NewTestRandomizer()).GORM()
+
+	// and: an unsigned TX is created (tx_id is null at this point)
+	createResult, _ := given.Action(activeStorage).
+		WithSatoshisToInternalize(10_000).
+		WithSatoshisToSend(1_000).
+		Created()
+
+	// and: find the internal transaction row ID to query its outputs
+	txRows, err := activeStorage.TransactionEntity().Read().
+		Reference().Equals(createResult.Reference).
+		Find(t.Context())
+	require.NoError(t, err)
+	require.Len(t, txRows, 1)
+	transactionID := txRows[0].ID
+
+	// when:
+	_, err = activeStorage.AbortAction(
+		t.Context(),
+		testusers.Alice.AuthID(),
+		wdk.AbortActionArgs{Reference: primitives.Base64String(createResult.Reference)},
+	)
+	require.NoError(t, err)
+
+	// then: outputs created by the aborted TX are all not spendable
+	outputs, err := activeStorage.OutputsEntity().Read().
+		TransactionID().Equals(transactionID).
+		Find(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, outputs, "expected to find outputs for the aborted transaction")
+
+	for _, output := range outputs {
+		assert.False(t, output.Spendable,
+			"output vout=%d from aborted TX must not be spendable", output.Vout)
+	}
 }

--- a/pkg/storage/provider_synchronize_tx_statuses_test.go
+++ b/pkg/storage/provider_synchronize_tx_statuses_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/testservices"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/randomizer"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/storage/internal/testabilities"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/storage/internal/testabilities/nosendtest"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
@@ -629,4 +631,69 @@ func TestSynchronizeTxNoSendBroadcastedExternally(t *testing.T) {
 		testabilities.ThenFunds(t, testusers.Alice, activeStorage).
 			ShouldNotBeAbleToReserveSatoshis(inputSatoshis - 2)
 	})
+}
+
+func TestSynchronizeTxFailed_CreatedOutputsAreMarkedNotSpendable(t *testing.T) {
+	// Regression test: when sync exhausts retries and marks a TX as invalid/failed,
+	// the outputs *created* by that TX must be marked spendable=false.
+	// Before this fix they remained spendable=true, corrupting wallet state.
+
+	// given:
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+
+	givenProvider := given.Provider()
+	cfg := defs.DefaultSynchronizeTxStatuses()
+	cfg.MaxAttempts = 1
+	cfg.MaxRebroadcastAttempts = 2
+	activeStorage := givenProvider.
+		WithRandomizer(randomizer.NewTestRandomizer()).
+		WithSynchronizeTxStatuses(cfg).
+		GORM()
+
+	// and: a TX is processed and broadcast successfully, but merkle proof never arrives
+	_, signedTx := given.Action(activeStorage).
+		WithSatoshisToInternalize(10_000).
+		WithSatoshisToSend(1_000).
+		Processed()
+	txID := signedTx.TxID().String()
+
+	givenProvider.ARC().WhenQueryingTx(txID).WillReturnTransactionWithoutMerklePath()
+	givenProvider.WhatsOnChain().WillRespondOnTxStatus(200, testservices.TxStatusExpectation{
+		ExpectBlockHash:   testservices.TestBlockHash,
+		ExpectBlockHeight: int64(testservices.TestBlockHeight),
+	})
+
+	// and: exhaust all rebroadcast attempts (mirrors TestSynchronizeTxCircuitBreakerForUnsentBroadcastTx)
+	for cycle := uint64(1); cycle <= cfg.MaxRebroadcastAttempts; cycle++ {
+		_, err := activeStorage.SynchronizeTransactionStatuses(t.Context())
+		require.NoError(t, err)
+	}
+
+	// when: final sync exhausts the circuit breaker and marks the TX invalid/failed
+	_, err := activeStorage.SynchronizeTransactionStatuses(t.Context())
+	require.NoError(t, err)
+
+	// then: user TX is failed
+	testabilities.ThenDBState(t, activeStorage).
+		HasUserTransactionByTxID(testusers.Alice, txID).
+		WithStatus(wdk.TxStatusFailed)
+
+	// and: outputs created by the failed TX are all not spendable
+	txRows, err := activeStorage.TransactionEntity().Read().
+		TxID().Equals(txID).
+		Find(t.Context())
+	require.NoError(t, err)
+	require.Len(t, txRows, 1)
+
+	outputs, err := activeStorage.OutputsEntity().Read().
+		TransactionID().Equals(txRows[0].ID).
+		Find(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, outputs)
+
+	for _, output := range outputs {
+		assert.False(t, output.Spendable,
+			"output vout=%d from a sync-failed TX must not be spendable", output.Vout)
+	}
 }

--- a/pkg/storage/provider_unfail_test.go
+++ b/pkg/storage/provider_unfail_test.go
@@ -5,6 +5,7 @@ import (
 
 	testvectors "github.com/bsv-blockchain/universal-test-vectors/pkg/testabilities"
 	"github.com/go-softwarelab/common/pkg/to"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
@@ -125,4 +126,152 @@ func TestUnFail_Empty_NoItems(t *testing.T) {
 
 	// then:
 	require.NoError(t, err)
+}
+
+func TestUnFail_WithMerklePath_CreatedOutputsAreRestoredToSpendable(t *testing.T) {
+	// Regression test: when unfail succeeds (merkle path found), the outputs created by
+	// the recovered TX must be restored to spendable=true so they can be used downstream.
+	// Before this fix, a successful unfail would leave outputs non-spendable if the fix
+	// for the failure path had already run.
+
+	// given:
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+	provider := given.Provider()
+	activeStorage := provider.
+		WithRandomizer(randomizer.NewTestRandomizer()).
+		GORM()
+
+	// and: create a TX and make it fail with double spend
+	createActionResult, signedTx := given.Action(activeStorage).
+		WithSatoshisToInternalize(10_000).
+		WithSatoshisToSend(1_000).
+		Created()
+	txID := signedTx.TxID().String()
+	otherTXID := testvectors.GivenTX().WithInput(2).WithP2PKHOutput(1).ID().String()
+	provider.ARC().WhenQueryingTx(txID).WillReturnDoubleSpending(otherTXID)
+
+	_, err := activeStorage.ProcessAction(t.Context(), testusers.Alice.AuthID(), wdk.ProcessActionArgs{
+		IsNewTx:    true,
+		IsSendWith: false,
+		IsNoSend:   false,
+		IsDelayed:  false,
+		Reference:  to.Ptr(createActionResult.Reference),
+		TxID:       to.Ptr(primitives.TXIDHexString(txID)),
+		RawTx:      signedTx.Bytes(),
+		SendWith:   []primitives.TXIDHexString{},
+	})
+	require.NoError(t, err)
+
+	// and: mark it for unfail
+	_, _ = activeStorage.ListActions(t.Context(), testusers.Alice.AuthID(), wdk.ListActionsArgs{
+		Labels: []primitives.StringUnder300{
+			primitives.StringUnder300(wdk.TxStatusUnfail),
+			primitives.StringUnder300(specops.ListActionsSpecOpFailedActionsLabel),
+		},
+		Limit: 10,
+	})
+
+	// and: mock merkle path present → unfail will succeed
+	mp := testutils.MockValidMerklePath(t, txID, 2000)
+	provider.ARC().WhenQueryingTx(txID).WillReturnTransactionWithMerklePath(mp)
+
+	// when:
+	err = activeStorage.UnFail(t.Context())
+	require.NoError(t, err)
+
+	// then: user TX is now unproven (recovered)
+	testabilities.ThenDBState(t, activeStorage).
+		HasUserTransactionByTxID(testusers.Alice, txID).
+		WithStatus(wdk.TxStatusUnproven)
+
+	// and: outputs created by the recovered TX are spendable again
+	txRows, err := activeStorage.TransactionEntity().Read().
+		TxID().Equals(txID).
+		Find(t.Context())
+	require.NoError(t, err)
+	require.Len(t, txRows, 1)
+
+	outputs, err := activeStorage.OutputsEntity().Read().
+		TransactionID().Equals(txRows[0].ID).
+		Find(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, outputs)
+
+	for _, output := range outputs {
+		assert.True(t, output.Spendable,
+			"output vout=%d from an unfailed TX must be spendable after successful recovery", output.Vout)
+	}
+}
+
+func TestUnFail_NoMerklePath_CreatedOutputsRemainNotSpendable(t *testing.T) {
+	// Regression test: when unfail fails (no merkle path), the outputs created by the TX
+	// must remain spendable=false — they should not become available for spending.
+
+	// given:
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+	provider := given.Provider()
+	activeStorage := provider.
+		WithRandomizer(randomizer.NewTestRandomizer()).
+		GORM()
+
+	// and: create a TX and make it fail with double spend
+	createActionResult, signedTx := given.Action(activeStorage).
+		WithSatoshisToInternalize(10_000).
+		WithSatoshisToSend(1_000).
+		Created()
+	txID := signedTx.TxID().String()
+	otherTXID := testvectors.GivenTX().WithInput(2).WithP2PKHOutput(1).ID().String()
+	provider.ARC().WhenQueryingTx(txID).WillReturnDoubleSpending(otherTXID)
+
+	_, err := activeStorage.ProcessAction(t.Context(), testusers.Alice.AuthID(), wdk.ProcessActionArgs{
+		IsNewTx:    true,
+		IsSendWith: false,
+		IsNoSend:   false,
+		IsDelayed:  false,
+		Reference:  to.Ptr(createActionResult.Reference),
+		TxID:       to.Ptr(primitives.TXIDHexString(txID)),
+		RawTx:      signedTx.Bytes(),
+		SendWith:   []primitives.TXIDHexString{},
+	})
+	require.NoError(t, err)
+
+	// and: mark it for unfail
+	_, _ = activeStorage.ListActions(t.Context(), testusers.Alice.AuthID(), wdk.ListActionsArgs{
+		Labels: []primitives.StringUnder300{
+			primitives.StringUnder300(wdk.TxStatusUnfail),
+			primitives.StringUnder300(specops.ListActionsSpecOpFailedActionsLabel),
+		},
+		Limit: 10,
+	})
+
+	// and: merkle path NOT found → unfail will cascade back to invalid
+	provider.ARC().WhenQueryingTx(txID).WillReturnTransactionWithoutMerklePath()
+
+	// when:
+	err = activeStorage.UnFail(t.Context())
+	require.NoError(t, err)
+
+	// then: known TX is back to invalid, user TX stays failed
+	testabilities.ThenDBState(t, activeStorage).
+		HasKnownTX(txID).WithStatus(wdk.ProvenTxStatusInvalid)
+
+	// and: outputs created by the TX remain not spendable
+	txRows, err := activeStorage.TransactionEntity().Read().
+		TxID().Equals(txID).
+		Find(t.Context())
+	require.NoError(t, err)
+	require.Len(t, txRows, 1)
+
+	outputs, err := activeStorage.OutputsEntity().Read().
+		TransactionID().Equals(txRows[0].ID).
+		Find(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, outputs)
+
+	for _, output := range outputs {
+		assert.False(t, output.Spendable,
+			"output vout=%d from a TX that failed unfail must not be spendable", output.Vout)
+	}
 }


### PR DESCRIPTION
Outputs created by a transaction were left with spendable=true and a
null tx_id when the transaction failed (abort, broadcast rejection, or
sync circuit-breaker). This caused ListOutputs to return zero-value
outpoints, which downstream transaction builders would select as inputs,
producing "duplicate input" / "malformed outpoint" broadcast errors.

Add two symmetric repo methods:
- MarkCreatedOutputsAsNotSpendable(transactionID): called on every
  failure path (abort, process broadcast rejection, sync circuit-breaker,
  unfail cascade-to-invalid)
- MarkCreatedOutputsAsSpendableByTxID(txID): called on unfail success
  to restore outputs when a tx is recovered with a merkle path

Five call sites updated: abort.go, process.go, synchronize_tx_statuses.go,
process_unfail.go (both failure and success branches).