### PR TITLE
fix: tolerate concurrent FindOrInsertUser race

### DIFF
--- a/pkg/internal/storage/repo/users.go
+++ b/pkg/internal/storage/repo/users.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"gorm.io/gen"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/entity"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/genquery"
@@ -68,7 +69,12 @@ func (u *Users) CreateUser(ctx context.Context, identityKey, activeStorage strin
 			}
 		}),
 	}
-	err = u.db.WithContext(ctx).Create(&user).Error
+	// DoNothing tolerates a concurrent insert of the same identity_key: under a
+	// find-then-create race two callers can both miss FindUser and reach here, and
+	// without this the loser's insert violates the identity_key unique index. On a
+	// conflict the row is left untouched and user.UserID stays zero; the caller
+	// detects that and re-reads the winner's row.
+	err = u.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(&user).Error
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user: %w", err)
 	}

--- a/pkg/storage/provider.go
+++ b/pkg/storage/provider.go
@@ -401,6 +401,24 @@ func (p *Provider) FindOrInsertUser(ctx context.Context, identityKey string) (*w
 		return nil, fmt.Errorf("failed to insert user: %w", err)
 	}
 
+	// A zero ID means CreateUser hit the identity_key conflict (DoNothing): a
+	// concurrent caller won the find-then-create race and already committed this
+	// user. Re-read the existing row and report it as not-new.
+	if user.ID == 0 {
+		user, err = p.repo.FindUser(ctx, identityKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find user after insert conflict: %w", err)
+		}
+		if user == nil {
+			return nil, fmt.Errorf("user %q not found after insert conflict", identityKey)
+		}
+
+		return &wdk.FindOrInsertUserResponse{
+			User:  *user.ToWDK(),
+			IsNew: false,
+		}, nil
+	}
+
 	return &wdk.FindOrInsertUserResponse{
 		User:  *user.ToWDK(),
 		IsNew: true,


### PR DESCRIPTION
## What Changed
- `CreateUser` now inserts with `clause.OnConflict{DoNothing: true}` instead of a bare `Create`, matching the existing idiom used for settings, commissions and output baskets.
- `FindOrInsertUser` detects the conflict (the returned user has a zero `UserID`), re-reads the existing row via `FindUser`, and returns it as `IsNew: false`.

## Why It Was Necessary
`FindOrInsertUser` performs a non-atomic find-then-create. On an empty `users` table, several concurrent first-callers can all miss `FindUser` and reach `CreateUser` together; the bare insert then violates the `identity_key` unique index and the losing callers fail with `duplicated key not allowed`.

On a long-lived database the user already exists, so this path never re-inserts and the bug stays dormant. But a freshly provisioned database (e.g. after a platform reset that drops the app DBs) exposes it: a consumer that starts multiple storage-touching goroutines at boot crashloops until one boot happens to win the race and commit the row.

Observed in a downstream service: `bsv_users` had a single row whose `created_at` matched the fatal "duplicated key" log to the same instant on the same boot — i.e. a concurrent double-insert, not a restart artifact.

## Testing Performed
- `go build ./...` — clean.
- `go vet ./pkg/storage/... ./pkg/internal/storage/repo/...` — clean.
- `golangci-lint run` on both changed packages — 0 issues.
- `go test ./pkg/storage/... ./pkg/internal/storage/repo/...` — all pass.

## Impact / Risk
- Low. The change is confined to the user find-or-create path. On the common (no-conflict) path behaviour is unchanged: a real insert still populates `UserID` and returns `IsNew: true`. Only the previously-fatal lost-race path changes — it now resolves to the existing row instead of erroring.
- `OnConflict{DoNothing}` is already the established pattern in this package for find-or-create writes, so no new dependency or idiom is introduced.

## Notifications
-