### PR TITLE
fix: prevent AbortAbandoned from restoring UTXOs of ARC-submitted TXs

### DIFF
--- a/pkg/internal/storage/repo/known_tx.go
+++ b/pkg/internal/storage/repo/known_tx.go
@@ -62,6 +62,32 @@ func (p *KnownTx) UpdateKnownTxStatus(ctx context.Context, txID string, status w
 	return updateKnownTxStatus(p.db.WithContext(ctx), txID, status, skipForStatuses, txNotes)
 }
 
+func (p *KnownTx) MarkKnownTxsAsSubmitting(ctx context.Context, txIDs []string) error {
+	var err error
+	ctx, span := tracing.StartTracing(ctx, "Repository-KnownTx-MarkKnownTxsAsSubmitting")
+	defer func() {
+		tracing.EndTracing(span, err)
+	}()
+
+	if len(txIDs) == 0 {
+		return nil
+	}
+
+	err = p.db.WithContext(ctx).
+		Model(&models.KnownTx{}).
+		Where("tx_id IN ?", txIDs).
+		Where("status = ?", wdk.ProvenTxStatusUnprocessed).
+		UpdateColumns(map[string]any{
+			"status":        wdk.ProvenTxStatusSending,
+			"was_broadcast": true,
+		}).Error
+	if err != nil {
+		return fmt.Errorf("failed to mark known txs as submitting: %w", err)
+	}
+
+	return nil
+}
+
 func upsertKnownTx(tx *gorm.DB, req *entity.UpsertKnownTx, txNote history.Builder) error {
 	var model models.KnownTx
 	err := tx.First(&model, "tx_id = ? ", req.TxID).Error

--- a/pkg/internal/storage/repo/transactions.go
+++ b/pkg/internal/storage/repo/transactions.go
@@ -738,6 +738,53 @@ func (txs *Transactions) FindTransactionIDsByStatuses(ctx context.Context, txSta
 	}), nil
 }
 
+func (txs *Transactions) FindTransactionIDsForAbort(ctx context.Context, opts ...queryopts.Options) ([]uint, error) {
+	var err error
+	ctx, span := tracing.StartTracing(ctx, "Repository-Transaction-FindTransactionIDsForAbort")
+	defer func() {
+		tracing.EndTracing(span, err)
+	}()
+
+	txTable := txs.query.Transaction.TableName()
+	knownTxTable := txs.query.KnownTx.TableName()
+
+	query := txs.db.WithContext(ctx).
+		Model(&models.Transaction{}).
+		Select(txTable+".id").
+		Joins(fmt.Sprintf("LEFT JOIN %s ON %s.tx_id = %s.tx_id", knownTxTable, knownTxTable, txTable)).
+		Where(
+			fmt.Sprintf(
+				"(%s.status = ? OR (%s.status = ? AND COALESCE(%s.status, ?) = ?))",
+				txTable, txTable, knownTxTable,
+			),
+			wdk.TxStatusUnsigned,
+			wdk.TxStatusUnprocessed,
+			string(wdk.ProvenTxStatusUnprocessed),
+			wdk.ProvenTxStatusUnprocessed,
+		).
+		Order(txTable + ".created_at ASC")
+
+	options := queryopts.MergeOptions(opts)
+	if options.Until != nil {
+		options.Until.ApplyDefaults()
+		query = query.Where(fmt.Sprintf("%s.created_at <= ?", txTable), options.Until.Time)
+	}
+	if options.Page != nil {
+		options.Page.ApplyDefaults()
+		query = query.Offset(options.Page.Offset).Limit(options.Page.Limit)
+	}
+
+	var rows []*models.Transaction
+	err = query.Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("query for finding transaction ids for abort failed: %w", err)
+	}
+
+	return slices.Map(rows, func(row *models.Transaction) uint {
+		return row.ID
+	}), nil
+}
+
 func (txs *Transactions) AddTransaction(ctx context.Context, tx *pkgentity.Transaction) error {
 	var err error
 	ctx, span := tracing.StartTracing(ctx, "Repository-Transaction-AddTransaction")

--- a/pkg/storage/internal/actions/abort_abandoned.go
+++ b/pkg/storage/internal/actions/abort_abandoned.go
@@ -9,18 +9,12 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/queryopts"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/logging"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/tracing"
-	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 )
 
 const (
 	failAbandonedMaxPages     = 10
 	failAbandonedItemsPerPage = 1000
 )
-
-var statusesOfAbandonedTxs = []wdk.TxStatus{
-	wdk.TxStatusUnprocessed,
-	wdk.TxStatusUnsigned,
-}
 
 func (a *abortAction) AbortAbandoned(ctx context.Context, minTransactionAge time.Duration) error {
 	var err error
@@ -47,14 +41,13 @@ func (a *abortAction) AbortAbandoned(ctx context.Context, minTransactionAge time
 	var idsToAbort []uint
 
 	for range failAbandonedMaxPages {
-		transactionIDs, err := a.transactionsRepo.FindTransactionIDsByStatuses(
+		transactionIDs, err := a.transactionsRepo.FindTransactionIDsForAbort(
 			ctx,
-			statusesOfAbandonedTxs,
 			queryopts.WithUntil(until),
 			queryopts.WithPage(paging),
 		)
 		if err != nil {
-			return fmt.Errorf("failed to find transactions by statuses: %w", err)
+			return fmt.Errorf("failed to find transactions for abort: %w", err)
 		}
 
 		idsToAbort = append(idsToAbort, transactionIDs...)

--- a/pkg/storage/internal/actions/process.go
+++ b/pkg/storage/internal/actions/process.go
@@ -535,6 +535,15 @@ func (p *process) broadcastTxs(ctx context.Context, txIDs []string, isDelayed bo
 	}
 
 	logger.DebugContext(
+		ctx, "Marking transactions as submitting before broadcast",
+		slog.Int("readyToSendCount", len(readyToSendTxIDs)),
+	)
+
+	if err = p.knownTxRepo.MarkKnownTxsAsSubmitting(ctx, readyToSendTxIDs); err != nil {
+		return nil, fmt.Errorf("failed to mark txs as submitting: %w", err)
+	}
+
+	logger.DebugContext(
 		ctx, "Posting BEEF to services",
 		slog.Int("readyToSendCount", len(readyToSendTxIDs)),
 	)

--- a/pkg/storage/internal/actions/repos.interface.go
+++ b/pkg/storage/internal/actions/repos.interface.go
@@ -52,6 +52,7 @@ type TransactionsRepo interface {
 	AddLabels(ctx context.Context, userID int, transactionID uint, labels ...string) error
 	FindTransactionIDsByTxID(ctx context.Context, txID string) ([]uint, error)
 	FindTransactionIDsByStatuses(ctx context.Context, txStatus []wdk.TxStatus, opts ...queryopts.Options) ([]uint, error)
+	FindTransactionIDsForAbort(ctx context.Context, opts ...queryopts.Options) ([]uint, error)
 }
 
 type KnownTxRepo interface {
@@ -69,6 +70,7 @@ type KnownTxRepo interface {
 	ApplyProofTimeouts(ctx context.Context, attempts, maxRebroadcastAttempts uint64, statuses []wdk.ProvenTxReqStatus) ([]models.KnownTx, error)
 	FindKnownTxRawTxs(ctx context.Context, txIDs []string) (map[string][]byte, error)
 	UpdateKnownTxStatus(ctx context.Context, txID string, status wdk.ProvenTxReqStatus, skipForStatuses []wdk.ProvenTxReqStatus, txNotes []history.Builder) error
+	MarkKnownTxsAsSubmitting(ctx context.Context, txIDs []string) error
 	SetBatchForKnownTxs(ctx context.Context, txIDs []string, batch string) error
 }
 


### PR DESCRIPTION
## Summary

- **Root cause:** When a `processAction` context cancels (e.g. 1-minute HTTP timeout)
  after the signed TX has been submitted to ARC but before `updateSingleTx` can record
  the result, the TX is left in `unprocessed` status with no indication it was already
  sent. `AbortAbandoned` then finds it, calls `RecreateSpentOutputs`, and frees the
  UTXOs. A concurrent TX grabs those UTXOs. ARC eventually mines the original. Double spend.

- **Fix 1 — `process.go`:** Call `MarkKnownTxsAsSubmitting` immediately before
  `PostFromBEEF`. This sets `ProvenTxReq = sending, was_broadcast = true` atomically
  before ARC ever sees the TX. Any subsequent context cancel leaves the TX in a state
  that `AbortAbandoned` skips, and `ApplyProofTimeouts` handles via the rebroadcast
  path rather than `invalid`.

- **Fix 2 — `abort_abandoned.go`:** Replace `FindTransactionIDsByStatuses` with
  `FindTransactionIDsForAbort`, which only returns `unprocessed` TXs where the
  corresponding `KnownTx` is still in `ProvenTxStatusUnprocessed` — i.e. they failed
  before BEEF building completed and ARC was never involved. Those are safe to abort.

## Known remaining issue

If the context cancels **during BEEF building** (before `MarkKnownTxsAsSubmitting` is
reached), the TX is left in `unprocessed + ProvenTxReq = unprocessed`. `AbortAbandoned`
will correctly treat it as safe to abort. However, if the client retries before
`AbortAbandoned` fires and that retry also gets cancelled after reaching ARC, the fix
kicks in. If `AbortAbandoned` fires first, the retry fails — the user's operation is
silently dropped and they must create a new action.

The root fix for that case is restructuring `processNewTx` to call `SpendTransaction`
only after BEEF is successfully built, so a BEEF build failure leaves the TX in
`unsigned` (always safe to abort) rather than `unprocessed`. That is a larger change
tracked separately.