### PR TITLE
fix: JSON wire-format compatibility with TypeScript storage servers

### DIFF
--- a/pkg/storage/v1adapter/handler.go
+++ b/pkg/storage/v1adapter/handler.go
@@ -312,7 +312,7 @@ func (h *Handler) createAction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var args wdk.ValidCreateActionArgs
-	if err := json.Unmarshal(argsRaw, &args); err != nil { //nolint:musttag // wdk.OutPoint (nested) has no JSON tags; decoded by wdk package conventions.
+	if err := json.Unmarshal(argsRaw, &args); err != nil {
 		h.writeError(w, http.StatusBadRequest, "invalid args for createAction")
 		return
 	}

--- a/pkg/wdk/outpoint.go
+++ b/pkg/wdk/outpoint.go
@@ -5,9 +5,9 @@ import "fmt"
 // OutPoint identifies a unique transaction output by its txid and index vout
 type OutPoint struct {
 	// TxID Transaction double sha256 hash as big endian hex string
-	TxID string
+	TxID string `json:"txid"`
 	// Vout Zero based output index within the transaction
-	Vout uint32
+	Vout uint32 `json:"vout"`
 }
 
 func (o OutPoint) String() string {

--- a/pkg/wdk/primitives/beef.go
+++ b/pkg/wdk/primitives/beef.go
@@ -7,6 +7,8 @@ import (
 )
 
 // BEEF An array of integers, each ranging from 0 to 255, indicating transaction data in BEEF (BRC-62) format.
+// Overloads default JSON serialization (base64 string) so the wire format matches TypeScript
+// storage servers, which expect an explicit [0..255] number array.
 type BEEF []byte
 
 // MarshalJSON marshals the BEEF to a JSON array of numbers, matching the
@@ -15,7 +17,8 @@ func (b BEEF) MarshalJSON() ([]byte, error) {
 	return ExplicitByteArray(b).MarshalJSON()
 }
 
-// UnmarshalJSON accepts either a JSON array of numbers or a base64 string.
+// UnmarshalJSON accepts either a JSON array of numbers or a base64 string
+// (legacy Go encoding/json []byte form). Null decodes to nil.
 func (b *BEEF) UnmarshalJSON(data []byte) error {
 	if len(data) > 0 && data[0] == '"' {
 		var s string
@@ -29,27 +32,12 @@ func (b *BEEF) UnmarshalJSON(data []byte) error {
 		*b = decoded
 		return nil
 	}
-	var nums []byte
-	if err := unmarshalByteNumbers(data, &nums); err != nil {
-		return err
-	}
-	*b = nums
-	return nil
-}
 
-// unmarshalByteNumbers decodes a JSON array of 0..255 numbers into bytes.
-func unmarshalByteNumbers(data []byte, out *[]byte) error {
-	var nums []uint16
-	if err := json.Unmarshal(data, &nums); err != nil {
-		return fmt.Errorf("invalid byte array: %w", err)
+	// Reuse ExplicitByteArray for number-array / null decoding.
+	var eba ExplicitByteArray
+	if err := eba.UnmarshalJSON(data); err != nil {
+		return fmt.Errorf("invalid BEEF: %w", err)
 	}
-	result := make([]byte, len(nums))
-	for i, n := range nums {
-		if n > 255 {
-			return fmt.Errorf("byte array value %d out of range at index %d", n, i)
-		}
-		result[i] = byte(n)
-	}
-	*out = result
+	*b = BEEF(eba)
 	return nil
 }

--- a/pkg/wdk/primitives/beef.go
+++ b/pkg/wdk/primitives/beef.go
@@ -1,4 +1,55 @@
 package primitives
 
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
 // BEEF An array of integers, each ranging from 0 to 255, indicating transaction data in BEEF (BRC-62) format.
 type BEEF []byte
+
+// MarshalJSON marshals the BEEF to a JSON array of numbers, matching the
+// wire format the TS wallet-toolbox expects.
+func (b BEEF) MarshalJSON() ([]byte, error) {
+	return ExplicitByteArray(b).MarshalJSON()
+}
+
+// UnmarshalJSON accepts either a JSON array of numbers or a base64 string.
+func (b *BEEF) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return fmt.Errorf("invalid BEEF string: %w", err)
+		}
+		decoded, err := base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			return fmt.Errorf("invalid BEEF base64: %w", err)
+		}
+		*b = decoded
+		return nil
+	}
+	var nums []byte
+	if err := unmarshalByteNumbers(data, &nums); err != nil {
+		return err
+	}
+	*b = nums
+	return nil
+}
+
+// unmarshalByteNumbers decodes a JSON array of 0..255 numbers into bytes.
+func unmarshalByteNumbers(data []byte, out *[]byte) error {
+	var nums []uint16
+	if err := json.Unmarshal(data, &nums); err != nil {
+		return fmt.Errorf("invalid byte array: %w", err)
+	}
+	result := make([]byte, len(nums))
+	for i, n := range nums {
+		if n > 255 {
+			return fmt.Errorf("byte array value %d out of range at index %d", n, i)
+		}
+		result[i] = byte(n)
+	}
+	*out = result
+	return nil
+}

--- a/pkg/wdk/primitives/beef_test.go
+++ b/pkg/wdk/primitives/beef_test.go
@@ -14,6 +14,12 @@ func TestBEEFMarshalsToNumberArray(t *testing.T) {
 	assert.Equal(t, "[0,1,255]", string(data))
 }
 
+func TestBEEFMarshalsEmptyAsEmptyArray(t *testing.T) {
+	data, err := json.Marshal(BEEF{})
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(data))
+}
+
 func TestBEEFUnmarshalRoundTrip(t *testing.T) {
 	original := BEEF{0, 1, 127, 255}
 	data, err := json.Marshal(original)
@@ -35,12 +41,13 @@ func TestBEEFUnmarshalRejectsOutOfRange(t *testing.T) {
 	assert.Error(t, json.Unmarshal([]byte("[0,256]"), &decoded))
 }
 
-func TestExplicitByteArrayUnmarshalRoundTrip(t *testing.T) {
-	original := ExplicitByteArray{0, 1, 127, 255}
-	data, err := json.Marshal(original)
-	require.NoError(t, err)
+func TestBEEFUnmarshalNull(t *testing.T) {
+	decoded := BEEF{1, 2, 3}
+	require.NoError(t, json.Unmarshal([]byte("null"), &decoded))
+	assert.Nil(t, decoded)
+}
 
-	var decoded ExplicitByteArray
-	require.NoError(t, json.Unmarshal(data, &decoded))
-	assert.Equal(t, original, decoded)
+func TestBEEFUnmarshalRejectsInvalidBase64(t *testing.T) {
+	var decoded BEEF
+	assert.Error(t, json.Unmarshal([]byte(`"not!!base64"`), &decoded))
 }

--- a/pkg/wdk/primitives/beef_test.go
+++ b/pkg/wdk/primitives/beef_test.go
@@ -1,0 +1,36 @@
+package primitives
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBEEFMarshalsToNumberArray(t *testing.T) {
+	data, err := json.Marshal(BEEF{0, 1, 255})
+	require.NoError(t, err)
+	assert.Equal(t, "[0,1,255]", string(data))
+}
+
+func TestBEEFUnmarshalRoundTrip(t *testing.T) {
+	original := BEEF{0, 1, 127, 255}
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded BEEF
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, original, decoded)
+}
+
+func TestBEEFUnmarshalAcceptsBase64(t *testing.T) {
+	var decoded BEEF
+	require.NoError(t, json.Unmarshal([]byte(`"AAH/"`), &decoded))
+	assert.Equal(t, BEEF{0, 1, 255}, decoded)
+}
+
+func TestBEEFUnmarshalRejectsOutOfRange(t *testing.T) {
+	var decoded BEEF
+	assert.Error(t, json.Unmarshal([]byte("[0,256]"), &decoded))
+}

--- a/pkg/wdk/primitives/beef_test.go
+++ b/pkg/wdk/primitives/beef_test.go
@@ -34,3 +34,13 @@ func TestBEEFUnmarshalRejectsOutOfRange(t *testing.T) {
 	var decoded BEEF
 	assert.Error(t, json.Unmarshal([]byte("[0,256]"), &decoded))
 }
+
+func TestExplicitByteArrayUnmarshalRoundTrip(t *testing.T) {
+	original := ExplicitByteArray{0, 1, 127, 255}
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded ExplicitByteArray
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, original, decoded)
+}

--- a/pkg/wdk/storage_create_action_args_json_test.go
+++ b/pkg/wdk/storage_create_action_args_json_test.go
@@ -1,0 +1,68 @@
+package wdk
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk/primitives"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression for #776: TS storage servers expect inputBEEF as a number array
+// (not base64) and outpoint fields as lowercase "txid"/"vout".
+func TestValidCreateActionArgsWireFormat(t *testing.T) {
+	args := ValidCreateActionArgs{
+		Description: "spend existing output",
+		InputBEEF:   primitives.BEEF{0, 1, 255},
+		Inputs: []ValidCreateActionInput{
+			{
+				Outpoint: OutPoint{
+					TxID: "abcd1234",
+					Vout: 1,
+				},
+				InputDescription: "input 0",
+			},
+		},
+		Outputs: []ValidCreateActionOutput{},
+		Labels:  []primitives.StringUnder300{},
+		Options: ValidCreateActionOptions{
+			SendWith:     []primitives.TXIDHexString{},
+			KnownTxids:   []primitives.TXIDHexString{},
+			NoSendChange: []OutPoint{},
+		},
+	}
+
+	data, err := json.Marshal(args)
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	// inputBEEF must be a JSON number array, never a base64 string.
+	assert.Equal(t, "[0,1,255]", string(raw["inputBEEF"]))
+
+	// Nested outpoint must use lowercase JSON keys expected by TS.
+	var inputs []map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw["inputs"], &inputs))
+	require.Len(t, inputs, 1)
+
+	var outpoint map[string]any
+	require.NoError(t, json.Unmarshal(inputs[0]["outpoint"], &outpoint))
+	assert.Equal(t, "abcd1234", outpoint["txid"])
+	assert.EqualValues(t, 1, outpoint["vout"])
+	_, hasTxID := outpoint["TxID"]
+	_, hasVoutPascal := outpoint["Vout"]
+	assert.False(t, hasTxID, "must not emit PascalCase TxID")
+	assert.False(t, hasVoutPascal, "must not emit PascalCase Vout")
+}
+
+func TestOutPointJSONTags(t *testing.T) {
+	data, err := json.Marshal(OutPoint{TxID: "deadbeef", Vout: 7})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"txid":"deadbeef","vout":7}`, string(data))
+
+	var decoded OutPoint
+	require.NoError(t, json.Unmarshal([]byte(`{"txid":"cafebabe","vout":3}`), &decoded))
+	assert.Equal(t, OutPoint{TxID: "cafebabe", Vout: 3}, decoded)
+}


### PR DESCRIPTION
Fixes #776.

Two fields in the remote-storage wire format serialize in a shape TypeScript storage servers reject, so any `CreateAction` against a TS storage server that supplies explicit inputs fails.

### `primitives.BEEF` marshals as base64, not a number array
`BEEF` is `[]byte`, which Go's `encoding/json` marshals as a base64 string. The TS wallet-toolbox reads `inputBEEF` with `makeReader`, which requires a number array, so a `createAction` carrying `inputBEEF` fails with:

```
bin must be Uint8Array or number[]
```

Adds `MarshalJSON` (emits `[0,1,255]`, reusing the existing `ExplicitByteArray` encoder) and `UnmarshalJSON` (accepts both a number array and a base64 string).

### `OutPoint` has no JSON tags
`OutPoint{TxID, Vout}` serializes as `{"TxID":…,"Vout":…}`; the TS server reads `outpoint.txid`/`outpoint.vout`, so the txid arrives `undefined` and validation fails with:

```
inputBEEF ... must be valid and contain proof data for possibly known undefined
```

Adds `json:"txid"` / `json:"vout"` tags.

### Tests
Round-trip tests for `BEEF` (number array, base64 input, out-of-range rejection).

Reproduced against a live TypeScript storage server: a Go service calling `CreateAction` with explicit inputs + `inputBEEF` fails on both counts before this change and succeeds after.