### PR TITLE
fix: persist KnownTx notify opaque payload for sync (#851)

### DIFF
--- a/pkg/entity/known_tx.go
+++ b/pkg/entity/known_tx.go
@@ -19,6 +19,9 @@ type KnownTx struct {
 	Notified            bool
 	WasBroadcast        bool
 	RebroadcastAttempts uint64
+	// Notify is an opaque payload (typically JSON) from ProvenTxReq.notify.
+	// Persisted and returned unchanged for sync round-trip; no Go-side semantics.
+	Notify string
 
 	RawTx     []byte
 	InputBEEF []byte

--- a/pkg/internal/storage/database/models/known_tx.go
+++ b/pkg/internal/storage/database/models/known_tx.go
@@ -17,6 +17,10 @@ type KnownTx struct {
 	RebroadcastAttempts uint64 `gorm:"column:rebroadcast_attempts;default:0"`
 	Notified            bool
 	Batch               *string `gorm:"index"`
+	// Notify is an opaque JSON blob used by the TypeScript wallet to track
+	// which transactions to notify when proofs arrive. Stored and returned
+	// unchanged for sync round-trip compatibility.
+	Notify string `gorm:"type:text;default:'{}'"`
 
 	WasBroadcast bool
 

--- a/pkg/internal/storage/repo/syncrepo/sync_knowntx.go
+++ b/pkg/internal/storage/repo/syncrepo/sync_knowntx.go
@@ -84,6 +84,11 @@ func (s *SyncKnownTx) FindKnownTxsForSync(ctx context.Context, userID int, opts 
 }
 
 func (s *SyncKnownTx) UpsertKnownTxForSync(ctx context.Context, entity *entity.KnownTx) (isNew bool, err error) {
+	notify := entity.Notify
+	if notify == "" {
+		notify = "{}"
+	}
+
 	model := models.KnownTx{
 		CreatedAt:           entity.CreatedAt,
 		UpdatedAt:           entity.UpdatedAt,
@@ -93,6 +98,7 @@ func (s *SyncKnownTx) UpsertKnownTxForSync(ctx context.Context, entity *entity.K
 		WasBroadcast:        entity.WasBroadcast || entity.Status.WasBroadcastStatus(),
 		RebroadcastAttempts: entity.RebroadcastAttempts,
 		Notified:            entity.Notified,
+		Notify:              notify,
 		RawTx:               entity.RawTx,
 		InputBeef:           entity.InputBEEF,
 		BlockHeight:         entity.BlockHeight,
@@ -217,6 +223,11 @@ func (s *SyncKnownTx) mapModelToTableProvenTxReqForSync(model *KnownTxWithNum) (
 		return nil, err
 	}
 
+	notify := model.Notify
+	if notify == "" {
+		notify = "{}"
+	}
+
 	return &wdk.TableProvenTxReq{
 		CreatedAt:           model.CreatedAt,
 		UpdatedAt:           model.UpdatedAt,
@@ -229,7 +240,7 @@ func (s *SyncKnownTx) mapModelToTableProvenTxReqForSync(model *KnownTxWithNum) (
 		TxID:                model.TxID,
 		Batch:               nil, // TODO: For now batch broadcasting is not supported, will be added later
 		History:             historyNotes,
-		Notify:              "{}", // TODO: Notify includes transaction IDs and they are only used by JS-version of the wallet, so we can ignore it for now
+		Notify:              notify,
 		RawTx:               model.RawTx,
 		InputBEEF:           model.InputBeef,
 	}, nil

--- a/pkg/internal/storage/repo/syncrepo/sync_knowntx_notify_test.go
+++ b/pkg/internal/storage/repo/syncrepo/sync_knowntx_notify_test.go
@@ -1,0 +1,152 @@
+package syncrepo_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/entity"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/dbfixtures"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+)
+
+// Tests for go-wallet-toolbox#851: ProvenTxReq.notify must round-trip through
+// UpsertKnownTxForSync / FindKnownTxsForSync as an opaque blob.
+
+func TestKnownTxNotify_UpsertPersistsOpaquePayload(t *testing.T) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	t0 := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	// 64 hex chars to satisfy varchar(64) primary key on Postgres.
+	txID := "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+	notifyPayload := `{"transactionIds":[42,99],"origin":"js-wallet"}`
+
+	isNew, err := repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+		CreatedAt: t0,
+		UpdatedAt: t0,
+		TxID:      txID,
+		Status:    wdk.ProvenTxStatusUnsent,
+		RawTx:     []byte{0x01, 0x00},
+		Notify:    notifyPayload,
+	})
+	require.NoError(t, err)
+	require.True(t, isNew)
+
+	var got models.KnownTx
+	require.NoError(t, d.DB.First(&got, "tx_id = ?", txID).Error)
+	require.Equal(t, notifyPayload, got.Notify,
+		"incoming notify payload must be stored unchanged")
+}
+
+func TestKnownTxNotify_UpsertDefaultEmptyToObject(t *testing.T) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	t0 := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	txID := "11223344556677889900aabbccddeeff11223344556677889900aabbccddeeff"
+
+	_, err := repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+		CreatedAt: t0,
+		UpdatedAt: t0,
+		TxID:      txID,
+		Status:    wdk.ProvenTxStatusUnsent,
+		RawTx:     []byte{0x01},
+		// Notify intentionally omitted / empty
+	})
+	require.NoError(t, err)
+
+	var got models.KnownTx
+	require.NoError(t, d.DB.First(&got, "tx_id = ?", txID).Error)
+	require.Equal(t, "{}", got.Notify, "empty notify must default to {}")
+}
+
+func TestKnownTxNotify_FindForSyncRoundTrip(t *testing.T) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	user, err := repos.CreateUser(
+		t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: defaultBasket, NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	)
+	require.NoError(t, err)
+
+	t0 := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	txID := "99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa"
+	notifyPayload := `{"transactionIds":[7],"note":"proof-pending"}`
+	rawTx := []byte{0x02, 0x00, 0x00, 0x00}
+
+	// Link a user transaction so FindKnownTxsForSync's EXISTS filter matches.
+	_, _, err = repos.UpsertTransactionForSync(t.Context(), &entity.Transaction{
+		CreatedAt:   t0,
+		UpdatedAt:   t0,
+		UserID:      user.ID,
+		Status:      wdk.TxStatusUnproven,
+		Reference:   "ref-notify-roundtrip",
+		IsOutgoing:  true,
+		Satoshis:    100,
+		Description: "notify round-trip",
+		TxID:        &txID,
+	})
+	require.NoError(t, err)
+
+	_, err = repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+		CreatedAt: t0,
+		UpdatedAt: t0,
+		TxID:      txID,
+		Status:    wdk.ProvenTxStatusUnsent,
+		RawTx:     rawTx,
+		Notify:    notifyPayload,
+	})
+	require.NoError(t, err)
+
+	reqs, proven, err := repos.FindKnownTxsForSync(t.Context(), user.ID)
+	require.NoError(t, err)
+	require.Empty(t, proven, "unmined known tx must appear as ProvenTxReq, not ProvenTx")
+	require.Len(t, reqs, 1)
+	require.Equal(t, txID, reqs[0].TxID)
+	require.Equal(t, notifyPayload, reqs[0].Notify,
+		"FindKnownTxsForSync must return the stored notify payload unchanged")
+}
+
+func TestKnownTxNotify_UpdateReplacesPayload(t *testing.T) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	tOld := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	tNew := time.Date(2026, 7, 18, 13, 0, 0, 0, time.UTC)
+	txID := "ddeeff00112233445566778899aabbccddeeff00112233445566778899aabbcc"
+
+	_, err := repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+		CreatedAt: tOld,
+		UpdatedAt: tOld,
+		TxID:      txID,
+		Status:    wdk.ProvenTxStatusUnsent,
+		RawTx:     []byte{0x01},
+		Notify:    `{"transactionIds":[1]}`,
+	})
+	require.NoError(t, err)
+
+	_, err = repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+		CreatedAt: tOld,
+		UpdatedAt: tNew,
+		TxID:      txID,
+		Status:    wdk.ProvenTxStatusUnmined,
+		RawTx:     []byte{0x01},
+		Notify:    `{"transactionIds":[1,2,3]}`,
+	})
+	require.NoError(t, err)
+
+	var got models.KnownTx
+	require.NoError(t, d.DB.First(&got, "tx_id = ?", txID).Error)
+	require.Equal(t, `{"transactionIds":[1,2,3]}`, got.Notify,
+		"newer updated_at must replace notify payload")
+	require.Equal(t, wdk.ProvenTxStatusUnmined, got.Status)
+}

--- a/pkg/internal/storage/repo/syncrepo/sync_knowntx_notify_test.go
+++ b/pkg/internal/storage/repo/syncrepo/sync_knowntx_notify_test.go
@@ -146,7 +146,7 @@ func TestKnownTxNotify_UpdateReplacesPayload(t *testing.T) {
 
 	var got models.KnownTx
 	require.NoError(t, d.DB.First(&got, "tx_id = ?", txID).Error)
-	require.Equal(t, `{"transactionIds":[1,2,3]}`, got.Notify,
+	require.JSONEq(t, `{"transactionIds":[1,2,3]}`, got.Notify,
 		"newer updated_at must replace notify payload")
 	require.Equal(t, wdk.ProvenTxStatusUnmined, got.Status)
 }

--- a/pkg/storage/internal/sync/chunk_processor.go
+++ b/pkg/storage/internal/sync/chunk_processor.go
@@ -222,6 +222,7 @@ func (p *ChunkProcessor) upsertProvenTxReqs(chunkProvenTxReq *wdk.TableProvenTxR
 		WasBroadcast:        chunkProvenTxReq.WasBroadcast || chunkProvenTxReq.Status.WasBroadcastStatus(),
 		RebroadcastAttempts: chunkProvenTxReq.RebroadcastAttempts,
 		Notified:            chunkProvenTxReq.Notified,
+		Notify:              chunkProvenTxReq.Notify,
 		RawTx:               chunkProvenTxReq.RawTx,
 		InputBEEF:           chunkProvenTxReq.InputBEEF,
 		TxNotes:             historyNotes,


### PR DESCRIPTION
## Summary
- Add `notify` text column on `KnownTx` (GORM AutoMigrate) to store the opaque ProvenTxReq.notify blob used by the TypeScript wallet.
- Wire notify through entity, chunk ingest (`upsertProvenTxReqs`), `UpsertKnownTxForSync`, and `FindKnownTxsForSync` so the payload round-trips unchanged.
- Empty notify defaults to `"{}"` for backward compatibility with the previous hardcoded value.

Fixes #851

## Test plan
- [x] `go test ./pkg/internal/storage/repo/syncrepo/ -run TestKnownTxNotify -count=1`
- [x] `go test ./pkg/internal/storage/repo/syncrepo/ -count=1`
- [ ] CI green on PR

### Local coverage
- Upsert persists opaque notify payload
- Empty notify defaults to `{}`
- FindKnownTxsForSync returns stored notify
- Newer updated_at update replaces notify payload