### PR TITLE
fix: listOutputs includeLabels populates output labels

### DIFF
--- a/pkg/storage/internal/actions/list_outputs.go
+++ b/pkg/storage/internal/actions/list_outputs.go
@@ -41,7 +41,6 @@ func newListOutputs(logger *slog.Logger, outputsRepo OutputRepo, knownTxRepo Kno
 
 func (l *listOutputs) ListOutputs(ctx context.Context, auth wdk.AuthID, args *wdk.ListOutputsArgs) (*wdk.ListOutputsResult, error) {
 	// TODO: Handle args.KnownTxids
-	// TODO: Handle args.IncludeLabels
 
 	userID := *auth.UserID
 	var err error
@@ -78,26 +77,18 @@ func (l *listOutputs) ListOutputs(ctx context.Context, auth wdk.AuthID, args *wd
 		return nil, fmt.Errorf("error during listing outputs: %w", err)
 	}
 
-	outputs := make([]*wdk.WalletOutput, len(outputModels))
-
-	var labelMap map[uint][]string
-	if args.IncludeLabels {
-		var txIDs []uint
-		for _, m := range outputModels {
-			txIDs = append(txIDs, m.TransactionID)
-		}
-
-		if labels, err := l.transactionsRepo.GetLabelsForTransactions(ctx, txIDs); err == nil {
-			labelMap = labels
-		}
+	labelMap, err := l.loadLabelsIfNeeded(ctx, outputModels, args.IncludeLabels)
+	if err != nil {
+		return nil, err
 	}
 
+	outputs := make([]*wdk.WalletOutput, len(outputModels))
 	for i, m := range outputModels {
 		out := l.outputModelToResult(m)
-		if labelMap != nil {
-			if labels, ok := labelMap[m.TransactionID]; ok {
-				out.Labels = slices.Map(labels, func(s string) primitives.StringUnder300 { return primitives.StringUnder300(s) })
-			}
+		if labels, ok := labelMap[m.TransactionID]; ok {
+			out.Labels = slices.Map(labels, func(s string) primitives.StringUnder300 {
+				return primitives.StringUnder300(s)
+			})
 		}
 		outputs[i] = out
 	}
@@ -129,6 +120,25 @@ func (l *listOutputs) ListOutputs(ctx context.Context, auth wdk.AuthID, args *wd
 	}
 
 	return result, nil
+}
+
+// loadLabelsIfNeeded fetches transaction labels for the given outputs when includeLabels is true.
+// Labels are attached to transactions (via TxLabel/TxLabelMap); each output inherits its parent tx labels.
+func (l *listOutputs) loadLabelsIfNeeded(ctx context.Context, outputModels []*pkgentity.Output, includeLabels bool) (map[uint][]string, error) {
+	if !includeLabels {
+		return map[uint][]string{}, nil
+	}
+
+	txIDs := make([]uint, 0, len(outputModels))
+	for _, m := range outputModels {
+		txIDs = append(txIDs, m.TransactionID)
+	}
+
+	labelMap, err := l.transactionsRepo.GetLabelsForTransactions(ctx, txIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load labels: %w", err)
+	}
+	return labelMap, nil
 }
 
 func (l *listOutputs) uniqueTxTDsForAllOutputs(outputModels []*pkgentity.Output) iter.Seq[string] {

--- a/pkg/storage/provider_list_outputs_test.go
+++ b/pkg/storage/provider_list_outputs_test.go
@@ -1,6 +1,7 @@
 package storage_test
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/go-softwarelab/common/pkg/seq"
@@ -416,4 +417,101 @@ func TestListOutputs_ShouldReturnOnlySpendableOutputs(t *testing.T) {
 	if len(result.Outputs) == 1 {
 		require.Less(t, result.Outputs[0].Satoshis, primitives.SatoshiValue(5))
 	}
+}
+
+func TestListOutputs_IncludeLabels_True(t *testing.T) {
+	// given: an internalized tx with labels and a created action with CreateActionTestLabel
+	ctx := t.Context()
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+
+	activeStorage := given.Provider().WithRandomizer(randomizer.NewTestRandomizer()).GORM()
+	given.Action(activeStorage).Processed()
+
+	// when:
+	result, err := activeStorage.ListOutputs(ctx, testusers.Alice.AuthID(), wdk.ListOutputsArgs{
+		Limit:         100,
+		IncludeLabels: true,
+	})
+
+	// then:
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Outputs)
+
+	var foundLabeled bool
+	for _, output := range result.Outputs {
+		if slices.Contains(output.Labels, fixtures.CreateActionTestLabel) {
+			foundLabeled = true
+			break
+		}
+	}
+	require.True(t, foundLabeled, "IncludeLabels=true should populate CreateActionTestLabel on at least one output")
+}
+
+func TestListOutputs_IncludeLabels_False(t *testing.T) {
+	// given:
+	ctx := t.Context()
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+
+	activeStorage := given.Provider().WithRandomizer(randomizer.NewTestRandomizer()).GORM()
+	given.Action(activeStorage).Processed()
+
+	// when: includeLabels omitted/false (default zero value)
+	result, err := activeStorage.ListOutputs(ctx, testusers.Alice.AuthID(), wdk.ListOutputsArgs{
+		Limit:         100,
+		IncludeLabels: false,
+	})
+
+	// then:
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Outputs)
+	for _, output := range result.Outputs {
+		assert.Empty(t, output.Labels, "IncludeLabels=false should leave labels empty")
+	}
+}
+
+func TestListOutputs_IncludeLabels_Internalize(t *testing.T) {
+	// given: internalized output with known labels
+	ctx := t.Context()
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+
+	activeStorage := given.Provider().WithRandomizer(randomizer.NewTestRandomizer()).GORM()
+
+	internalizeArgs := fixtures.DefaultInternalizeActionArgs(t, wdk.BasketInsertionProtocol)
+	internalizeResult, err := activeStorage.InternalizeAction(ctx, testusers.Alice.AuthID(), internalizeArgs)
+	require.NoError(t, err)
+
+	outpoint := primitives.NewOutpointString(internalizeResult.TxID, 0)
+
+	// when: includeLabels=true
+	result, err := activeStorage.ListOutputs(ctx, testusers.Alice.AuthID(), wdk.ListOutputsArgs{
+		Limit:         100,
+		IncludeLabels: true,
+	})
+	require.NoError(t, err)
+
+	// then: labels from internalize are present on the output
+	output, _ := testutils.FindOutput(t, result.Outputs, func(p *wdk.WalletOutput) bool {
+		return p.Outpoint == outpoint
+	})
+	require.NotNil(t, output)
+	for _, label := range internalizeArgs.Labels {
+		assert.Contains(t, output.Labels, label)
+	}
+
+	// when: includeLabels=false
+	result, err = activeStorage.ListOutputs(ctx, testusers.Alice.AuthID(), wdk.ListOutputsArgs{
+		Limit:         100,
+		IncludeLabels: false,
+	})
+	require.NoError(t, err)
+
+	// then: labels are empty
+	output, _ = testutils.FindOutput(t, result.Outputs, func(p *wdk.WalletOutput) bool {
+		return p.Outpoint == outpoint
+	})
+	require.NotNil(t, output)
+	assert.Empty(t, output.Labels)
 }

--- a/pkg/wallet/wallet_list_outputs_test.go
+++ b/pkg/wallet/wallet_list_outputs_test.go
@@ -253,5 +253,18 @@ func (s *WalletTestSuite) TestWalletListOutputs() {
 		assert.Contains(t, result.Outputs[0].Tags, "tag1", "Should contain expected tag")
 		assert.Contains(t, result.Outputs[0].Tags, "tag2", "Should contain expected tag")
 		assert.NotEmpty(t, result.Outputs[0].CustomInstructions, "Custom instructions should be included")
+
+		// and: includeLabels=true should populate transaction labels on each output
+		assert.NotEmpty(t, result.Outputs[0].Labels, "Labels should be included when IncludeLabels=true")
+		assert.Contains(t, result.Outputs[0].Labels, "label1", "Should contain expected label")
+		assert.Contains(t, result.Outputs[0].Labels, "label2", "Should contain expected label")
+
+		// when: includeLabels=false
+		falseValue := false
+		args.IncludeLabels = &falseValue
+		resultWithoutLabels, err := aliceWallet.ListOutputs(t.Context(), args, fixtures.DefaultOriginator)
+		require.NoError(t, err)
+		require.NotEmpty(t, resultWithoutLabels.Outputs)
+		assert.Empty(t, resultWithoutLabels.Outputs[0].Labels, "Labels should be empty when IncludeLabels=false")
 	})
 }


### PR DESCRIPTION
## Summary
- `listOutputs` already fetched labels when `includeLabels` was true, but still had a stale TODO and **swallowed** label-fetch errors (leaving empty labels).
- Refactored label loading into `loadLabelsIfNeeded`, removed the TODO, and return errors from `GetLabelsForTransactions`.
- Outputs inherit labels from their parent transaction (TxLabel / transaction_labels), matching TypeScript behavior.

Fixes #820

## Test plan
- [x] `go test ./pkg/storage/ -run 'TestListOutputs_IncludeLabels|TestListOutputs_MinimalFilter|TestListOutputs_IncludeTags' -count=1`
- [x] `go test ./pkg/wallet/ -run 'ListOutputs' -count=1`
- [x] `go test ./pkg/storage/internal/actions/ -count=1`
- [ ] Verify `includeLabels: true` returns populated labels on each output
- [ ] Verify `includeLabels: false` / omitted leaves labels empty/nil