### PR TITLE
fix: populate provenTx/provenTxReq idMap in processSyncChunk

### DIFF
--- a/pkg/internal/storage/repo/syncrepo/brc40_conformance_test.go
+++ b/pkg/internal/storage/repo/syncrepo/brc40_conformance_test.go
@@ -274,7 +274,7 @@ func runMergeExistingProvenTx(t *testing.T, v brc40Vector) {
 	existingHeight := asUint32(t, existing["height"])
 	existingRoot := "root-existing"
 	existingHash := "hash-existing"
-	_, err := repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+	_, _, err := repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
 		CreatedAt:   parseISO(t, asString(existing["created_at"])),
 		UpdatedAt:   parseISO(t, asString(existing["updated_at"])),
 		TxID:        txid,
@@ -290,7 +290,7 @@ func runMergeExistingProvenTx(t *testing.T, v brc40Vector) {
 	incomingHeight := asUint32(t, incoming["height"])
 	incomingRoot := "root-incoming"
 	incomingHash := "hash-incoming"
-	_, err = repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+	_, _, err = repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
 		CreatedAt:   parseISO(t, asString(incoming["created_at"])),
 		UpdatedAt:   parseISO(t, asString(incoming["updated_at"])),
 		TxID:        txid,

--- a/pkg/internal/storage/repo/syncrepo/brc40_guard_test.go
+++ b/pkg/internal/storage/repo/syncrepo/brc40_guard_test.go
@@ -32,7 +32,7 @@ func TestBRC40Guard_KnownTx_StaleSkip(t *testing.T) {
 	var blockHeight uint32 = 845123
 
 	// Seed newer (proven) record
-	isNew, err := repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+	isNew, _, err := repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
 		CreatedAt:   tNewer,
 		UpdatedAt:   tNewer,
 		TxID:        txID,
@@ -46,7 +46,7 @@ func TestBRC40Guard_KnownTx_StaleSkip(t *testing.T) {
 	require.True(t, isNew)
 
 	// Stale incoming: older updated_at, attempts to overwrite with unknown/no-merkle
-	isNew, err = repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+	isNew, _, err = repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
 		CreatedAt:  tStale,
 		UpdatedAt:  tStale,
 		TxID:       txID,
@@ -86,7 +86,7 @@ func TestBRC40Guard_KnownTx_EqualSkip(t *testing.T) {
 	blockHash := "hash-equal"
 	var blockHeight uint32 = 100
 
-	_, err := repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+	_, _, err := repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
 		CreatedAt:   t0,
 		UpdatedAt:   t0,
 		TxID:        txID,
@@ -99,7 +99,7 @@ func TestBRC40Guard_KnownTx_EqualSkip(t *testing.T) {
 	require.NoError(t, err)
 
 	// Equal updated_at — strict `>` boundary: MUST skip
-	_, err = repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+	_, _, err = repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
 		CreatedAt:  t0,
 		UpdatedAt:  t0,
 		TxID:       txID,
@@ -125,7 +125,7 @@ func TestBRC40Guard_KnownTx_HappyUpdate(t *testing.T) {
 	tNew := time.Date(2026, 4, 23, 13, 0, 0, 0, time.UTC)
 	txID := "0011223344556677889900aabbccddeeff00112233445566778899aabbccddee"
 
-	_, err := repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+	_, _, err := repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
 		CreatedAt: tOld,
 		UpdatedAt: tOld,
 		TxID:      txID,
@@ -137,7 +137,7 @@ func TestBRC40Guard_KnownTx_HappyUpdate(t *testing.T) {
 	merkleRoot := "root"
 	blockHash := "hash"
 	var blockHeight uint32 = 10
-	_, err = repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
+	_, _, err = repos.UpsertKnownTxForSync(t.Context(), &entity.KnownTx{
 		CreatedAt:   tOld,
 		UpdatedAt:   tNew,
 		TxID:        txID,

--- a/pkg/internal/storage/repo/syncrepo/sync_knowntx.go
+++ b/pkg/internal/storage/repo/syncrepo/sync_knowntx.go
@@ -83,7 +83,7 @@ func (s *SyncKnownTx) FindKnownTxsForSync(ctx context.Context, userID int, opts 
 	return provenTxReqs, provenTxs, nil
 }
 
-func (s *SyncKnownTx) UpsertKnownTxForSync(ctx context.Context, entity *entity.KnownTx) (isNew bool, err error) {
+func (s *SyncKnownTx) UpsertKnownTxForSync(ctx context.Context, entity *entity.KnownTx) (isNew bool, knownTxNumID uint, err error) {
 	model := models.KnownTx{
 		CreatedAt:           entity.CreatedAt,
 		UpdatedAt:           entity.UpdatedAt,
@@ -102,6 +102,14 @@ func (s *SyncKnownTx) UpsertKnownTxForSync(ctx context.Context, entity *entity.K
 	}
 
 	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Always ensure a numeric_id_lookup entry exists so processSyncChunk can
+		// populate provenTx/provenTxReq idMap (readerID → writerID) for round-trips.
+		numID, numErr := s.saveNumericIDForKnownTx(ctx, tx, entity.TxID)
+		if numErr != nil {
+			return numErr
+		}
+		knownTxNumID = numID
+
 		// BRC-40 stale-chunk guard: only apply UPDATE when incoming is strictly newer.
 		// Equal updated_at must SKIP. TxNote delete/insert side-effects only fire
 		// inside the post-guard branch. See ts-stack EntityProvenTx.mergeExisting and
@@ -157,10 +165,19 @@ func (s *SyncKnownTx) UpsertKnownTxForSync(ctx context.Context, entity *entity.K
 		return nil
 	})
 	if err != nil {
-		return false, fmt.Errorf("transaction failed: %w", err)
+		return false, 0, fmt.Errorf("transaction failed: %w", err)
 	}
 
-	return isNew, nil
+	return isNew, knownTxNumID, nil
+}
+
+func (s *SyncKnownTx) saveNumericIDForKnownTx(ctx context.Context, tx *gorm.DB, txID string) (uint, error) {
+	err := saveNumericIDLookup(ctx, tx, s.tableName(), txID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to save numeric ID lookup for known tx %q: %w", txID, err)
+	}
+
+	return findNumericIDLookup(ctx, tx, s.tableName(), txID)
 }
 
 func (s *SyncKnownTx) whereExistsScope(userID int) func(*gorm.DB) *gorm.DB {

--- a/pkg/storage/internal/sync/chunk_processor.go
+++ b/pkg/storage/internal/sync/chunk_processor.go
@@ -213,7 +213,7 @@ func (p *ChunkProcessor) upsertProvenTxReqs(chunkProvenTxReq *wdk.TableProvenTxR
 		return fmt.Errorf("failed to get history notes for TxID %q: %w", chunkProvenTxReq.TxID, err)
 	}
 
-	isNew, err := p.repo.UpsertKnownTxForSync(p.ctx, &pkgentity.KnownTx{
+	isNew, knownTxNumID, err := p.repo.UpsertKnownTxForSync(p.ctx, &pkgentity.KnownTx{
 		CreatedAt:           chunkProvenTxReq.CreatedAt,
 		UpdatedAt:           chunkProvenTxReq.UpdatedAt,
 		TxID:                chunkProvenTxReq.TxID,
@@ -231,7 +231,10 @@ func (p *ChunkProcessor) upsertProvenTxReqs(chunkProvenTxReq *wdk.TableProvenTxR
 	}
 
 	p.incrementOperations(isNew)
-	err = p.updateSyncState(wdk.ProvenTxReqEntityName, chunkProvenTxReq.UpdatedAt)
+	err = p.updateSyncState(wdk.ProvenTxReqEntityName, chunkProvenTxReq.UpdatedAt, idDictionary{
+		readerID: chunkProvenTxReq.ProvenTxReqID,
+		writerID: knownTxNumID,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to update sync state for proven tx req %q: %w", chunkProvenTxReq.TxID, err)
 	}
@@ -266,7 +269,7 @@ func (p *ChunkProcessor) getHistoryNotes(txID, encoded string) ([]*pkgentity.TxH
 func (p *ChunkProcessor) upsertProvenTx(chunkProvenTx *wdk.TableProvenTx) error {
 	p.logger.DebugContext(p.ctx, "upserting proven tx", slog.String("txid", chunkProvenTx.TxID))
 
-	isNew, err := p.repo.UpsertKnownTxForSync(p.ctx, &pkgentity.KnownTx{
+	isNew, knownTxNumID, err := p.repo.UpsertKnownTxForSync(p.ctx, &pkgentity.KnownTx{
 		CreatedAt:   chunkProvenTx.CreatedAt,
 		UpdatedAt:   chunkProvenTx.UpdatedAt,
 		TxID:        chunkProvenTx.TxID,
@@ -282,7 +285,10 @@ func (p *ChunkProcessor) upsertProvenTx(chunkProvenTx *wdk.TableProvenTx) error 
 	}
 
 	p.incrementOperations(isNew)
-	err = p.updateSyncState(wdk.ProvenTxEntityName, chunkProvenTx.UpdatedAt)
+	err = p.updateSyncState(wdk.ProvenTxEntityName, chunkProvenTx.UpdatedAt, idDictionary{
+		readerID: chunkProvenTx.ProvenTxID,
+		writerID: knownTxNumID,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to update sync state for proven tx %q: %w", chunkProvenTx.TxID, err)
 	}

--- a/pkg/storage/internal/sync/repos.interface.go
+++ b/pkg/storage/internal/sync/repos.interface.go
@@ -23,7 +23,7 @@ type Repository interface {
 	FindBasketNameByNumIDForSync(ctx context.Context, basketNumID uint) (string, error)
 
 	FindKnownTxsForSync(ctx context.Context, userID int, opts ...queryopts.Options) ([]*wdk.TableProvenTxReq, []*wdk.TableProvenTx, error)
-	UpsertKnownTxForSync(ctx context.Context, entity *pkgentity.KnownTx) (isNew bool, err error)
+	UpsertKnownTxForSync(ctx context.Context, entity *pkgentity.KnownTx) (isNew bool, knownTxNumID uint, err error)
 
 	FindTransactionsForSync(ctx context.Context, userID int, opts ...queryopts.Options) ([]*wdk.TableTransaction, error)
 	UpsertTransactionForSync(ctx context.Context, entity *pkgentity.Transaction) (isNew bool, transactionID uint, err error)

--- a/pkg/storage/sync_test.go
+++ b/pkg/storage/sync_test.go
@@ -17,6 +17,113 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk/primitives"
 )
 
+// TestProcessSyncChunkPopulatesProvenTxIDMap verifies issue #852:
+// processSyncChunk must populate SyncMap idMap entries for provenTx and provenTxReq
+// so transaction.provenTxId round-trips correctly across storages.
+func TestProcessSyncChunkPopulatesProvenTxIDMap(t *testing.T) {
+	// given:
+	givenSourceDB, cleanup := testabilities.GivenSyncFixture(t)
+	defer cleanup()
+
+	sourceProvider := givenSourceDB.Provider().GORM()
+	sourceStorageManager := givenSourceDB.StorageManagerForUser(testusers.Alice, sourceProvider)
+
+	seed := givenSourceDB.SeedDB(sourceProvider, testusers.Alice)
+	ownedMinedTx := seed.OwnsMinedTransaction()
+	ownedUnminedTx := seed.OwnsTransaction()
+
+	// Capture reader-side numeric IDs from the source storage chunk.
+	sourceArgs := givenSourceDB.RequestSyncChunk(testusers.Alice).Args()
+	sourceChunk, err := sourceProvider.GetSyncChunk(t.Context(), sourceArgs)
+	require.NoError(t, err)
+	require.NotEmpty(t, sourceChunk.ProvenTxs, "expected at least one provenTx (mined)")
+	require.NotEmpty(t, sourceChunk.ProvenTxReqs, "expected at least one provenTxReq (unmined)")
+
+	sourceProvenTxIDs := map[string]int{}
+	for _, pt := range sourceChunk.ProvenTxs {
+		sourceProvenTxIDs[pt.TxID] = pt.ProvenTxID
+	}
+	sourceProvenTxReqIDs := map[string]int{}
+	for _, ptr := range sourceChunk.ProvenTxReqs {
+		sourceProvenTxReqIDs[ptr.TxID] = ptr.ProvenTxReqID
+	}
+	require.Contains(t, sourceProvenTxIDs, ownedMinedTx.ID().String())
+	require.Contains(t, sourceProvenTxReqIDs, ownedUnminedTx.ID().String())
+
+	// and:
+	givenBackupDB, cleanup := testabilities.GivenCustomStorage(t, fixtures.SecondStorageServerPrivKey, fixtures.SecondStorageName)
+	defer cleanup()
+	backupProvider := givenBackupDB.Provider().GORMWithCleanDatabase()
+
+	// when:
+	_, err = sourceStorageManager.MakeAvailable(t.Context())
+	require.NoError(t, err)
+	_, _, err = sourceStorageManager.SyncToWriter(t.Context(), backupProvider)
+	require.NoError(t, err)
+
+	// then: writer-side sync state has populated provenTx / provenTxReq idMaps
+	userOnWriter, err := backupProvider.FindOrInsertUser(t.Context(), testusers.Alice.IdentityKey(t))
+	require.NoError(t, err)
+	writerAuth := wdk.AuthID{
+		IdentityKey: testusers.Alice.IdentityKey(t),
+		UserID:      to.Ptr(userOnWriter.User.UserID),
+	}
+
+	syncStateResp, err := backupProvider.FindOrInsertSyncStateAuth(
+		t.Context(),
+		writerAuth,
+		fixtures.StorageIdentityKey,
+		fixtures.StorageName,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, syncStateResp.SyncState)
+
+	syncMap, err := wdk.NewSyncMapFromJSON([]byte(syncStateResp.SyncState.SyncMap))
+	require.NoError(t, err)
+
+	provenTxEntity := syncMap[wdk.ProvenTxEntityName]
+	require.NotNil(t, provenTxEntity, "provenTx sync map entity must exist")
+	require.NotEmpty(t, provenTxEntity.IDMap, "provenTx idMap must be populated (issue #852)")
+
+	provenTxReqEntity := syncMap[wdk.ProvenTxReqEntityName]
+	require.NotNil(t, provenTxReqEntity, "provenTxReq sync map entity must exist")
+	require.NotEmpty(t, provenTxReqEntity.IDMap, "provenTxReq idMap must be populated (issue #852)")
+
+	// and: every reader-side provenTx / provenTxReq ID is mapped to a positive writer ID
+	for txID, readerID := range sourceProvenTxIDs {
+		writerID, ok := provenTxEntity.IDMap[readerID]
+		require.Truef(t, ok, "provenTx idMap missing readerID %d for tx %s", readerID, txID)
+		require.Positivef(t, writerID, "provenTx writerID for readerID %d must be > 0", readerID)
+	}
+	for txID, readerID := range sourceProvenTxReqIDs {
+		writerID, ok := provenTxReqEntity.IDMap[readerID]
+		require.Truef(t, ok, "provenTxReq idMap missing readerID %d for tx %s", readerID, txID)
+		require.Positivef(t, writerID, "provenTxReq writerID for readerID %d must be > 0", readerID)
+	}
+
+	// and: writer-side GetSyncChunk IDs match the idMap values (full round-trip)
+	backupArgs := fixtures.DefaultRequestSyncChunkArgs(
+		testusers.Alice.IdentityKey(t),
+		fixtures.SecondStorageIdentityKey,
+		fixtures.StorageIdentityKey,
+	)
+	backupChunk, err := backupProvider.GetSyncChunk(t.Context(), backupArgs)
+	require.NoError(t, err)
+
+	for _, pt := range backupChunk.ProvenTxs {
+		readerID, ok := sourceProvenTxIDs[pt.TxID]
+		require.Truef(t, ok, "unexpected provenTx %s on writer", pt.TxID)
+		assert.Equalf(t, pt.ProvenTxID, provenTxEntity.IDMap[readerID],
+			"writer provenTxID for %s should equal idMap[%d]", pt.TxID, readerID)
+	}
+	for _, ptr := range backupChunk.ProvenTxReqs {
+		readerID, ok := sourceProvenTxReqIDs[ptr.TxID]
+		require.Truef(t, ok, "unexpected provenTxReq %s on writer", ptr.TxID)
+		assert.Equalf(t, ptr.ProvenTxReqID, provenTxReqEntity.IDMap[readerID],
+			"writer provenTxReqID for %s should equal idMap[%d]", ptr.TxID, readerID)
+	}
+}
+
 func TestSyncProcess(t *testing.T) {
 	// given:
 	givenSourceDB, cleanup := testabilities.GivenSyncFixture(t)


### PR DESCRIPTION
## Summary
- `upsertProvenTx` / `upsertProvenTxReqs` now pass `idDictionary{readerID, writerID}` into `updateSyncState`, matching transaction/output/label/basket.
- `UpsertKnownTxForSync` returns the `numeric_id_lookup` writer ID so the idMap can be populated even on stale-skip paths.
- Prevents silent corruption of `transaction.provenTxId` on TS↔Go sync round-trips.

Fixes #852

## Test plan
- [x] `go test ./pkg/storage/ -run 'TestProcessSyncChunkPopulatesProvenTxIDMap|TestSyncProcess|TestGetSyncChunk' -count=1`
- [x] `go test ./pkg/internal/storage/repo/syncrepo/ -count=1`
- [x] `go test ./pkg/storage/ -run 'TestSync' -count=1`
- [x] New `TestProcessSyncChunkPopulatesProvenTxIDMap` asserts:
  - writer SyncMap `provenTx.idMap` and `provenTxReq.idMap` are non-empty after `SyncToWriter`
  - every source-side reader ID is mapped to a positive writer ID
  - writer `GetSyncChunk` IDs match the idMap values