### PR TITLE
fix: listOutputs knownTxids BEEF optimization (#821)

### DIFF
--- a/pkg/storage/internal/actions/list_outputs.go
+++ b/pkg/storage/internal/actions/list_outputs.go
@@ -40,9 +40,6 @@ func newListOutputs(logger *slog.Logger, outputsRepo OutputRepo, knownTxRepo Kno
 }
 
 func (l *listOutputs) ListOutputs(ctx context.Context, auth wdk.AuthID, args *wdk.ListOutputsArgs) (*wdk.ListOutputsResult, error) {
-	// TODO: Handle args.KnownTxids
-	// TODO: Handle args.IncludeLabels
-
 	userID := *auth.UserID
 	var err error
 	ctx, span := tracing.StartTracing(ctx, "StorageActions-ListOutputs", attribute.Int("userID", userID))

--- a/pkg/storage/provider_list_outputs_test.go
+++ b/pkg/storage/provider_list_outputs_test.go
@@ -225,7 +225,7 @@ func TestListOutputs_KnownTxids(t *testing.T) {
 	require.Len(t, fullBeef.Transactions, 3)
 
 	// knownTxids = direct input parents of the created tx (same optimization surface as TS)
-	var knownTxids []string
+	knownTxids := make([]string, 0, len(signedTx.Inputs))
 	for _, in := range signedTx.Inputs {
 		require.NotNil(t, in.SourceTXID)
 		knownTxids = append(knownTxids, in.SourceTXID.String())

--- a/pkg/storage/provider_list_outputs_test.go
+++ b/pkg/storage/provider_list_outputs_test.go
@@ -3,6 +3,7 @@ package storage_test
 import (
 	"testing"
 
+	"github.com/bsv-blockchain/go-sdk/transaction"
 	"github.com/go-softwarelab/common/pkg/seq"
 	"github.com/go-softwarelab/common/pkg/to"
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/satoshi"
+	pkgtestabilities "github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/testutils"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/randomizer"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/storage/internal/testabilities"
@@ -196,6 +198,75 @@ func TestListOutputs_IncludeTransactions(t *testing.T) {
 		assert.NotEmpty(t, output.Outpoint)
 		require.NoError(t, output.Outpoint.Validate())
 		assert.NotNil(t, beef.FindTransaction(output.Outpoint.MustGetTxID()))
+	}
+}
+
+// TestListOutputs_KnownTxids verifies that knownTxids optimizes returned BEEF by
+// representing already-known transactions as TxIDOnly (matching TS listOutputs behavior).
+func TestListOutputs_KnownTxids(t *testing.T) {
+	// given:
+	ctx := t.Context()
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+
+	activeStorage := given.Provider().WithRandomizer(randomizer.NewTestRandomizer()).GORM()
+
+	_, signedTx := given.Action(activeStorage).Processed()
+	signedTxID := signedTx.TxID().String()
+
+	// baseline: full BEEF without knownTxids embeds parent + grandparent + created tx
+	fullResult, err := activeStorage.ListOutputs(ctx, testusers.Alice.AuthID(), wdk.ListOutputsArgs{
+		Limit:               100,
+		IncludeTransactions: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, fullResult.BEEF)
+	fullBeef := testutils.BEEFFromBytes(t, fullResult.BEEF)
+	require.Len(t, fullBeef.Transactions, 3)
+
+	// knownTxids = direct input parents of the created tx (same optimization surface as TS)
+	var knownTxids []string
+	for _, in := range signedTx.Inputs {
+		require.NotNil(t, in.SourceTXID)
+		knownTxids = append(knownTxids, in.SourceTXID.String())
+	}
+	require.NotEmpty(t, knownTxids)
+
+	// when: listOutputs with knownTxids
+	result, err := activeStorage.ListOutputs(ctx, testusers.Alice.AuthID(), wdk.ListOutputsArgs{
+		Limit:               100,
+		IncludeTransactions: true,
+		KnownTxids:          knownTxids,
+	})
+
+	// then:
+	require.NoError(t, err)
+	require.NotNil(t, result.BEEF)
+	assert.Less(t, len(result.BEEF), len(fullResult.BEEF),
+		"knownTxids should reduce BEEF payload size by omitting embedded raw txs / proofs")
+
+	optimizedBeef := testutils.BEEFFromBytes(t, result.BEEF)
+
+	// known parents appear as TxIDOnly stubs (mergeTxidOnly), matching TS listOutputs
+	for _, known := range knownTxids {
+		pkgtestabilities.AssertBEEFState(t, result.BEEF, pkgtestabilities.ExpectedBeefTransactionState{
+			ID:         known,
+			DataFormat: to.Ptr(transaction.TxIDOnly),
+		})
+	}
+
+	// further ancestors that were only reachable via known parents are dropped entirely
+	assert.Less(t, len(optimizedBeef.Transactions), len(fullBeef.Transactions),
+		"knownTxids should stop recursion so unused ancestors are excluded from BEEF")
+
+	// the caller's unknown (newly created) tx remains fully embedded (not TxIDOnly)
+	created := optimizedBeef.Transactions
+	require.NotNil(t, optimizedBeef.FindTransaction(signedTxID))
+	for hash, beefTx := range created {
+		if hash.String() == signedTxID {
+			assert.NotEqual(t, transaction.TxIDOnly, beefTx.DataFormat,
+				"created tx must keep full transaction data for the caller")
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Confirmed storage `listOutputs` already passes `args.KnownTxids` into `GetBEEFForTxIDs` via `entity.WithKnownTxIDs`, matching TS `mergeTxidOnly` behavior when `includeTransactions` is true.
- Removed obsolete `TODO: Handle args.KnownTxids` and `TODO: Handle args.IncludeLabels` (both are implemented).
- Added `TestListOutputs_KnownTxids` demonstrating known parents become `TxIDOnly`, ancestor recursion stops, and BEEF payload size shrinks.

## Test plan
- [x] `go test ./pkg/storage/ -run 'TestListOutputs_' -count=1`
- [ ] Reviewer: spot-check BEEF with/without `knownTxids` on a funded wallet

Fixes #821