### PR TITLE
fix: CertificateType/SerialNumber short base64 TS wire compat

### DIFF
--- a/pkg/internal/validate/validate_prove_certificate_args.go
+++ b/pkg/internal/validate/validate_prove_certificate_args.go
@@ -1,7 +1,6 @@
 package validate
 
 import (
-	"encoding/base64"
 	"fmt"
 
 	sdk "github.com/bsv-blockchain/go-sdk/wallet"
@@ -16,14 +15,14 @@ func ProveCertificateArgs(args sdk.ProveCertificateArgs) error {
 	}
 
 	if len(cert.Type) != 0 {
-		str := primitives.Base64String(cert.Type.Base64())
+		str := primitives.Base64String(primitives.EncodeBytes32Base64([32]byte(cert.Type)))
 		if err := str.Validate(); err != nil {
 			return fmt.Errorf("invalid certificate type: base64 encoded validation check: %w", err)
 		}
 	}
 
 	if len(cert.SerialNumber) != 0 {
-		str := primitives.Base64String(base64.StdEncoding.EncodeToString(cert.SerialNumber[:]))
+		str := primitives.Base64String(primitives.EncodeBytes32Base64([32]byte(cert.SerialNumber)))
 		if err := str.Validate(); err != nil {
 			return fmt.Errorf("invalid certificate serial number: base64 encoded validation check: %w", err)
 		}

--- a/pkg/wallet/internal/actions/wallet_acquire_certificate_issuance.go
+++ b/pkg/wallet/internal/actions/wallet_acquire_certificate_issuance.go
@@ -106,8 +106,8 @@ func PrepareIssuanceActionData(ctx context.Context, p PrepareIssuanceActionDataP
 		masterKeyring[to.String(k)] = to.String(v)
 	}
 
-	// Build certificate signing request
-	certTypeB64 := base64.StdEncoding.EncodeToString(p.Args.Type[:])
+	// Build certificate signing request — trim zero-pad so certifiers see the original short type.
+	certTypeB64 := primitives.EncodeBytes32Base64([32]byte(p.Args.Type))
 	body, err := json.Marshal(&walletcerts.ProtocolIssuanceRequest{
 		Type:          certTypeB64,
 		Nonce:         p.Nonce,

--- a/pkg/wallet/internal/mapping/mapping_list_certificates_args.go
+++ b/pkg/wallet/internal/mapping/mapping_list_certificates_args.go
@@ -1,8 +1,6 @@
 package mapping
 
 import (
-	"encoding/base64"
-
 	sdk "github.com/bsv-blockchain/go-sdk/wallet"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk/primitives"
@@ -16,7 +14,8 @@ func MapListCertificatesArgs(args sdk.ListCertificatesArgs) ([]primitives.PubKey
 
 	types := make([]primitives.Base64String, 0, len(args.Types))
 	for _, certType := range args.Types {
-		types = append(types, primitives.Base64String(base64.StdEncoding.EncodeToString(certType[:])))
+		// Trim trailing zero-pad so filter values match TS-ecosystem short base64 types in storage.
+		types = append(types, primitives.Base64String(primitives.EncodeBytes32Base64([32]byte(certType))))
 	}
 
 	return certifiers, types

--- a/pkg/wallet/internal/mapping/mapping_list_certificates_args_test.go
+++ b/pkg/wallet/internal/mapping/mapping_list_certificates_args_test.go
@@ -1,0 +1,36 @@
+package mapping_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/bsv-blockchain/go-sdk/wallet"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/internal/mapping"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk/primitives"
+)
+
+func TestMapListCertificatesArgs_ShortCertificateTypeNoZeroPad(t *testing.T) {
+	t.Parallel()
+
+	// given: TS-style short type ("CommonSource identity") zero-padded into CertificateType
+	const shortB64 = "Q29tbW9uU291cmNlIGlkZW50aXR5"
+	raw, err := base64.StdEncoding.DecodeString(shortB64)
+	require.NoError(t, err)
+
+	var certType wallet.CertificateType
+	copy(certType[:], raw)
+
+	// naive full-array encode produces a different string (the bug)
+	paddedWire := base64.StdEncoding.EncodeToString(certType[:])
+	require.NotEqual(t, shortB64, paddedWire)
+
+	// when:
+	_, types := mapping.MapListCertificatesArgs(wallet.ListCertificatesArgs{
+		Types: []wallet.CertificateType{certType},
+	})
+
+	// then: mapped type matches original short base64 (no zero-pad re-encode corruption)
+	require.Equal(t, []primitives.Base64String{shortB64}, types)
+}

--- a/pkg/wallet/internal/mapping/mapping_relinquish_certificate_args.go
+++ b/pkg/wallet/internal/mapping/mapping_relinquish_certificate_args.go
@@ -1,7 +1,6 @@
 package mapping
 
 import (
-	"encoding/base64"
 	"fmt"
 
 	sdk "github.com/bsv-blockchain/go-sdk/wallet"
@@ -24,8 +23,8 @@ func MapRelinquishRelinquishCertificateArgs(args sdk.RelinquishCertificateArgs) 
 	}
 
 	return wdk.RelinquishCertificateArgs{
-		Type:         primitives.Base64String(base64.StdEncoding.EncodeToString(args.Type[:])),
-		SerialNumber: primitives.Base64String(base64.StdEncoding.EncodeToString(args.SerialNumber[:])),
+		Type:         primitives.Base64String(primitives.EncodeBytes32Base64([32]byte(args.Type))),
+		SerialNumber: primitives.Base64String(primitives.EncodeBytes32Base64([32]byte(args.SerialNumber))),
 		Certifier:    primitives.PubKeyHex(args.Certifier.ToDERHex()),
 	}, nil
 }

--- a/pkg/wallet/internal/mapping/mapping_verifiable_certificate.go
+++ b/pkg/wallet/internal/mapping/mapping_verifiable_certificate.go
@@ -1,39 +1,26 @@
 package mapping
 
 import (
-	"encoding/base64"
 	"fmt"
 
 	"github.com/bsv-blockchain/go-sdk/auth/certificates"
 	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
 	"github.com/bsv-blockchain/go-sdk/wallet"
 	"github.com/go-softwarelab/common/pkg/to"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk/primitives"
 )
 
 func MapVerifiableCertificateToCertificate(cert certificates.VerifiableCertificate) (wallet.Certificate, error) {
-	serialBytes, err := base64.StdEncoding.DecodeString(string(cert.SerialNumber))
+	serial, err := primitives.DecodeBytes32Base64(string(cert.SerialNumber))
 	if err != nil {
 		return wallet.Certificate{}, fmt.Errorf("failed to decode certificate serial number: %w", err)
 	}
 
-	var serial wallet.SerialNumber
-	if len(serialBytes) != len(serial) {
-		return wallet.Certificate{}, fmt.Errorf("serial bytes length: %d is not equal to wallet.SerialNumber bytes length: %d", len(serialBytes), len(serial))
-	}
-
-	copy(serial[:], serialBytes)
-
-	certTypeBytes, err := base64.StdEncoding.DecodeString(string(cert.Type))
+	certType, err := primitives.DecodeBytes32Base64(string(cert.Type))
 	if err != nil {
 		return wallet.Certificate{}, fmt.Errorf("failed to decode certificate type: %w", err)
 	}
-
-	var certType wallet.CertificateType
-	if len(certType) != len(certTypeBytes) {
-		return wallet.Certificate{}, fmt.Errorf("certificate type bytes length: %d is not equal to wallet.CertificateType bytes length: %d", len(certTypeBytes), len(certType))
-	}
-
-	copy(certType[:], certTypeBytes)
 
 	fields := make(map[string]string, len(cert.Fields))
 	for k, v := range cert.Fields {
@@ -46,8 +33,8 @@ func MapVerifiableCertificateToCertificate(cert certificates.VerifiableCertifica
 	}
 
 	return wallet.Certificate{
-		Type:               certType,
-		SerialNumber:       serial,
+		Type:               wallet.CertificateType(certType),
+		SerialNumber:       wallet.SerialNumber(serial),
 		Subject:            to.Ptr(cert.Subject),
 		Certifier:          to.Ptr(cert.Certifier),
 		RevocationOutpoint: cert.RevocationOutpoint,

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -892,12 +892,12 @@ func (w *Wallet) acquireDirectCertificate(ctx context.Context, args sdk.AcquireC
 		verifier = args.KeyringRevealer.PubKey.ToDERHex()
 	}
 
-	// Insert certificate into storage
+	// Insert certificate into storage (trim zero-pad on wire so short TS types round-trip)
 	_, err = w.storage.InsertCertificateAuth(ctx, &wdk.TableCertificateX{
 		TableCertificate: wdk.TableCertificate{
 			UserID:             to.Value(auth.UserID),
-			Type:               primitives.Base64String(base64.StdEncoding.EncodeToString(args.Type[:])),
-			SerialNumber:       primitives.Base64String(base64.StdEncoding.EncodeToString(args.SerialNumber[:])),
+			Type:               primitives.Base64String(primitives.EncodeBytes32Base64([32]byte(args.Type))),
+			SerialNumber:       primitives.Base64String(primitives.EncodeBytes32Base64([32]byte(to.Value(args.SerialNumber)))),
 			Certifier:          primitives.PubKeyHex(args.Certifier.ToDERHex()),
 			Subject:            primitives.PubKeyHex(key.PublicKey.ToDERHex()),
 			RevocationOutpoint: primitives.OutpointString(args.RevocationOutpoint.String()),
@@ -1000,7 +1000,7 @@ func (w *Wallet) ProveCertificate(ctx context.Context, args sdk.ProveCertificate
 	sHex := fmt.Sprintf("%064x", cert.Signature.S)
 	sigHex := rHex + sHex
 
-	serialNumber := base64.StdEncoding.EncodeToString(cert.SerialNumber[:])
+	serialNumber := primitives.EncodeBytes32Base64([32]byte(cert.SerialNumber))
 
 	// Fetch certificate from storage
 	listCertificatesResult, err := w.storage.ListCertificates(ctx, wdk.ListCertificatesArgs{
@@ -1041,7 +1041,7 @@ func (w *Wallet) ProveCertificate(ctx context.Context, args sdk.ProveCertificate
 	certificateFields := certificateFieldsResult.CertificateFields
 	masterKeyring := certificateFieldsResult.MasterKeyring
 	verifier := sdk.Counterparty{Type: sdk.CounterpartyTypeOther, Counterparty: args.Verifier}
-	serial := sdk.StringBase64(base64.StdEncoding.EncodeToString(args.Certificate.SerialNumber[:]))
+	serial := sdk.StringBase64(primitives.EncodeBytes32Base64([32]byte(args.Certificate.SerialNumber)))
 
 	// Validate certificate field names
 	fieldNames, err := mapping.MapToCertificateFieldNameUnder50BytesSlice(certificateFields)

--- a/pkg/wallet/wallet_list_certificates_short_type_test.go
+++ b/pkg/wallet/wallet_list_certificates_short_type_test.go
@@ -1,0 +1,73 @@
+package wallet_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/bsv-blockchain/go-sdk/wallet"
+	"github.com/go-softwarelab/common/pkg/to"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures"
+	certs_testabilities "github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/internal/testabilities"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk/primitives"
+)
+
+// Regression for #769: short certificate types from the TS ecosystem must round-trip
+// through acquire → storage → list without zero-pad re-encode corruption.
+func (s *WalletTestSuite) Test_ListCertificates_ShortCertificateTypeRoundTrip() {
+	t := s.T()
+
+	// given:
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+
+	aliceWallet := given.AliceWalletWithStorage(s.StorageType)
+
+	const shortTypeB64 = "Q29tbW9uU291cmNlIGlkZW50aXR5" // "CommonSource identity" (21 bytes)
+	rawType, err := base64.StdEncoding.DecodeString(shortTypeB64)
+	require.NoError(t, err)
+	require.Len(t, rawType, 21)
+
+	var shortType wallet.CertificateType
+	copy(shortType[:], rawType)
+
+	args := certs_testabilities.CreateSampleAcquireCertificateArgs(t)
+	args.Type = shortType
+
+	// when: acquire stores the cert (must use trimmed base64, not 32-byte pad)
+	cert, err := aliceWallet.AcquireCertificate(t.Context(), args, fixtures.DefaultOriginator)
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+	require.Equal(t, shortType, cert.Type)
+
+	// and: list by the short (zero-padded in [32]byte) type
+	listResult, err := aliceWallet.ListCertificates(t.Context(), wallet.ListCertificatesArgs{
+		Types: []wallet.CertificateType{shortType},
+		Limit: to.Ptr(uint32(10)),
+	}, fixtures.DefaultOriginator)
+
+	// then:
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), listResult.TotalCertificates)
+	require.Len(t, listResult.Certificates, 1)
+	require.Equal(t, shortType, listResult.Certificates[0].Type)
+	// wire form after encode must still be the original short base64
+	require.Equal(t, shortTypeB64, primitives.EncodeBytes32Base64([32]byte(listResult.Certificates[0].Type)))
+}
+
+func TestShortCertificateType_WireForm(t *testing.T) {
+	t.Parallel()
+
+	const shortTypeB64 = "Q29tbW9uU291cmNlIGlkZW50aXR5"
+	rawType, err := base64.StdEncoding.DecodeString(shortTypeB64)
+	require.NoError(t, err)
+
+	var shortType wallet.CertificateType
+	copy(shortType[:], rawType)
+
+	// go-sdk CertificateType.Base64() still pads — toolbox helper must not.
+	require.NotEqual(t, shortTypeB64, shortType.Base64())
+	require.Equal(t, shortTypeB64, primitives.EncodeBytes32Base64([32]byte(shortType)))
+}

--- a/pkg/wdk/certificate.go
+++ b/pkg/wdk/certificate.go
@@ -1,7 +1,6 @@
 package wdk
 
 import (
-	"encoding/base64"
 	"fmt"
 
 	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
@@ -208,37 +207,21 @@ func parseSignature(s primitives.HexString) (*ec.Signature, error) {
 }
 
 // parseSerialNumber decodes a base64-encoded string into an sdk.SerialNumber.
-// Returns the decoded SerialNumber, or an error if decoding fails.
+// Accepts decoded lengths ≤ 32 (zero-padded), matching the TS SDK Base64String wire format.
 func parseSerialNumber(s string) (sdk.SerialNumber, error) {
-	serialBytes, err := base64.StdEncoding.DecodeString(s)
+	serial, err := primitives.DecodeBytes32Base64(s)
 	if err != nil {
 		return sdk.SerialNumber{}, fmt.Errorf("failed to decode certificate serial number: %w", err)
 	}
-
-	var serial sdk.SerialNumber
-	if len(serialBytes) != len(serial) {
-		return sdk.SerialNumber{}, fmt.Errorf("serial bytes length: %d is not equal to sdk.SerialNumber bytes length: %d", len(serialBytes), len(serial))
-	}
-
-	copy(serial[:], serialBytes)
-
-	return serial, nil
+	return sdk.SerialNumber(serial), nil
 }
 
 // parseCertificationType decodes a base64-encoded string into an sdk.CertificateType.
-// Returns the decoded CertificateType, or an error if decoding fails.
+// Accepts decoded lengths ≤ 32 (zero-padded), matching the TS SDK Base64String wire format.
 func parseCertificationType(s string) (sdk.CertificateType, error) {
-	certBytes, err := base64.StdEncoding.DecodeString(s)
+	certType, err := primitives.DecodeBytes32Base64(s)
 	if err != nil {
 		return sdk.CertificateType{}, fmt.Errorf("failed to decode certificate type: %w", err)
 	}
-
-	var certType sdk.CertificateType
-	if len(certType) != len(certBytes) {
-		return sdk.CertificateType{}, fmt.Errorf("certificate type bytes length: %d is not equal to sdk.CertificateType bytes length: %d", len(certBytes), len(certType))
-	}
-
-	copy(certType[:], certBytes)
-
-	return certType, nil
+	return sdk.CertificateType(certType), nil
 }

--- a/pkg/wdk/primitives/bytes32_base64.go
+++ b/pkg/wdk/primitives/bytes32_base64.go
@@ -1,0 +1,42 @@
+package primitives
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+)
+
+// EncodeBytes32Base64 encodes a fixed [32]byte value as standard base64 for wire/storage use.
+//
+// Trailing 0x00 padding bytes are trimmed before encoding so the result matches TypeScript SDK
+// Base64String certificate types/serials that may be shorter than 32 decoded bytes
+// (e.g. "CommonSource identity" → "Q29tbW9uU291cmNlIGlkZW50aXR5").
+//
+// If the array is all zeros, the full 32 zero bytes are encoded (avoids empty base64).
+func EncodeBytes32Base64(b [32]byte) string {
+	trimmed := bytes.TrimRight(b[:], "\x00")
+	if len(trimmed) == 0 {
+		trimmed = b[:]
+	}
+	return base64.StdEncoding.EncodeToString(trimmed)
+}
+
+// DecodeBytes32Base64 decodes a standard base64 string into a fixed [32]byte value.
+//
+// Decoded lengths from 0 through 32 are accepted; shorter values are zero-padded on the right
+// (matching CertificateTypeFromBase64 / StringBase64.ToArray semantics in go-sdk). Lengths
+// greater than 32 are rejected.
+func DecodeBytes32Base64(s string) ([32]byte, error) {
+	var out [32]byte
+
+	decoded, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return out, fmt.Errorf("invalid base64: %w", err)
+	}
+	if len(decoded) > len(out) {
+		return out, fmt.Errorf("decoded length %d exceeds 32 bytes", len(decoded))
+	}
+
+	copy(out[:], decoded)
+	return out, nil
+}

--- a/pkg/wdk/primitives/bytes32_base64_test.go
+++ b/pkg/wdk/primitives/bytes32_base64_test.go
@@ -1,0 +1,138 @@
+package primitives_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk/primitives"
+)
+
+// TS-ecosystem short cert type: base64("CommonSource identity") = 21 bytes decoded.
+const commonSourceIdentityB64 = "Q29tbW9uU291cmNlIGlkZW50aXR5"
+
+func TestEncodeBytes32Base64_TrimsTrailingZeros(t *testing.T) {
+	t.Parallel()
+
+	// given: 21-byte type zero-padded into [32]byte (as CertificateType does)
+	decoded, err := base64.StdEncoding.DecodeString(commonSourceIdentityB64)
+	require.NoError(t, err)
+	require.Len(t, decoded, 21)
+
+	var padded [32]byte
+	copy(padded[:], decoded)
+
+	// when:
+	got := primitives.EncodeBytes32Base64(padded)
+
+	// then: must match original short base64, not the zero-padded re-encode
+	require.Equal(t, commonSourceIdentityB64, got)
+
+	paddedB64 := base64.StdEncoding.EncodeToString(padded[:])
+	require.NotEqual(t, paddedB64, got, "naive EncodeToString of [32]byte must not equal trimmed form")
+	require.Equal(t, "Q29tbW9uU291cmNlIGlkZW50aXR5AAAAAAAAAAAAAAA=", paddedB64)
+}
+
+func TestDecodeBytes32Base64_AcceptsShortBase64(t *testing.T) {
+	t.Parallel()
+
+	// when:
+	got, err := primitives.DecodeBytes32Base64(commonSourceIdentityB64)
+
+	// then:
+	require.NoError(t, err)
+	require.Equal(t, []byte("CommonSource identity"), bytes.TrimRight(got[:], "\x00"))
+	require.Equal(t, byte(0), got[21])
+	require.Equal(t, byte(0), got[31])
+}
+
+func TestBytes32Base64_ShortRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// when: short base64 → [32]byte → short base64
+	arr, err := primitives.DecodeBytes32Base64(commonSourceIdentityB64)
+	require.NoError(t, err)
+	got := primitives.EncodeBytes32Base64(arr)
+
+	// then: no zero-pad re-encode corruption
+	require.Equal(t, commonSourceIdentityB64, got)
+}
+
+func TestBytes32Base64_Full32RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var full [32]byte
+	for i := range full {
+		full[i] = byte(i + 1) // no trailing zeros
+	}
+	encoded := primitives.EncodeBytes32Base64(full)
+	decoded, err := primitives.DecodeBytes32Base64(encoded)
+	require.NoError(t, err)
+	require.Equal(t, full, decoded)
+	require.Equal(t, base64.StdEncoding.EncodeToString(full[:]), encoded)
+}
+
+func TestDecodeBytes32Base64_RejectsTooLong(t *testing.T) {
+	t.Parallel()
+
+	tooLong := base64.StdEncoding.EncodeToString(make([]byte, 33))
+	_, err := primitives.DecodeBytes32Base64(tooLong)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds 32")
+}
+
+func TestDecodeBytes32Base64_RejectsInvalidBase64(t *testing.T) {
+	t.Parallel()
+
+	_, err := primitives.DecodeBytes32Base64("not!valid")
+	require.Error(t, err)
+}
+
+func TestEncodeBytes32Base64_AllZerosEncodesFullArray(t *testing.T) {
+	t.Parallel()
+
+	var zeros [32]byte
+	got := primitives.EncodeBytes32Base64(zeros)
+	require.Equal(t, base64.StdEncoding.EncodeToString(zeros[:]), got)
+	require.NotEmpty(t, got)
+}
+
+func TestWalletCertificate_ToSDKCertificate_AcceptsShortTypeAndSerial(t *testing.T) {
+	t.Parallel()
+
+	// Storage layer may hold TS-ecosystem short base64 (fixtures use short forms too).
+	shortSerial := "c2VyaWFsMTIz" // "serial123"
+	cert := wdk.WalletCertificate{
+		Type:               primitives.Base64String(commonSourceIdentityB64),
+		SerialNumber:       primitives.Base64String(shortSerial),
+		Subject:            "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+		Certifier:          "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+		RevocationOutpoint: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890.0",
+		// 64-byte signature as 128 hex chars
+		Signature: primitives.HexString(
+			"abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" +
+				"abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+		),
+	}
+
+	sdkCert, err := cert.ToSDKCertificate()
+	require.NoError(t, err)
+	require.Equal(t, commonSourceIdentityB64, primitives.EncodeBytes32Base64([32]byte(sdkCert.Type)))
+	require.Equal(t, shortSerial, primitives.EncodeBytes32Base64([32]byte(sdkCert.SerialNumber)))
+}
+
+func TestListCertificatesArgs_JSON_AcceptsShortTypesAsBase64String(t *testing.T) {
+	t.Parallel()
+
+	// wdk storage args use opaque Base64String (not Bytes32Base64), so short types must work.
+	raw := []byte(`{"certifiers":[],"types":["Q29tbW9uU291cmNlIGlkZW50aXR5"],"limit":100}`)
+	var args wdk.ListCertificatesArgs
+	require.NoError(t, json.Unmarshal(raw, &args))
+	require.Len(t, args.Types, 1)
+	require.Equal(t, primitives.Base64String(commonSourceIdentityB64), args.Types[0])
+	require.NoError(t, args.Types[0].Validate())
+}


### PR DESCRIPTION
## Summary
- Fixes zero-pad re-encode of `CertificateType` / `SerialNumber` when mapping `[32]byte` ↔ base64 for storage, list filters, relinquish, prove, and certifier issuance requests.
- Accepts short base64 (≤32 decoded bytes) when parsing stored/wire values into fixed arrays, matching TS SDK `Base64String` and go-sdk `CertificateTypeFromBase64`.
- Adds `primitives.EncodeBytes32Base64` / `DecodeBytes32Base64` helpers used at all affected call sites.

Fixes #769

## Context
TS clients send short types like `Q29tbW9uU291cmNlIGlkZW50aXR5` (`"CommonSource identity"`, 21 bytes). Re-encoding the zero-padded `[32]byte` produced a different string (`…AAAAAAAAAAAAAAA=`), which remote certifiers and storage filters rejected.

## Test plan
- [x] `go test ./pkg/wdk/primitives/ ./pkg/wdk/ ./pkg/wallet/internal/mapping/ ./pkg/internal/validate/`
- [x] `go test ./pkg/wallet/ -run 'Certificate|ShortCertificate'`
- [x] `go test ./pkg/storage/ -run 'Certificate|Cert'`
- [ ] CI green

## Notes / residual risk
- Upstream go-sdk `Bytes32Base64.UnmarshalJSON` still requires exactly 32 decoded bytes. Callers that JSON-unmarshal directly into `sdk.ListCertificatesArgs` / `CertificateType` still hit that boundary; toolbox storage APIs already use opaque `primitives.Base64String`.
- BRC-104 HMAC nonce incompatibility with TS certifiers (called out in the issue) is separate and not addressed here.