### PR TITLE
fix: listActions BRC-114 action time label filtering

### DIFF
--- a/pkg/internal/brc114/action_time_labels.go
+++ b/pkg/internal/brc114/action_time_labels.go
@@ -1,0 +1,121 @@
+// Package brc114 implements BRC-114 action time label helpers used by listActions.
+//
+// Time control labels embedded in the labels query parameter:
+//   - "action time from <unix-ms>" — inclusive lower bound on action created_at
+//   - "action time to <unix-ms>"   — exclusive upper bound on action created_at
+//
+// When a time filter is active and includeLabels is true, responses may also
+// contain computed labels of the form "action time <unix-ms>" for each action.
+package brc114
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// ActionTimeFromPrefix is the BRC-114 inclusive lower-bound control label prefix.
+	ActionTimeFromPrefix = "action time from "
+	// ActionTimeToPrefix is the BRC-114 exclusive upper-bound control label prefix.
+	ActionTimeToPrefix = "action time to "
+	// ActionTimeLabelPrefix is the prefix of computed action-time response labels.
+	ActionTimeLabelPrefix = "action time "
+
+	// maxSafeInteger is JavaScript Number.MAX_SAFE_INTEGER (2^53 - 1).
+	// Timestamps above this are rejected for TS parity.
+	maxSafeInteger = 9007199254740991
+)
+
+// ParsedActionTimeLabels holds the result of stripping BRC-114 time control labels.
+type ParsedActionTimeLabels struct {
+	// From is the inclusive lower bound in unix milliseconds, if present.
+	From *int64
+	// To is the exclusive upper bound in unix milliseconds, if present.
+	To *int64
+	// TimeFilterRequested is true when at least one time control label was present.
+	TimeFilterRequested bool
+	// RemainingLabels are the original labels with time control labels removed.
+	RemainingLabels []string
+}
+
+// ParseActionTimeLabels extracts BRC-114 time control labels from a labels list.
+// Time control labels are removed from RemainingLabels so they are not treated as
+// ordinary DB label filters. Invalid control labels return an error.
+func ParseActionTimeLabels(labels []string) (ParsedActionTimeLabels, error) {
+	var from, to *int64
+	remaining := make([]string, 0, len(labels))
+	timeFilterRequested := false
+
+	for _, label := range labels {
+		if strings.HasPrefix(label, ActionTimeFromPrefix) {
+			timeFilterRequested = true
+			if from != nil {
+				return ParsedActionTimeLabels{}, fmt.Errorf("labels: valid. Duplicate action time from label")
+			}
+			n, err := parseUnixMillis(label[len(ActionTimeFromPrefix):], "from")
+			if err != nil {
+				return ParsedActionTimeLabels{}, err
+			}
+			from = &n
+			continue
+		}
+
+		if strings.HasPrefix(label, ActionTimeToPrefix) {
+			timeFilterRequested = true
+			if to != nil {
+				return ParsedActionTimeLabels{}, fmt.Errorf("labels: valid. Duplicate action time to label")
+			}
+			n, err := parseUnixMillis(label[len(ActionTimeToPrefix):], "to")
+			if err != nil {
+				return ParsedActionTimeLabels{}, err
+			}
+			to = &n
+			continue
+		}
+
+		remaining = append(remaining, label)
+	}
+
+	if from != nil && to != nil && *from >= *to {
+		return ParsedActionTimeLabels{}, fmt.Errorf("labels: valid. action time from must be less than action time to")
+	}
+
+	return ParsedActionTimeLabels{
+		From:                from,
+		To:                  to,
+		TimeFilterRequested: timeFilterRequested,
+		RemainingLabels:     remaining,
+	}, nil
+}
+
+// MakeActionTimeLabel builds the computed response label for an action's creation time.
+func MakeActionTimeLabel(unixMillis int64) string {
+	return fmt.Sprintf("%s%d", ActionTimeLabelPrefix, unixMillis)
+}
+
+// FromMillis converts a unix-millisecond timestamp to a time.Time in UTC.
+func FromMillis(unixMillis int64) time.Time {
+	return time.UnixMilli(unixMillis).UTC()
+}
+
+func parseUnixMillis(v, kind string) (int64, error) {
+	if v == "" || !isAllDigits(v) {
+		return 0, fmt.Errorf("labels: valid. Invalid action time %s timestamp value", kind)
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || n < 0 || n > maxSafeInteger {
+		return 0, fmt.Errorf("labels: valid. Invalid action time %s timestamp value", kind)
+	}
+	return n, nil
+}
+
+func isAllDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/internal/brc114/action_time_labels_test.go
+++ b/pkg/internal/brc114/action_time_labels_test.go
@@ -1,0 +1,72 @@
+package brc114_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/brc114"
+)
+
+func TestParseActionTimeLabels_NoTimeLabels(t *testing.T) {
+	parsed, err := brc114.ParseActionTimeLabels([]string{"foo", "bar"})
+	require.NoError(t, err)
+	assert.False(t, parsed.TimeFilterRequested)
+	assert.Nil(t, parsed.From)
+	assert.Nil(t, parsed.To)
+	assert.Equal(t, []string{"foo", "bar"}, parsed.RemainingLabels)
+}
+
+func TestParseActionTimeLabels_FromAndTo(t *testing.T) {
+	parsed, err := brc114.ParseActionTimeLabels([]string{
+		"run-label",
+		"action time from 1704067200000",
+		"action time to 1704067202000",
+		"other",
+	})
+	require.NoError(t, err)
+	require.True(t, parsed.TimeFilterRequested)
+	require.NotNil(t, parsed.From)
+	require.NotNil(t, parsed.To)
+	assert.Equal(t, int64(1704067200000), *parsed.From)
+	assert.Equal(t, int64(1704067202000), *parsed.To)
+	assert.Equal(t, []string{"run-label", "other"}, parsed.RemainingLabels)
+}
+
+func TestParseActionTimeLabels_FromOnly(t *testing.T) {
+	parsed, err := brc114.ParseActionTimeLabels([]string{"action time from 0"})
+	require.NoError(t, err)
+	require.True(t, parsed.TimeFilterRequested)
+	require.NotNil(t, parsed.From)
+	assert.Equal(t, int64(0), *parsed.From)
+	assert.Nil(t, parsed.To)
+	assert.Empty(t, parsed.RemainingLabels)
+}
+
+func TestParseActionTimeLabels_Invalid(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels []string
+	}{
+		{"duplicate from", []string{"action time from 0", "action time from 1"}},
+		{"duplicate to", []string{"action time to 1", "action time to 2"}},
+		{"from >= to", []string{"action time from 2", "action time to 1"}},
+		{"from == to", []string{"action time from 5", "action time to 5"}},
+		{"non-numeric from", []string{"action time from abc"}},
+		{"negative to", []string{"action time to -1"}},
+		{"too large", []string{"action time from 9999999999999999999999999"}},
+		{"trailing junk", []string{"action time from 123abc"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := brc114.ParseActionTimeLabels(tc.labels)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestMakeActionTimeLabel(t *testing.T) {
+	assert.Equal(t, "action time 1704067200000", brc114.MakeActionTimeLabel(1704067200000))
+}

--- a/pkg/internal/storage/entity/list_actions_model.go
+++ b/pkg/internal/storage/entity/list_actions_model.go
@@ -1,6 +1,8 @@
 package entity
 
 import (
+	"time"
+
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 )
@@ -12,4 +14,10 @@ type ListActionsFilter struct {
 	Status         []wdk.TxStatus
 	Limit          int
 	Offset         int
+
+	// BRC-114 action time filters (parsed from control labels).
+	// CreatedAtFrom is inclusive; CreatedAtTo is exclusive.
+	TimeFilterRequested bool
+	CreatedAtFrom       *time.Time
+	CreatedAtTo         *time.Time
 }

--- a/pkg/internal/storage/repo/outputs.go
+++ b/pkg/internal/storage/repo/outputs.go
@@ -478,6 +478,15 @@ func (o *Outputs) selectedActionsSubquery(tx *gorm.DB, userID int, filter entity
 		}
 		selected = selected.Where("id IN (?)", subQuery)
 	}
+	if filter.TimeFilterRequested {
+		selected = selected.Where("created_at IS NOT NULL")
+		if filter.CreatedAtFrom != nil {
+			selected = selected.Where("created_at >= ?", *filter.CreatedAtFrom)
+		}
+		if filter.CreatedAtTo != nil {
+			selected = selected.Where("created_at < ?", *filter.CreatedAtTo)
+		}
+	}
 	return selected.Order("id ASC").Limit(filter.Limit).Offset(filter.Offset)
 }
 

--- a/pkg/internal/storage/repo/transactions.go
+++ b/pkg/internal/storage/repo/transactions.go
@@ -539,6 +539,8 @@ func (txs *Transactions) ListAndCountActions(ctx context.Context, userID int, fi
 			query = query.Scopes(txs.labelFilterScope(tx, userID, filter))
 		}
 
+		query = applyListActionsTimeFilters(query, filter)
+
 		if err = query.Count(&total).Error; err != nil {
 			return fmt.Errorf("count failed: %w", err)
 		}
@@ -579,7 +581,25 @@ func (txs *Transactions) buildSelectedActionsSubQuery(tx *gorm.DB, userID int, f
 		query = query.Scopes(txs.labelFilterScope(tx, userID, filter))
 	}
 
+	query = applyListActionsTimeFilters(query, filter)
+
 	return query.Order("id ASC").Limit(filter.Limit).Offset(filter.Offset)
+}
+
+// applyListActionsTimeFilters applies BRC-114 created_at range filters.
+// from is inclusive; to is exclusive — matching the TypeScript implementation.
+func applyListActionsTimeFilters(query *gorm.DB, filter entity.ListActionsFilter) *gorm.DB {
+	if !filter.TimeFilterRequested {
+		return query
+	}
+	query = query.Where("created_at IS NOT NULL")
+	if filter.CreatedAtFrom != nil {
+		query = query.Where("created_at >= ?", *filter.CreatedAtFrom)
+	}
+	if filter.CreatedAtTo != nil {
+		query = query.Where("created_at < ?", *filter.CreatedAtTo)
+	}
+	return query
 }
 
 // GetLabelsForSelectedActions fetches labels via JOIN with the selected actions subquery to avoid IN lists.

--- a/pkg/internal/validate/validate_list_actions_args.go
+++ b/pkg/internal/validate/validate_list_actions_args.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"fmt"
 
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/brc114"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk/primitives"
 )
@@ -23,10 +24,17 @@ func ListActionsArgs(args *wdk.ListActionsArgs) error {
 		return fmt.Errorf("offset must be less than or equal to %d", MaxPaginationOffset)
 	}
 
-	for _, label := range args.Labels {
+	labelNames := make([]string, len(args.Labels))
+	for i, label := range args.Labels {
 		if err := validateLabel(label); err != nil {
 			return fmt.Errorf("invalid label: %w", err)
 		}
+		labelNames[i] = string(label)
+	}
+
+	// BRC-114 time control labels are validated (and later stripped) for TS parity.
+	if _, err := brc114.ParseActionTimeLabels(labelNames); err != nil {
+		return err
 	}
 
 	if !args.SeekPermission.Value() {

--- a/pkg/internal/validate/validate_list_actions_args_test.go
+++ b/pkg/internal/validate/validate_list_actions_args_test.go
@@ -39,6 +39,16 @@ func TestListActionsArgs(t *testing.T) {
 				SeekPermission: to.Ptr(primitives.BooleanDefaultTrue(true)),
 			},
 		},
+		"valid BRC-114 time labels": {
+			args: &wdk.ListActionsArgs{
+				Labels: []primitives.StringUnder300{
+					"run",
+					"action time from 1704067200000",
+					"action time to 1704067202000",
+				},
+				SeekPermission: to.Ptr(primitives.BooleanDefaultTrue(true)),
+			},
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -88,6 +98,21 @@ func TestWrongListActionsArgs(t *testing.T) {
 		"inconsistent includeOutputLockingScripts with no includeOutputs": {
 			args: &wdk.ListActionsArgs{
 				IncludeOutputLockingScripts: to.Ptr(primitives.BooleanDefaultFalse(true)),
+			},
+		},
+		"duplicate BRC-114 action time from": {
+			args: &wdk.ListActionsArgs{
+				Labels: []primitives.StringUnder300{"action time from 0", "action time from 1"},
+			},
+		},
+		"BRC-114 from >= to": {
+			args: &wdk.ListActionsArgs{
+				Labels: []primitives.StringUnder300{"action time from 2", "action time to 1"},
+			},
+		},
+		"invalid BRC-114 timestamp": {
+			args: &wdk.ListActionsArgs{
+				Labels: []primitives.StringUnder300{"action time from abc"},
 			},
 		},
 	}

--- a/pkg/storage/internal/actions/list_actions.go
+++ b/pkg/storage/internal/actions/list_actions.go
@@ -82,7 +82,7 @@ func (l *listActions) ListActions(ctx context.Context, auth wdk.AuthID, args *wd
 		return nil, fmt.Errorf("failed to load raw transactions: %w", err)
 	}
 
-	if err := l.mapInputsOutputsLabels(actions, txs, inputMap, outputMap, labelMap, rawTxMap, args); err != nil {
+	if err := l.mapInputsOutputsLabels(actions, txs, inputMap, outputMap, labelMap, rawTxMap, args, filter.TimeFilterRequested); err != nil {
 		return nil, fmt.Errorf("failed to map inputs/outputs/labels: %w", err)
 	}
 

--- a/pkg/storage/internal/actions/list_actions_mapping.go
+++ b/pkg/storage/internal/actions/list_actions_mapping.go
@@ -12,19 +12,26 @@ import (
 	commonslices "github.com/go-softwarelab/common/pkg/slices"
 
 	pkgentity "github.com/bsv-blockchain/go-wallet-toolbox/pkg/entity"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/brc114"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/entity"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk/primitives"
 )
 
-func (l *listActions) toFilterParams(userID int, args *wdk.ListActionsArgs) (entity.ListActionsFilter, error) { //nolint:unparam // error return reserved for future validation
+func (l *listActions) toFilterParams(userID int, args *wdk.ListActionsArgs) (entity.ListActionsFilter, error) {
 	labelNames := commonslices.Map(args.Labels, func(label primitives.StringUnder300) string {
 		return string(label)
 	})
 
+	// BRC-114: strip time-control labels and capture created_at range filters.
+	parsed, err := brc114.ParseActionTimeLabels(labelNames)
+	if err != nil {
+		return entity.ListActionsFilter{}, fmt.Errorf("invalid BRC-114 action time labels: %w", err)
+	}
+
 	isFailedQuery := false
-	filteredLabels := make([]string, 0, len(labelNames))
-	for _, label := range labelNames {
+	filteredLabels := make([]string, 0, len(parsed.RemainingLabels))
+	for _, label := range parsed.RemainingLabels {
 		if label == string(wdk.TxStatusUnfail) {
 			isFailedQuery = true
 			continue
@@ -41,14 +48,26 @@ func (l *listActions) toFilterParams(userID int, args *wdk.ListActionsArgs) (ent
 		statuses = []wdk.TxStatus{wdk.TxStatusFailed}
 	}
 
-	return entity.ListActionsFilter{
-		UserID:         userID,
-		Labels:         filteredLabels,
-		Status:         statuses,
-		LabelQueryMode: args.LabelQueryMode.MustGetValue(),
-		Limit:          must.ConvertToIntFromUnsigned(args.Limit),
-		Offset:         must.ConvertToIntFromUnsigned(args.Offset),
-	}, nil
+	filter := entity.ListActionsFilter{
+		UserID:              userID,
+		Labels:              filteredLabels,
+		Status:              statuses,
+		LabelQueryMode:      args.LabelQueryMode.MustGetValue(),
+		Limit:               must.ConvertToIntFromUnsigned(args.Limit),
+		Offset:              must.ConvertToIntFromUnsigned(args.Offset),
+		TimeFilterRequested: parsed.TimeFilterRequested,
+	}
+
+	if parsed.From != nil {
+		t := brc114.FromMillis(*parsed.From)
+		filter.CreatedAtFrom = &t
+	}
+	if parsed.To != nil {
+		t := brc114.FromMillis(*parsed.To)
+		filter.CreatedAtTo = &t
+	}
+
+	return filter, nil
 }
 
 func (l *listActions) mapTransactionsToActions(txs []*pkgentity.Transaction) ([]uint, []string, []wdk.WalletAction) {
@@ -113,12 +132,12 @@ func (l *listActions) loadRawTxsIfNeeded(ctx context.Context, txIDStrs []string,
 	return rawTxMap, nil
 }
 
-func (l *listActions) mapInputsOutputsLabels(actions []wdk.WalletAction, txs []*pkgentity.Transaction, inputMap, outputMap map[uint][]*pkgentity.Output, labelMap map[uint][]string, rawTxMap map[string][]byte, args *wdk.ListActionsArgs) error {
+func (l *listActions) mapInputsOutputsLabels(actions []wdk.WalletAction, txs []*pkgentity.Transaction, inputMap, outputMap map[uint][]*pkgentity.Output, labelMap map[uint][]string, rawTxMap map[string][]byte, args *wdk.ListActionsArgs, timeFilterRequested bool) error {
 	for i, tx := range txs {
 		action := &actions[i]
 
 		if args.IncludeLabels.Value() {
-			l.mapLabelsToAction(action, tx.ID, labelMap)
+			l.mapLabelsToAction(action, tx, labelMap, timeFilterRequested)
 		}
 
 		if args.IncludeOutputs.Value() {
@@ -134,11 +153,19 @@ func (l *listActions) mapInputsOutputsLabels(actions []wdk.WalletAction, txs []*
 	return nil
 }
 
-func (l *listActions) mapLabelsToAction(action *wdk.WalletAction, txID uint, labelMap map[uint][]string) {
-	if labels, ok := labelMap[txID]; ok {
+func (l *listActions) mapLabelsToAction(action *wdk.WalletAction, tx *pkgentity.Transaction, labelMap map[uint][]string, timeFilterRequested bool) {
+	if labels, ok := labelMap[tx.ID]; ok {
 		action.Labels = slices.Clone(labels)
 	} else {
 		action.Labels = []string{}
+	}
+
+	// BRC-114: when time filtering is active, inject computed "action time {ms}" labels.
+	if timeFilterRequested && !tx.CreatedAt.IsZero() {
+		timeLabel := brc114.MakeActionTimeLabel(tx.CreatedAt.UnixMilli())
+		if !slices.Contains(action.Labels, timeLabel) {
+			action.Labels = append(action.Labels, timeLabel)
+		}
 	}
 }
 

--- a/pkg/storage/internal/actions/list_failed_actions.go
+++ b/pkg/storage/internal/actions/list_failed_actions.go
@@ -78,7 +78,7 @@ func (l *listActions) ListFailedActions(ctx context.Context, auth wdk.AuthID, ar
 		IncludeInputSourceLockingScripts: args.IncludeInputSourceLockingScripts,
 		IncludeInputUnlockingScripts:     args.IncludeInputUnlockingScripts,
 	}
-	if err := l.mapInputsOutputsLabels(actions, txs, inputMap, outputMap, labelMap, rawTxMap, mappingArgs); err != nil {
+	if err := l.mapInputsOutputsLabels(actions, txs, inputMap, outputMap, labelMap, rawTxMap, mappingArgs, filter.TimeFilterRequested); err != nil {
 		return nil, fmt.Errorf("failed to map inputs/outputs/labels: %w", err)
 	}
 

--- a/pkg/storage/provider_list_actions_brc114_test.go
+++ b/pkg/storage/provider_list_actions_brc114_test.go
@@ -71,8 +71,8 @@ func TestListActions_BRC114_TimeFilteringAndResponseInjection(t *testing.T) {
 	for i, ts := range times {
 		label := fmt.Sprintf("%s-%c", runLabel, 'a'+i)
 		_, signedTx := given.Action(activeStorage).
-			WithSatoshisToInternalize(uint64(50_000 + i*1_000)).
-			WithSatoshisToSend(uint64(1_000 + i)).
+			WithSatoshisToInternalize(uint64(50_000+i*1_000)).
+			WithSatoshisToSend(uint64(1_000+i)).
 			WithLabels(runLabel, label).
 			Processed()
 

--- a/pkg/storage/provider_list_actions_brc114_test.go
+++ b/pkg/storage/provider_list_actions_brc114_test.go
@@ -1,0 +1,291 @@
+package storage_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-softwarelab/common/pkg/to"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/brc114"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/randomizer"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/storage/internal/testabilities"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk/primitives"
+)
+
+func TestListActions_BRC114_InvalidTimeLabels(t *testing.T) {
+	ctx := t.Context()
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+
+	activeStorage := given.Provider().GORM()
+
+	invalid := [][]string{
+		{"action time from 0", "action time from 1"},
+		{"action time to 1", "action time to 2"},
+		{"action time from 2", "action time to 1"},
+		{"action time from abc"},
+		{"action time to -1"},
+		{"action time from 9999999999999999999999999"},
+		{"action time from 123abc"},
+	}
+
+	for _, labels := range invalid {
+		t.Run(fmt.Sprintf("%v", labels), func(t *testing.T) {
+			args := wdk.ListActionsArgs{
+				Labels: primitives.ToStringUnder300Slice(labels),
+				Limit:  10,
+			}
+			_, err := activeStorage.ListActions(ctx, testusers.Alice.AuthID(), args)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestListActions_BRC114_TimeFilteringAndResponseInjection(t *testing.T) {
+	// Given:
+	ctx := t.Context()
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+
+	activeStorage := given.Provider().WithRandomizer(randomizer.NewTestRandomizer()).GORM()
+
+	runLabel := fmt.Sprintf("brc114-%d", time.Now().UnixNano())
+	baseMs := int64(1704067200000) // 2024-01-01T00:00:00.000Z
+	times := []int64{baseMs, baseMs + 1000, baseMs + 2000}
+
+	type inserted struct {
+		txID        string
+		createdAtMs int64
+		label       string
+	}
+	var actions [3]inserted
+
+	for i, ts := range times {
+		label := fmt.Sprintf("%s-%c", runLabel, 'a'+i)
+		_, signedTx := given.Action(activeStorage).
+			WithSatoshisToInternalize(uint64(50_000 + i*1_000)).
+			WithSatoshisToSend(uint64(1_000 + i)).
+			WithLabels(runLabel, label).
+			Processed()
+
+		txID := signedTx.TxID().String()
+		createdAt := time.UnixMilli(ts).UTC()
+		require.NoError(t, activeStorage.Database.DB.Model(&models.Transaction{}).
+			Where("tx_id = ?", txID).
+			Updates(map[string]any{
+				"created_at": createdAt,
+				"updated_at": createdAt,
+			}).Error)
+
+		actions[i] = inserted{
+			txID:        txID,
+			createdAtMs: ts,
+			label:       label,
+		}
+	}
+
+	a, b, c := actions[0], actions[1], actions[2]
+
+	// Baseline without time filter: all three, no computed action-time labels.
+	t.Run("baseline_no_time_filter", func(t *testing.T) {
+		result, err := activeStorage.ListActions(ctx, testusers.Alice.AuthID(), wdk.ListActionsArgs{
+			Labels:        []primitives.StringUnder300{primitives.StringUnder300(runLabel)},
+			IncludeLabels: to.Ptr(primitives.BooleanDefaultFalse(true)),
+			Limit:         100,
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{a.txID, b.txID, c.txID}, actionTxIDs(result))
+		for _, act := range result.Actions {
+			assert.False(t, hasReservedTimeControlLabel(act.Labels))
+			assert.Empty(t, injectedTimeLabels(act.Labels))
+		}
+	})
+
+	// Time filter with includeLabels=false: still filters, but labels omitted.
+	t.Run("from_zero_include_labels_false", func(t *testing.T) {
+		result, err := activeStorage.ListActions(ctx, testusers.Alice.AuthID(), wdk.ListActionsArgs{
+			Labels: []primitives.StringUnder300{
+				primitives.StringUnder300(runLabel),
+				primitives.StringUnder300(brc114.ActionTimeFromPrefix + "0"),
+			},
+			IncludeLabels: to.Ptr(primitives.BooleanDefaultFalse(false)),
+			Limit:         100,
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{a.txID, b.txID, c.txID}, actionTxIDs(result))
+		for _, act := range result.Actions {
+			assert.Empty(t, act.Labels)
+		}
+	})
+
+	// Time filter with includeLabels=true: injects "action time {ms}".
+	t.Run("from_zero_injects_time_labels", func(t *testing.T) {
+		result, err := activeStorage.ListActions(ctx, testusers.Alice.AuthID(), wdk.ListActionsArgs{
+			Labels: []primitives.StringUnder300{
+				primitives.StringUnder300(runLabel),
+				primitives.StringUnder300(brc114.ActionTimeFromPrefix + "0"),
+			},
+			IncludeLabels: to.Ptr(primitives.BooleanDefaultFalse(true)),
+			Limit:         100,
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{a.txID, b.txID, c.txID}, actionTxIDs(result))
+
+		byTxID := map[string]wdk.WalletAction{}
+		for _, act := range result.Actions {
+			assert.False(t, hasReservedTimeControlLabel(act.Labels))
+			require.Len(t, injectedTimeLabels(act.Labels), 1)
+			byTxID[act.TxID] = act
+		}
+		assert.Contains(t, byTxID[a.txID].Labels, brc114.MakeActionTimeLabel(a.createdAtMs))
+		assert.Contains(t, byTxID[b.txID].Labels, brc114.MakeActionTimeLabel(b.createdAtMs))
+		assert.Contains(t, byTxID[c.txID].Labels, brc114.MakeActionTimeLabel(c.createdAtMs))
+	})
+
+	// Pagination still works under time filtering.
+	t.Run("pagination_with_time_filter", func(t *testing.T) {
+		result, err := activeStorage.ListActions(ctx, testusers.Alice.AuthID(), wdk.ListActionsArgs{
+			Labels: []primitives.StringUnder300{
+				primitives.StringUnder300(runLabel),
+				primitives.StringUnder300(brc114.ActionTimeFromPrefix + "0"),
+			},
+			IncludeLabels: to.Ptr(primitives.BooleanDefaultFalse(true)),
+			Limit:         2,
+			Offset:        2,
+		})
+		require.NoError(t, err)
+		assert.EqualValues(t, 3, result.TotalActions)
+		assert.Len(t, result.Actions, 1)
+	})
+
+	// from inclusive: b and c.
+	t.Run("from_inclusive", func(t *testing.T) {
+		result, err := activeStorage.ListActions(ctx, testusers.Alice.AuthID(), wdk.ListActionsArgs{
+			Labels: []primitives.StringUnder300{
+				primitives.StringUnder300(runLabel),
+				primitives.StringUnder300(fmt.Sprintf("%s%d", brc114.ActionTimeFromPrefix, b.createdAtMs)),
+			},
+			IncludeLabels: to.Ptr(primitives.BooleanDefaultFalse(true)),
+			Limit:         100,
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{b.txID, c.txID}, actionTxIDs(result))
+	})
+
+	// to exclusive: a and b.
+	t.Run("to_exclusive", func(t *testing.T) {
+		result, err := activeStorage.ListActions(ctx, testusers.Alice.AuthID(), wdk.ListActionsArgs{
+			Labels: []primitives.StringUnder300{
+				primitives.StringUnder300(runLabel),
+				primitives.StringUnder300(fmt.Sprintf("%s%d", brc114.ActionTimeToPrefix, c.createdAtMs)),
+			},
+			IncludeLabels: to.Ptr(primitives.BooleanDefaultFalse(true)),
+			Limit:         100,
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{a.txID, b.txID}, actionTxIDs(result))
+	})
+
+	// from inclusive + to exclusive: only b.
+	t.Run("from_and_to_range", func(t *testing.T) {
+		result, err := activeStorage.ListActions(ctx, testusers.Alice.AuthID(), wdk.ListActionsArgs{
+			Labels: []primitives.StringUnder300{
+				primitives.StringUnder300(runLabel),
+				primitives.StringUnder300(fmt.Sprintf("%s%d", brc114.ActionTimeFromPrefix, b.createdAtMs)),
+				primitives.StringUnder300(fmt.Sprintf("%s%d", brc114.ActionTimeToPrefix, c.createdAtMs)),
+			},
+			IncludeLabels: to.Ptr(primitives.BooleanDefaultFalse(true)),
+			Limit:         100,
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{b.txID}, actionTxIDs(result))
+	})
+
+	// Time labels are stripped before labelQueryMode=all matching.
+	t.Run("label_query_mode_all_ignores_time_control_labels", func(t *testing.T) {
+		baseline, err := activeStorage.ListActions(ctx, testusers.Alice.AuthID(), wdk.ListActionsArgs{
+			Labels:         []primitives.StringUnder300{primitives.StringUnder300(runLabel)},
+			IncludeLabels:  to.Ptr(primitives.BooleanDefaultFalse(true)),
+			LabelQueryMode: to.Ptr(defs.QueryModeAll),
+			Limit:          100,
+		})
+		require.NoError(t, err)
+
+		withTime, err := activeStorage.ListActions(ctx, testusers.Alice.AuthID(), wdk.ListActionsArgs{
+			Labels: []primitives.StringUnder300{
+				primitives.StringUnder300(runLabel),
+				primitives.StringUnder300(brc114.ActionTimeFromPrefix + "0"),
+			},
+			IncludeLabels:  to.Ptr(primitives.BooleanDefaultFalse(true)),
+			LabelQueryMode: to.Ptr(defs.QueryModeAll),
+			Limit:          100,
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, actionTxIDs(baseline), actionTxIDs(withTime))
+	})
+
+	// Ordinary label AND still works.
+	t.Run("label_query_mode_all_with_ordinary_label", func(t *testing.T) {
+		result, err := activeStorage.ListActions(ctx, testusers.Alice.AuthID(), wdk.ListActionsArgs{
+			Labels: []primitives.StringUnder300{
+				primitives.StringUnder300(runLabel),
+				primitives.StringUnder300(a.label),
+			},
+			IncludeLabels:  to.Ptr(primitives.BooleanDefaultFalse(true)),
+			LabelQueryMode: to.Ptr(defs.QueryModeAll),
+			Limit:          100,
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{a.txID}, actionTxIDs(result))
+	})
+}
+
+func actionTxIDs(r *wdk.ListActionsResult) []string {
+	out := make([]string, 0, len(r.Actions))
+	for _, a := range r.Actions {
+		out = append(out, a.TxID)
+	}
+	return out
+}
+
+func hasReservedTimeControlLabel(labels []string) bool {
+	for _, l := range labels {
+		if strings.HasPrefix(l, brc114.ActionTimeFromPrefix) || strings.HasPrefix(l, brc114.ActionTimeToPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func injectedTimeLabels(labels []string) []string {
+	var out []string
+	for _, l := range labels {
+		if strings.HasPrefix(l, brc114.ActionTimeFromPrefix) || strings.HasPrefix(l, brc114.ActionTimeToPrefix) {
+			continue
+		}
+		if strings.HasPrefix(l, brc114.ActionTimeLabelPrefix) {
+			rest := strings.TrimPrefix(l, brc114.ActionTimeLabelPrefix)
+			if rest != "" && isAllDigits(rest) {
+				out = append(out, l)
+			}
+		}
+	}
+	return out
+}
+
+func isAllDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- Implements BRC-114 action time control labels for `listActions` to match the TypeScript wallet-toolbox behavior.
- Parses `"action time from <unix-ms>"` / `"action time to <unix-ms>"` as created_at range filters (from inclusive, to exclusive).
- Strips time-control labels from ordinary DB label matching (so `labelQueryMode: all` is not broken).
- When time filtering is active and `includeLabels` is true, injects computed `"action time {ms}"` labels into responses.
- Validates invalid/duplicate/out-of-order time labels.

Fixes #822

## Test plan
- [x] `go test ./pkg/internal/brc114/ -count=1`
- [x] `go test ./pkg/internal/validate/ -count=1 -run ListActionsArgs`
- [x] `go test ./pkg/storage/ -count=1 -run 'TestListActions'`
- [x] `go test ./pkg/wallet/ -count=1 -run ListActions`
- Manual: list actions with labels `["run", "action time from 0"]` and `includeLabels: true` — expect computed time labels and filtered results.