### PR TITLE
fix: include tx and noSendChange on ProcessActionError (#819)

### DIFF
--- a/pkg/errors/action_error.go
+++ b/pkg/errors/action_error.go
@@ -128,10 +128,26 @@ func (c *CreateActionError) Is(target error) bool {
 }
 
 // ProcessActionError represents an error that occurred during processing actions, including send and review results.
+//
+// When undelayed createAction/signAction broadcast outcomes require review (matching TypeScript
+// WERR_REVIEW_ACTIONS), optional TxID, Tx (AtomicBEEF bytes), and NoSendChange carry the same
+// recovery data a successful result would have returned. Callers can recover them via errors.As:
+//
+//	var processErr *errors.ProcessActionError
+//	if errors.As(err, &processErr) {
+//	    _ = processErr.Tx
+//	    _ = processErr.NoSendChange
+//	}
 type ProcessActionError struct {
 	SendWithResults []wdk.SendWithResult
 	ReviewResults   []wdk.ReviewActionResult
-	Cause           error
+	// TxID is the hex transaction id of the new transaction, when available.
+	TxID string
+	// Tx is AtomicBEEF bytes of the new transaction, when available.
+	Tx []byte
+	// NoSendChange is outpoint strings ("txid.vout") for change outputs from noSend batches.
+	NoSendChange []string
+	Cause        error
 }
 
 // NewProcessActionError creates a new ProcessActionError instance from send and review operation results.
@@ -142,11 +158,29 @@ func NewProcessActionError(sendWithResults []wdk.SendWithResult, reviewResults [
 	}
 }
 
+// WithTx attaches the new transaction id and optional AtomicBEEF bytes for caller recovery.
+// tx may be nil when only the txid is known (e.g. beef serialization failed).
+func (p *ProcessActionError) WithTx(txID string, tx []byte) *ProcessActionError {
+	p.TxID = txID
+	p.Tx = tx
+	return p
+}
+
+// WithNoSendChange attaches noSend change outpoints as "txid.vout" strings for chained noSend workflows.
+func (p *ProcessActionError) WithNoSendChange(noSendChange []string) *ProcessActionError {
+	p.NoSendChange = noSendChange
+	return p
+}
+
 func (p *ProcessActionError) Error() string {
 	var parts []string
 
 	baseMsg := "process action failed"
 	parts = append(parts, baseMsg)
+
+	if p.TxID != "" {
+		parts = append(parts, fmt.Sprintf("txID: %s", p.TxID))
+	}
 
 	if len(p.SendWithResults) > 0 {
 		successCount := 0

--- a/pkg/errors/action_error_test.go
+++ b/pkg/errors/action_error_test.go
@@ -154,5 +154,5 @@ func TestProcessActionError_RecoverViaErrorsAsThroughTransactionError(t *testing
 	// Existing error interface behavior preserved.
 	var txErr *pkgerrors.TransactionError
 	require.ErrorAs(t, wrapped, &txErr)
-	assert.True(t, errors.Is(wrapped, processErr))
+	assert.ErrorIs(t, wrapped, processErr)
 }

--- a/pkg/errors/action_error_test.go
+++ b/pkg/errors/action_error_test.go
@@ -101,3 +101,58 @@ func TestProcessActionError_ErrorCases(t *testing.T) {
 		assert.NoError(t, err.Unwrap())
 	})
 }
+
+func TestProcessActionError_WithTxAndNoSendChange(t *testing.T) {
+	txID := "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+	txBytes := []byte{0x01, 0x00, 0xbe, 0xef}
+	noSendChange := []string{txID + ".0", txID + ".1"}
+	sendResults := []wdk.SendWithResult{
+		{TxID: "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899", Status: wdk.SendWithResultStatusFailed},
+	}
+	reviewResults := []wdk.ReviewActionResult{
+		{Status: wdk.ReviewActionResultStatusDoubleSpend},
+	}
+	cause := errors.New("unexpected not delayed results when send with results are not all unproven")
+
+	err := pkgerrors.NewProcessActionError(sendResults, reviewResults).
+		WithTx(txID, txBytes).
+		WithNoSendChange(noSendChange).
+		Wrap(cause)
+
+	require.NotNil(t, err)
+	assert.Equal(t, txID, err.TxID)
+	assert.Equal(t, txBytes, err.Tx)
+	assert.Equal(t, noSendChange, err.NoSendChange)
+	assert.Equal(t, sendResults, err.SendWithResults)
+	assert.Equal(t, reviewResults, err.ReviewResults)
+	assert.Contains(t, err.Error(), "txID: "+txID)
+	assert.Contains(t, err.Error(), "review results: 1 require review")
+	assert.ErrorIs(t, err, cause)
+}
+
+func TestProcessActionError_RecoverViaErrorsAsThroughTransactionError(t *testing.T) {
+	txIDHex := "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
+	txBytes := []byte{0xde, 0xad, 0xbe, 0xef}
+	noSendChange := []string{txIDHex + ".2"}
+
+	processErr := pkgerrors.NewProcessActionError(
+		[]wdk.SendWithResult{{Status: wdk.SendWithResultStatusFailed}},
+		[]wdk.ReviewActionResult{{Status: wdk.ReviewActionResultStatusServiceError}},
+	).WithTx(txIDHex, txBytes).WithNoSendChange(noSendChange).Wrap(errors.New("review required"))
+
+	// Wallet createAction wraps ProcessActionError in TransactionError; callers must still recover fields.
+	wrapped := pkgerrors.NewTransactionError(chainhash.Hash{}).Wrap(processErr)
+
+	var recovered *pkgerrors.ProcessActionError
+	require.ErrorAs(t, wrapped, &recovered)
+	assert.Equal(t, txIDHex, recovered.TxID)
+	assert.Equal(t, txBytes, recovered.Tx)
+	assert.Equal(t, noSendChange, recovered.NoSendChange)
+	assert.Len(t, recovered.SendWithResults, 1)
+	assert.Len(t, recovered.ReviewResults, 1)
+
+	// Existing error interface behavior preserved.
+	var txErr *pkgerrors.TransactionError
+	require.ErrorAs(t, wrapped, &txErr)
+	assert.True(t, errors.Is(wrapped, processErr))
+}

--- a/pkg/wallet/internal/actions/process_action_error.go
+++ b/pkg/wallet/internal/actions/process_action_error.go
@@ -1,0 +1,54 @@
+package actions
+
+import (
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/go-softwarelab/common/pkg/slices"
+
+	pkgerrors "github.com/bsv-blockchain/go-wallet-toolbox/pkg/errors"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/assembler"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/internal/mapping"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk/primitives"
+)
+
+// newProcessActionError builds a ProcessActionError from process results, attaching optional
+// recovery fields (Tx AtomicBEEF + noSendChange outpoints) when a new transaction is available.
+// Matches TypeScript WERR_REVIEW_ACTIONS which carries txid, tx, sendWithResults,
+// reviewActionResults, and noSendChange.
+func newProcessActionError(
+	processActionResult *wdk.ProcessActionResult,
+	txID *chainhash.Hash,
+	tx *assembler.AssembledTransaction,
+	noSendChangeOutputVouts []int,
+) *pkgerrors.ProcessActionError {
+	processErr := pkgerrors.NewProcessActionError(
+		processActionResult.SendWithResults,
+		processActionResult.NotDelayedResults,
+	)
+
+	if txID != nil {
+		var beef []byte
+		if tx != nil {
+			// Best-effort: if AtomicBEEF serialization fails, still attach the txid.
+			if bytes, err := tx.AtomicBEEF(true); err == nil {
+				beef = bytes
+			}
+		}
+		processErr = processErr.WithTx(txID.String(), beef)
+	}
+
+	if txID != nil && len(noSendChangeOutputVouts) > 0 {
+		if outpoints, err := mapping.MapIndexesToOutpoints(txID, noSendChangeOutputVouts); err == nil {
+			processErr = processErr.WithNoSendChange(outpointsToStrings(outpoints))
+		}
+	}
+
+	return processErr
+}
+
+func outpointsToStrings(outpoints []transaction.Outpoint) []string {
+	return slices.Map(outpoints, func(op transaction.Outpoint) string {
+		return string(primitives.NewOutpointString(op.Txid.String(), op.Index))
+	})
+}

--- a/pkg/wallet/internal/actions/wallet_create_action.go
+++ b/pkg/wallet/internal/actions/wallet_create_action.go
@@ -50,6 +50,7 @@ func (a *CreateAction) handleNotNewTX(ctx context.Context) (*wallet.CreateAction
 
 	broadcastErr := a.validateProcessActionResult(processActionResult)
 	if broadcastErr != nil {
+		// sendWith-only path has no new transaction / noSendChange (matches TS WERR_REVIEW_ACTIONS optionals).
 		return nil, pkgerrors.NewProcessActionError(processActionResult.SendWithResults, processActionResult.NotDelayedResults).Wrap(broadcastErr)
 	}
 
@@ -140,9 +141,14 @@ func (a *CreateAction) handleProcessAction(ctx context.Context, tx *assembler.As
 
 	broadcastErr := a.validateProcessActionResult(processActionResult)
 	if broadcastErr != nil {
-		return nil, pkgerrors.
-			NewProcessActionError(processActionResult.SendWithResults, processActionResult.NotDelayedResults).
-			Wrap(broadcastErr)
+		// Attach AtomicBEEF + noSendChange so callers can recover from review-required broadcasts
+		// (TypeScript WERR_REVIEW_ACTIONS carries txid, tx, noSendChange).
+		return nil, newProcessActionError(
+			processActionResult,
+			txID,
+			tx,
+			createActionResult.NoSendChangeOutputVouts,
+		).Wrap(broadcastErr)
 	}
 
 	return processActionResult, nil

--- a/pkg/wallet/internal/actions/wallet_sign_action.go
+++ b/pkg/wallet/internal/actions/wallet_sign_action.go
@@ -80,7 +80,7 @@ func (s *SignAction) SignAction(ctx context.Context, args wallet.SignActionArgs,
 	if err != nil {
 		return nil, fmt.Errorf("failed to build result after processing signed action: %w",
 			pkgerrors.NewTransactionError(*s.txID).
-				Wrap(pkgerrors.NewProcessActionError(processActionResult.SendWithResults, processActionResult.NotDelayedResults).
+				Wrap(newProcessActionError(processActionResult, s.txID, s.tx, nil).
 					Wrap(err)))
 	}
 
@@ -124,7 +124,9 @@ func (s *SignAction) handleProcessAction(ctx context.Context) (*wdk.ProcessActio
 	if s.requiresNotDelayedResult() {
 		err = validate.NotDelayedProcessActionResult(processActionResult)
 		if err != nil {
-			return nil, pkgerrors.NewProcessActionError(processActionResult.SendWithResults, processActionResult.NotDelayedResults).Wrap(err)
+			// Attach AtomicBEEF so callers can recover the signed tx from the review error
+			// (TypeScript WERR_REVIEW_ACTIONS carries txid + tx).
+			return nil, newProcessActionError(processActionResult, s.txID, s.tx, nil).Wrap(err)
 		}
 	}
 

--- a/pkg/wallet/wallet_create_action_test.go
+++ b/pkg/wallet/wallet_create_action_test.go
@@ -874,9 +874,11 @@ func (s *WalletTestSuite) TestWalletCreateAction_NoSend_SendWith_BroadcastErrorF
 
 		// and:
 		_, _ = given.Faucet(aliceWallet).TopUp(topUpValue)
+		// second createAction also spends wallet change; ensure enough UTXOs
+		_, _ = given.Faucet(aliceWallet).TopUp(topUpValue)
 
 		// when:
-		args := fixtures.DefaultWalletCreateActionArgs(t, walletargs.WithNoSend(true))
+		args := fixtures.DefaultWalletCreateActionArgs(t, walletargs.WithNoSend(true), walletargs.WithSatoshisAsFirstOutput(1))
 
 		firstResult, err := aliceWallet.CreateAction(t.Context(), args, fixtures.DefaultOriginator)
 
@@ -891,13 +893,73 @@ func (s *WalletTestSuite) TestWalletCreateAction_NoSend_SendWith_BroadcastErrorF
 		// given:
 		given.Services().ARC().WhenQueryingTx(firstResult.Txid.String()).WillReturnDoubleSpending()
 
-		// when:
-		args = fixtures.DefaultWalletCreateActionArgs(t, walletargs.WithSendWith(firstResult.Txid))
+		// when: new tx + sendWith of the failed noSend tx (review-required undelayed broadcast)
+		args = fixtures.DefaultWalletCreateActionArgs(t, walletargs.WithSendWith(firstResult.Txid), walletargs.WithSatoshisAsFirstOutput(1))
 
-		_, err = aliceWallet.CreateAction(t.Context(), args, fixtures.DefaultOriginator)
+		result, err := aliceWallet.CreateAction(t.Context(), args, fixtures.DefaultOriginator)
 
 		// then:
 		require.Error(t, err)
+		assert.Nil(t, result)
+
+		// and: ProcessActionError is recoverable with AtomicBEEF of the new tx (#819)
+		var processErr *pkgerrors.ProcessActionError
+		require.ErrorAs(t, err, &processErr)
+		require.NotEmpty(t, processErr.TxID, "review error should carry new txid")
+		require.NotEmpty(t, processErr.Tx, "review error should carry AtomicBEEF bytes of the new tx")
+		require.NotEmpty(t, processErr.SendWithResults)
+		require.NotEmpty(t, processErr.ReviewResults)
+
+		// and: TxID is present in the error message
+		assert.Contains(t, processErr.Error(), processErr.TxID)
+	})
+
+	s.Run("review-required createAction with noSend populates noSendChange on ProcessActionError", func() {
+		t := s.T()
+		const topUpValue = testValueForFunding
+
+		// given:
+		given, cleanup := testabilities.Given(t)
+		defer cleanup()
+
+		aliceWallet := given.AliceWalletWithStorage(s.StorageType)
+		_, _ = given.Faucet(aliceWallet).TopUp(topUpValue)
+		_, _ = given.Faucet(aliceWallet).TopUp(topUpValue)
+
+		// and: a prior noSend tx that will fail review when sendWith'd
+		firstArgs := fixtures.DefaultWalletCreateActionArgs(t, walletargs.WithNoSend(true), walletargs.WithSatoshisAsFirstOutput(1))
+		firstResult, err := aliceWallet.CreateAction(t.Context(), firstArgs, fixtures.DefaultOriginator)
+		require.NoError(t, err)
+		require.NotEmpty(t, firstResult.NoSendChange)
+
+		given.Services().ARC().WhenQueryingTx(firstResult.Txid.String()).WillReturnDoubleSpending()
+
+		// when: create another noSend tx while sendWithing the double-spend one
+		// (SendWith overrides NoSend broadcast skip for listed txs; new tx still produces noSendChange)
+		secondArgs := fixtures.DefaultWalletCreateActionArgs(
+			t,
+			walletargs.WithNoSend(true),
+			walletargs.WithSendWith(firstResult.Txid),
+			walletargs.WithSatoshisAsFirstOutput(1),
+		)
+		result, err := aliceWallet.CreateAction(t.Context(), secondArgs, fixtures.DefaultOriginator)
+
+		// then:
+		require.Error(t, err)
+		assert.Nil(t, result)
+
+		var processErr *pkgerrors.ProcessActionError
+		require.ErrorAs(t, err, &processErr)
+		require.NotEmpty(t, processErr.TxID, "review error should carry new txid")
+		require.NotEmpty(t, processErr.Tx, "review error should carry AtomicBEEF of the new noSend tx")
+		require.NotEmpty(t, processErr.NoSendChange, "review error should carry noSendChange outpoints")
+		require.NotEmpty(t, processErr.SendWithResults)
+		require.NotEmpty(t, processErr.ReviewResults)
+
+		// and: noSendChange outpoints reference the new txid
+		for _, op := range processErr.NoSendChange {
+			assert.True(t, strings.HasPrefix(op, processErr.TxID+"."), "noSendChange outpoint %q should start with new txid", op)
+		}
 	})
 }
 


### PR DESCRIPTION
## Summary
- Extend `ProcessActionError` with optional `TxID`, `Tx` (AtomicBEEF bytes), and `NoSendChange` (outpoint strings) to match TypeScript `WERR_REVIEW_ACTIONS`.
- Populate those fields when undelayed `CreateAction` / `SignAction` process results require review, while keeping sendWith-only path fields empty when no new tx exists.
- Callers recover data via `errors.As` even when the error is wrapped in `TransactionError`; existing `Error`/`Unwrap`/`Is` behavior is preserved.

Fixes #819

## Test plan
- [x] `go test ./pkg/errors/ -count=1`
- [x] `go test ./pkg/wallet/ -count=1 -run 'TestWalletWithSQLiteStorage/TestWalletCreateAction_NoSend_SendWith_BroadcastErrorForOne' -timeout 180s`
- [ ] CI green on PR