### PR TITLE
fix: sync certificates, certificateFields, and commissions

### DIFF
--- a/pkg/entity/certifier.go
+++ b/pkg/entity/certifier.go
@@ -15,7 +15,9 @@ type Certificate struct {
 	Verifier           string
 	RevocationOutpoint string
 	Signature          string
-	CertificateFields  []CertificateField
+	// IsDeleted is set during sync when the certificate was soft-deleted on the reader side.
+	IsDeleted         bool
+	CertificateFields []CertificateField
 }
 
 // CertificateReadSpecification defines filter criteria for querying certificates based on various optional comparable fields.
@@ -36,7 +38,9 @@ type CertificateField struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 
-	FieldName  string
-	FieldValue string
-	MasterKey  string
+	UserID        int
+	CertificateID uint
+	FieldName     string
+	FieldValue    string
+	MasterKey     string
 }

--- a/pkg/internal/fixtures/default_request_sync_chunk_args.go
+++ b/pkg/internal/fixtures/default_request_sync_chunk_args.go
@@ -49,7 +49,18 @@ func DefaultRequestSyncChunkArgs(userIdentityKey, fromIdentityKey, toIdentityKey
 				Name:   wdk.OutputTagMapEntityName,
 				Offset: 0,
 			},
-			// TODO: Add more offsets for other entities when implemented
+			{
+				Name:   wdk.CertificateEntityName,
+				Offset: 0,
+			},
+			{
+				Name:   wdk.CertificateFieldEntityName,
+				Offset: 0,
+			},
+			{
+				Name:   wdk.CommissionEntityName,
+				Offset: 0,
+			},
 		},
 	}
 }

--- a/pkg/internal/storage/repo/certificates.go
+++ b/pkg/internal/storage/repo/certificates.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-softwarelab/common/pkg/slices"
 	"go.opentelemetry.io/otel/attribute"
@@ -48,12 +49,24 @@ func (c *Certificates) DeleteCertificate(ctx context.Context, userID int, args w
 		tracing.EndTracing(span, err)
 	}()
 
-	tx := c.db.WithContext(ctx).Delete(&models.Certificate{}, "type = ? AND serial_number = ? AND certifier = ? AND user_id = ?", args.Type, args.SerialNumber, args.Certifier, userID)
-	if tx.RowsAffected == 0 {
-		return fmt.Errorf("failed to delete certificate model: certificate not found")
-	}
+	// Soft-delete and bump updated_at so getSyncChunk's since-filter picks up the
+	// relinquished certificate for cross-storage sync (issue #850). GORM's default
+	// soft-delete only sets deleted_at, which is invisible to the since filter.
+	now := time.Now().UTC()
+	tx := c.db.WithContext(ctx).
+		Unscoped().
+		Model(&models.Certificate{}).
+		Where("type = ? AND serial_number = ? AND certifier = ? AND user_id = ? AND deleted_at IS NULL",
+			args.Type, args.SerialNumber, args.Certifier, userID).
+		Updates(map[string]any{
+			"updated_at": now,
+			"deleted_at": now,
+		})
 	if tx.Error != nil {
 		return fmt.Errorf("failed to delete certificate model: %w", tx.Error)
+	}
+	if tx.RowsAffected == 0 {
+		return fmt.Errorf("failed to delete certificate model: certificate not found")
 	}
 
 	return nil

--- a/pkg/internal/storage/repo/sync.go
+++ b/pkg/internal/storage/repo/sync.go
@@ -16,6 +16,9 @@ type Sync struct {
 	*syncrepo.SyncLabelMap
 	*syncrepo.SyncTag
 	*syncrepo.SyncTagMap
+	*syncrepo.SyncCertificate
+	*syncrepo.SyncCertificateField
+	*syncrepo.SyncCommission
 
 	db *gorm.DB
 }
@@ -24,13 +27,16 @@ func NewSync(db *gorm.DB, query *genquery.Query) *Sync {
 	return &Sync{
 		db: db,
 
-		SyncBasket:      syncrepo.NewSyncBasket(db, query),
-		SyncKnownTx:     syncrepo.NewSyncKnownTx(db, query),
-		SyncTransaction: syncrepo.NewSyncTransaction(db, query),
-		SyncOutput:      syncrepo.NewSyncOutput(db, query),
-		SyncLabel:       syncrepo.NewSyncLabel(db, query),
-		SyncLabelMap:    syncrepo.NewSyncLabelMap(db, query),
-		SyncTag:         syncrepo.NewSyncTag(db, query),
-		SyncTagMap:      syncrepo.NewSyncTagMap(db, query),
+		SyncBasket:           syncrepo.NewSyncBasket(db, query),
+		SyncKnownTx:          syncrepo.NewSyncKnownTx(db, query),
+		SyncTransaction:      syncrepo.NewSyncTransaction(db, query),
+		SyncOutput:           syncrepo.NewSyncOutput(db, query),
+		SyncLabel:            syncrepo.NewSyncLabel(db, query),
+		SyncLabelMap:         syncrepo.NewSyncLabelMap(db, query),
+		SyncTag:              syncrepo.NewSyncTag(db, query),
+		SyncTagMap:           syncrepo.NewSyncTagMap(db, query),
+		SyncCertificate:      syncrepo.NewSyncCertificate(db, query),
+		SyncCertificateField: syncrepo.NewSyncCertificateField(db, query),
+		SyncCommission:       syncrepo.NewSyncCommission(db, query),
 	}
 }

--- a/pkg/internal/storage/repo/syncrepo/sync_cert_commission_test.go
+++ b/pkg/internal/storage/repo/syncrepo/sync_cert_commission_test.go
@@ -1,0 +1,277 @@
+package syncrepo_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/entity"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/dbfixtures"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+)
+
+func TestUpsertCertificateForSync_CreateUpdateAndStaleSkip(t *testing.T) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	user, err := repos.CreateUser(
+		t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: defaultBasket, NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	)
+	require.NoError(t, err)
+
+	tOld := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	tNew := time.Date(2026, 4, 23, 13, 0, 0, 0, time.UTC)
+	tStale := time.Date(2026, 4, 23, 11, 0, 0, 0, time.UTC)
+
+	isNew, certID, err := repos.UpsertCertificateForSync(t.Context(), &entity.Certificate{
+		CreatedAt:          tOld,
+		UpdatedAt:          tOld,
+		UserID:             user.ID,
+		Type:               fixtures.TypeField,
+		SerialNumber:       fixtures.SerialNumber,
+		Certifier:          fixtures.Certifier,
+		Subject:            string(testusers.Alice.PubKey(t)),
+		RevocationOutpoint: fixtures.RevocationOutpoint,
+		Signature:          fixtures.Signature,
+	})
+	require.NoError(t, err)
+	require.True(t, isNew)
+	require.NotZero(t, certID)
+
+	// Happy update: newer updated_at changes subject/signature.
+	newSig := "feedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface"
+	isNew, certID2, err := repos.UpsertCertificateForSync(t.Context(), &entity.Certificate{
+		CreatedAt:          tOld,
+		UpdatedAt:          tNew,
+		UserID:             user.ID,
+		Type:               fixtures.TypeField,
+		SerialNumber:       fixtures.SerialNumber,
+		Certifier:          fixtures.Certifier,
+		Subject:            "updated-subject",
+		RevocationOutpoint: fixtures.RevocationOutpoint,
+		Signature:          newSig,
+	})
+	require.NoError(t, err)
+	require.False(t, isNew)
+	require.Equal(t, certID, certID2)
+
+	var got models.Certificate
+	require.NoError(t, d.DB.Unscoped().First(&got, certID).Error)
+	require.Equal(t, "updated-subject", got.Subject)
+	require.Equal(t, newSig, got.Signature)
+	require.False(t, got.DeletedAt.Valid)
+
+	// Stale skip: older updated_at must not regress.
+	isNew, _, err = repos.UpsertCertificateForSync(t.Context(), &entity.Certificate{
+		CreatedAt:          tOld,
+		UpdatedAt:          tStale,
+		UserID:             user.ID,
+		Type:               fixtures.TypeField,
+		SerialNumber:       fixtures.SerialNumber,
+		Certifier:          fixtures.Certifier,
+		Subject:            "stale-subject",
+		RevocationOutpoint: fixtures.RevocationOutpoint,
+		Signature:          "stale",
+	})
+	require.NoError(t, err)
+	require.False(t, isNew)
+
+	require.NoError(t, d.DB.Unscoped().First(&got, certID).Error)
+	require.Equal(t, "updated-subject", got.Subject)
+	require.Equal(t, newSig, got.Signature)
+
+	// Soft-delete via IsDeleted with newer timestamp.
+	tDel := time.Date(2026, 4, 23, 14, 0, 0, 0, time.UTC)
+	_, _, err = repos.UpsertCertificateForSync(t.Context(), &entity.Certificate{
+		CreatedAt:          tOld,
+		UpdatedAt:          tDel,
+		UserID:             user.ID,
+		Type:               fixtures.TypeField,
+		SerialNumber:       fixtures.SerialNumber,
+		Certifier:          fixtures.Certifier,
+		Subject:            "updated-subject",
+		RevocationOutpoint: fixtures.RevocationOutpoint,
+		Signature:          newSig,
+		IsDeleted:          true,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, d.DB.Unscoped().First(&got, certID).Error)
+	require.True(t, got.DeletedAt.Valid)
+
+	// Find for sync should return the soft-deleted certificate with IsDeleted=true.
+	rows, err := repos.FindCertificatesForSync(t.Context(), user.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.True(t, rows[0].IsDeleted)
+	require.Equal(t, certID, rows[0].CertificateID)
+}
+
+func TestUpsertCertificateFieldForSync_CreateUpdateAndStaleSkip(t *testing.T) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	user, err := repos.CreateUser(
+		t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: defaultBasket, NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	)
+	require.NoError(t, err)
+
+	tOld := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	tNew := time.Date(2026, 4, 23, 13, 0, 0, 0, time.UTC)
+	tStale := time.Date(2026, 4, 23, 11, 0, 0, 0, time.UTC)
+
+	_, certID, err := repos.UpsertCertificateForSync(t.Context(), &entity.Certificate{
+		CreatedAt:          tOld,
+		UpdatedAt:          tOld,
+		UserID:             user.ID,
+		Type:               fixtures.TypeField,
+		SerialNumber:       fixtures.SerialNumber,
+		Certifier:          fixtures.Certifier,
+		Subject:            string(testusers.Alice.PubKey(t)),
+		RevocationOutpoint: fixtures.RevocationOutpoint,
+		Signature:          fixtures.Signature,
+	})
+	require.NoError(t, err)
+
+	isNew, err := repos.UpsertCertificateFieldForSync(t.Context(), &entity.CertificateField{
+		CreatedAt:     tOld,
+		UpdatedAt:     tOld,
+		UserID:        user.ID,
+		CertificateID: certID,
+		FieldName:     "exampleField",
+		FieldValue:    "value-old",
+		MasterKey:     "master-old",
+	})
+	require.NoError(t, err)
+	require.True(t, isNew)
+
+	isNew, err = repos.UpsertCertificateFieldForSync(t.Context(), &entity.CertificateField{
+		CreatedAt:     tOld,
+		UpdatedAt:     tNew,
+		UserID:        user.ID,
+		CertificateID: certID,
+		FieldName:     "exampleField",
+		FieldValue:    "value-new",
+		MasterKey:     "master-new",
+	})
+	require.NoError(t, err)
+	require.False(t, isNew)
+
+	var got models.CertificateField
+	require.NoError(t, d.DB.Where("certificate_id = ? AND field_name = ?", certID, "exampleField").First(&got).Error)
+	require.Equal(t, "value-new", got.FieldValue)
+	require.Equal(t, "master-new", got.MasterKey)
+
+	// Stale skip
+	_, err = repos.UpsertCertificateFieldForSync(t.Context(), &entity.CertificateField{
+		CreatedAt:     tOld,
+		UpdatedAt:     tStale,
+		UserID:        user.ID,
+		CertificateID: certID,
+		FieldName:     "exampleField",
+		FieldValue:    "value-stale",
+		MasterKey:     "master-stale",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, d.DB.Where("certificate_id = ? AND field_name = ?", certID, "exampleField").First(&got).Error)
+	require.Equal(t, "value-new", got.FieldValue)
+
+	rows, err := repos.FindCertificateFieldsForSync(t.Context(), user.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, certID, rows[0].CertificateID)
+	require.Equal(t, "exampleField", rows[0].FieldName)
+	require.Equal(t, "value-new", rows[0].FieldValue)
+}
+
+func TestUpsertCommissionForSync_CreateUpdateAndStaleSkip(t *testing.T) {
+	d, cleanup := dbfixtures.TestDatabase(t)
+	defer cleanup()
+	repos := d.CreateRepositories()
+
+	user, err := repos.CreateUser(
+		t.Context(), testusers.Alice.IdentityKey(t), "test-storage",
+		wdk.BasketConfiguration{Name: defaultBasket, NumberOfDesiredUTXOs: 1, MinimumDesiredUTXOValue: 1000},
+	)
+	require.NoError(t, err)
+
+	tOld := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	tNew := time.Date(2026, 4, 23, 13, 0, 0, 0, time.UTC)
+	tStale := time.Date(2026, 4, 23, 11, 0, 0, 0, time.UTC)
+
+	_, txID, err := repos.UpsertTransactionForSync(t.Context(), &entity.Transaction{
+		CreatedAt: tOld, UpdatedAt: tOld,
+		UserID: user.ID, Status: wdk.TxStatusCompleted, Reference: "ref-commission-sync",
+		IsOutgoing: true, Satoshis: 1000, Description: "commission parent",
+	})
+	require.NoError(t, err)
+
+	script := []byte{0x76, 0xa9, 0x14}
+	isNew, commissionID, err := repos.UpsertCommissionForSync(t.Context(), &entity.Commission{
+		CreatedAt:     tOld,
+		UpdatedAt:     tOld,
+		UserID:        user.ID,
+		TransactionID: txID,
+		Satoshis:      100,
+		KeyOffset:     "offset-1",
+		IsRedeemed:    false,
+		LockingScript: script,
+	})
+	require.NoError(t, err)
+	require.True(t, isNew)
+	require.NotZero(t, commissionID)
+
+	// Happy update: only is_redeemed changes on update path.
+	isNew, commissionID2, err := repos.UpsertCommissionForSync(t.Context(), &entity.Commission{
+		CreatedAt:     tOld,
+		UpdatedAt:     tNew,
+		UserID:        user.ID,
+		TransactionID: txID,
+		Satoshis:      999, // ignored on update
+		KeyOffset:     "offset-ignored",
+		IsRedeemed:    true,
+		LockingScript: []byte{0xff},
+	})
+	require.NoError(t, err)
+	require.False(t, isNew)
+	require.Equal(t, commissionID, commissionID2)
+
+	var got models.Commission
+	require.NoError(t, d.DB.First(&got, commissionID).Error)
+	require.True(t, got.IsRedeemed)
+	require.Equal(t, uint64(100), got.Satoshis, "satoshis must not change on update (TS mergeExisting)")
+	require.Equal(t, "offset-1", got.KeyOffset)
+	require.Equal(t, script, got.LockingScript)
+
+	// Stale skip
+	_, _, err = repos.UpsertCommissionForSync(t.Context(), &entity.Commission{
+		CreatedAt:     tOld,
+		UpdatedAt:     tStale,
+		UserID:        user.ID,
+		TransactionID: txID,
+		Satoshis:      100,
+		KeyOffset:     "offset-1",
+		IsRedeemed:    false,
+		LockingScript: script,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, d.DB.First(&got, commissionID).Error)
+	require.True(t, got.IsRedeemed, "stale chunk must not un-redeem")
+
+	rows, err := repos.FindCommissionsForSync(t.Context(), user.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, commissionID, rows[0].CommissionID)
+	require.Equal(t, txID, rows[0].TransactionID)
+	require.True(t, rows[0].IsRedeemed)
+}

--- a/pkg/internal/storage/repo/syncrepo/sync_certificate.go
+++ b/pkg/internal/storage/repo/syncrepo/sync_certificate.go
@@ -1,0 +1,178 @@
+package syncrepo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-softwarelab/common/pkg/slices"
+	"github.com/go-softwarelab/common/pkg/to"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/entity"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/genquery"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/scopes"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/queryopts"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk/primitives"
+)
+
+// SyncCertificate handles certificate read/upsert for cross-storage sync.
+type SyncCertificate struct {
+	db    *gorm.DB
+	query *genquery.Query
+}
+
+// NewSyncCertificate constructs a SyncCertificate repository.
+func NewSyncCertificate(db *gorm.DB, query *genquery.Query) *SyncCertificate {
+	return &SyncCertificate{db: db, query: query}
+}
+
+func (s *SyncCertificate) tableName() string {
+	return s.query.Certificate.TableName()
+}
+
+// FindCertificatesForSync returns user certificates (including soft-deleted) for getSyncChunk.
+func (s *SyncCertificate) FindCertificatesForSync(ctx context.Context, userID int, opts ...queryopts.Options) ([]*wdk.TableCertificate, error) {
+	queryopts.ModifyOptions(opts, func(options *queryopts.Options) {
+		if options.Since != nil && options.Since.TableName == "" {
+			options.Since.TableName = s.tableName()
+		}
+	})
+	filters := append(scopes.FromQueryOpts(opts), scopes.UserID(userID))
+
+	var resultModels []*models.Certificate
+	err := s.db.WithContext(ctx).
+		Model(&models.Certificate{}).
+		// Include soft-deleted certificates so isDeleted is preserved across sync.
+		Unscoped().
+		Scopes(filters...).
+		// Deterministic tiebreak after Paginate's created_at DESC (see FindOutputsForSync).
+		Scopes(func(db *gorm.DB) *gorm.DB {
+			return db.Order(clause.OrderByColumn{Column: clause.Column{Table: s.tableName(), Name: "id"}})
+		}).
+		Find(&resultModels).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to find certificates for sync: %w", err)
+	}
+
+	return slices.Map(resultModels, s.mapModelToTableCertificate), nil
+}
+
+// UpsertCertificateForSync inserts or updates a certificate for processSyncChunk.
+// Natural key (reader-side mergeFind): serial_number + certifier + user_id.
+// BRC-40: only apply UPDATE when incoming.updated_at is strictly newer.
+func (s *SyncCertificate) UpsertCertificateForSync(ctx context.Context, e *entity.Certificate) (isNew bool, certificateID uint, err error) {
+	if e == nil {
+		return false, 0, fmt.Errorf("certificate entity is nil")
+	}
+
+	model := models.Certificate{
+		Model: gorm.Model{
+			CreatedAt: e.CreatedAt,
+			UpdatedAt: e.UpdatedAt,
+		},
+		Type:               e.Type,
+		SerialNumber:       e.SerialNumber,
+		Certifier:          e.Certifier,
+		Subject:            e.Subject,
+		Verifier:           e.Verifier,
+		RevocationOutpoint: e.RevocationOutpoint,
+		Signature:          e.Signature,
+		UserID:             e.UserID,
+	}
+
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing models.Certificate
+		// Unscoped so we can restore a previously soft-deleted certificate.
+		existsErr := tx.Unscoped().
+			Model(&models.Certificate{}).
+			Select("id, updated_at, deleted_at").
+			Where("user_id = ? AND serial_number = ? AND certifier = ?", e.UserID, e.SerialNumber, e.Certifier).
+			First(&existing).Error
+
+		if existsErr == nil {
+			if !model.UpdatedAt.After(existing.UpdatedAt) {
+				certificateID = existing.ID
+				return nil
+			}
+
+			updateMap := map[string]any{
+				"type":                model.Type,
+				"subject":             model.Subject,
+				"serial_number":       model.SerialNumber,
+				"certifier":           model.Certifier,
+				"verifier":            model.Verifier,
+				"revocation_outpoint": model.RevocationOutpoint,
+				"signature":           model.Signature,
+				"updated_at":          model.UpdatedAt,
+			}
+			if e.IsDeleted {
+				updateMap["deleted_at"] = model.UpdatedAt
+			} else {
+				updateMap["deleted_at"] = nil
+			}
+
+			updateTx := tx.Unscoped().
+				Model(&models.Certificate{}).
+				Where("id = ? AND updated_at < ?", existing.ID, model.UpdatedAt).
+				Updates(updateMap)
+			if updateTx.Error != nil {
+				return fmt.Errorf("failed to update certificate: %w", updateTx.Error)
+			}
+
+			certificateID = existing.ID
+			return nil
+		}
+
+		if !errors.Is(existsErr, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("failed to lookup existing certificate: %w", existsErr)
+		}
+
+		if err = tx.Create(&model).Error; err != nil {
+			return fmt.Errorf("failed to create certificate: %w", err)
+		}
+		if model.ID == 0 {
+			return fmt.Errorf("certificate ID is zero after creation")
+		}
+
+		if e.IsDeleted {
+			if err = tx.Delete(&models.Certificate{}, model.ID).Error; err != nil {
+				return fmt.Errorf("failed to soft-delete newly created certificate: %w", err)
+			}
+		}
+
+		isNew = true
+		certificateID = model.ID
+		return nil
+	})
+	if err != nil {
+		return false, 0, fmt.Errorf("transaction failed: %w", err)
+	}
+
+	return isNew, certificateID, nil
+}
+
+func (s *SyncCertificate) mapModelToTableCertificate(model *models.Certificate) *wdk.TableCertificate {
+	var verifier *primitives.PubKeyHex
+	if model.Verifier != "" {
+		verifier = to.Ptr(primitives.PubKeyHex(model.Verifier))
+	}
+
+	return &wdk.TableCertificate{
+		CreatedAt:          model.CreatedAt,
+		UpdatedAt:          model.UpdatedAt,
+		CertificateID:      model.ID,
+		UserID:             model.UserID,
+		Type:               primitives.Base64String(model.Type),
+		SerialNumber:       primitives.Base64String(model.SerialNumber),
+		Certifier:          primitives.PubKeyHex(model.Certifier),
+		Subject:            primitives.PubKeyHex(model.Subject),
+		Verifier:           verifier,
+		RevocationOutpoint: primitives.OutpointString(model.RevocationOutpoint),
+		Signature:          primitives.HexString(model.Signature),
+		IsDeleted:          model.DeletedAt.Valid,
+	}
+}

--- a/pkg/internal/storage/repo/syncrepo/sync_certificate_field.go
+++ b/pkg/internal/storage/repo/syncrepo/sync_certificate_field.go
@@ -1,0 +1,141 @@
+package syncrepo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-softwarelab/common/pkg/slices"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/entity"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/genquery"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/scopes"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/queryopts"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk/primitives"
+)
+
+// SyncCertificateField handles certificate field read/upsert for cross-storage sync.
+type SyncCertificateField struct {
+	db    *gorm.DB
+	query *genquery.Query
+}
+
+// NewSyncCertificateField constructs a SyncCertificateField repository.
+func NewSyncCertificateField(db *gorm.DB, query *genquery.Query) *SyncCertificateField {
+	return &SyncCertificateField{db: db, query: query}
+}
+
+func (s *SyncCertificateField) tableName() string {
+	// CertificateField is not a top-level genquery table; derive from the model schema.
+	stmt := &gorm.Statement{DB: s.db}
+	if err := stmt.Parse(&models.CertificateField{}); err != nil {
+		return "bsv_certificate_fields"
+	}
+	return stmt.Schema.Table
+}
+
+// FindCertificateFieldsForSync returns user certificate fields for getSyncChunk.
+func (s *SyncCertificateField) FindCertificateFieldsForSync(ctx context.Context, userID int, opts ...queryopts.Options) ([]*wdk.TableCertificateField, error) {
+	queryopts.ModifyOptions(opts, func(options *queryopts.Options) {
+		if options.Since != nil && options.Since.TableName == "" {
+			options.Since.TableName = s.tableName()
+		}
+	})
+	filters := append(scopes.FromQueryOpts(opts), scopes.UserID(userID))
+
+	var resultModels []*models.CertificateField
+	err := s.db.WithContext(ctx).
+		Model(&models.CertificateField{}).
+		Scopes(filters...).
+		// Deterministic tiebreak after Paginate's created_at DESC.
+		Scopes(func(db *gorm.DB) *gorm.DB {
+			return db.Order(clause.OrderByColumn{Column: clause.Column{Table: s.tableName(), Name: "field_name"}}).
+				Order(clause.OrderByColumn{Column: clause.Column{Table: s.tableName(), Name: "certificate_id"}})
+		}).
+		Find(&resultModels).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to find certificate fields for sync: %w", err)
+	}
+
+	return slices.Map(resultModels, s.mapModelToTableCertificateField), nil
+}
+
+// UpsertCertificateFieldForSync inserts or updates a certificate field for processSyncChunk.
+// Natural key: certificate_id (writer-side) + user_id + field_name.
+// BRC-40: only apply UPDATE when incoming.updated_at is strictly newer.
+// Note: certificateField has no ID map (see wdk.SyncMapEntity).
+func (s *SyncCertificateField) UpsertCertificateFieldForSync(ctx context.Context, e *entity.CertificateField) (isNew bool, err error) {
+	if e == nil {
+		return false, fmt.Errorf("certificate field entity is nil")
+	}
+
+	model := models.CertificateField{
+		CreatedAt:     e.CreatedAt,
+		UpdatedAt:     e.UpdatedAt,
+		FieldName:     e.FieldName,
+		FieldValue:    e.FieldValue,
+		MasterKey:     e.MasterKey,
+		UserID:        e.UserID,
+		CertificateID: e.CertificateID,
+	}
+
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing models.CertificateField
+		existsErr := tx.Model(&models.CertificateField{}).
+			Select("field_name, certificate_id, updated_at").
+			Where("user_id = ? AND certificate_id = ? AND field_name = ?", e.UserID, e.CertificateID, e.FieldName).
+			First(&existing).Error
+
+		if existsErr == nil {
+			if !model.UpdatedAt.After(existing.UpdatedAt) {
+				return nil
+			}
+
+			updateTx := tx.Model(&models.CertificateField{}).
+				Where("user_id = ? AND certificate_id = ? AND field_name = ? AND updated_at < ?",
+					e.UserID, e.CertificateID, e.FieldName, model.UpdatedAt).
+				Updates(map[string]any{
+					"field_value": model.FieldValue,
+					"master_key":  model.MasterKey,
+					"updated_at":  model.UpdatedAt,
+				})
+			if updateTx.Error != nil {
+				return fmt.Errorf("failed to update certificate field: %w", updateTx.Error)
+			}
+			return nil
+		}
+
+		if !errors.Is(existsErr, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("failed to lookup existing certificate field: %w", existsErr)
+		}
+
+		// Skip BeforeCreate OnConflict DoNothing so create is a real insert for sync.
+		if err = tx.Session(&gorm.Session{SkipHooks: true}).Create(&model).Error; err != nil {
+			return fmt.Errorf("failed to create certificate field: %w", err)
+		}
+
+		isNew = true
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("transaction failed: %w", err)
+	}
+
+	return isNew, nil
+}
+
+func (s *SyncCertificateField) mapModelToTableCertificateField(model *models.CertificateField) *wdk.TableCertificateField {
+	return &wdk.TableCertificateField{
+		CreatedAt:     model.CreatedAt,
+		UpdatedAt:     model.UpdatedAt,
+		UserID:        model.UserID,
+		CertificateID: model.CertificateID,
+		FieldName:     model.FieldName,
+		FieldValue:    model.FieldValue,
+		MasterKey:     primitives.Base64String(model.MasterKey),
+	}
+}

--- a/pkg/internal/storage/repo/syncrepo/sync_commission.go
+++ b/pkg/internal/storage/repo/syncrepo/sync_commission.go
@@ -1,0 +1,146 @@
+package syncrepo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-softwarelab/common/pkg/must"
+	"github.com/go-softwarelab/common/pkg/slices"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/entity"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/genquery"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/scopes"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/queryopts"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk/primitives"
+)
+
+// SyncCommission handles commission read/upsert for cross-storage sync.
+type SyncCommission struct {
+	db    *gorm.DB
+	query *genquery.Query
+}
+
+// NewSyncCommission constructs a SyncCommission repository.
+func NewSyncCommission(db *gorm.DB, query *genquery.Query) *SyncCommission {
+	return &SyncCommission{db: db, query: query}
+}
+
+func (s *SyncCommission) tableName() string {
+	return s.query.Commission.TableName()
+}
+
+// FindCommissionsForSync returns user commissions for getSyncChunk.
+func (s *SyncCommission) FindCommissionsForSync(ctx context.Context, userID int, opts ...queryopts.Options) ([]*wdk.TableCommission, error) {
+	queryopts.ModifyOptions(opts, func(options *queryopts.Options) {
+		if options.Since != nil && options.Since.TableName == "" {
+			options.Since.TableName = s.tableName()
+		}
+	})
+	filters := append(scopes.FromQueryOpts(opts), scopes.UserID(userID))
+
+	var resultModels []*models.Commission
+	err := s.db.WithContext(ctx).
+		Model(&models.Commission{}).
+		Scopes(filters...).
+		// Deterministic tiebreak after Paginate's created_at DESC (see FindOutputsForSync).
+		Scopes(func(db *gorm.DB) *gorm.DB {
+			return db.Order(clause.OrderByColumn{Column: clause.Column{Table: s.tableName(), Name: "id"}})
+		}).
+		Find(&resultModels).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to find commissions for sync: %w", err)
+	}
+
+	return slices.Map(resultModels, s.mapModelToTableCommission), nil
+}
+
+// UpsertCommissionForSync inserts or updates a commission for processSyncChunk.
+// Natural key (reader-side mergeFind): transaction_id (writer-side) + user_id.
+// BRC-40: only apply UPDATE when incoming.updated_at is strictly newer.
+// On update, only is_redeemed (and timestamps) change per TS EntityCommission.mergeExisting.
+func (s *SyncCommission) UpsertCommissionForSync(ctx context.Context, e *entity.Commission) (isNew bool, commissionID uint, err error) {
+	if e == nil {
+		return false, 0, fmt.Errorf("commission entity is nil")
+	}
+
+	model := models.Commission{
+		Model: gorm.Model{
+			CreatedAt: e.CreatedAt,
+			UpdatedAt: e.UpdatedAt,
+		},
+		UserID:        e.UserID,
+		TransactionID: e.TransactionID,
+		Satoshis:      e.Satoshis,
+		KeyOffset:     e.KeyOffset,
+		IsRedeemed:    e.IsRedeemed,
+		LockingScript: e.LockingScript,
+	}
+
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing models.Commission
+		existsErr := tx.Model(&models.Commission{}).
+			Select("id, updated_at").
+			Where("user_id = ? AND transaction_id = ?", e.UserID, e.TransactionID).
+			First(&existing).Error
+
+		if existsErr == nil {
+			if !model.UpdatedAt.After(existing.UpdatedAt) {
+				commissionID = existing.ID
+				return nil
+			}
+
+			// TS mergeExisting only updates isRedeemed (plus updated_at).
+			updateTx := tx.Model(&models.Commission{}).
+				Where("id = ? AND updated_at < ?", existing.ID, model.UpdatedAt).
+				Updates(map[string]any{
+					"is_redeemed": model.IsRedeemed,
+					"updated_at":  model.UpdatedAt,
+				})
+			if updateTx.Error != nil {
+				return fmt.Errorf("failed to update commission: %w", updateTx.Error)
+			}
+
+			commissionID = existing.ID
+			return nil
+		}
+
+		if !errors.Is(existsErr, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("failed to lookup existing commission: %w", existsErr)
+		}
+
+		if err = tx.Create(&model).Error; err != nil {
+			return fmt.Errorf("failed to create commission: %w", err)
+		}
+		if model.ID == 0 {
+			return fmt.Errorf("commission ID is zero after creation")
+		}
+
+		isNew = true
+		commissionID = model.ID
+		return nil
+	})
+	if err != nil {
+		return false, 0, fmt.Errorf("transaction failed: %w", err)
+	}
+
+	return isNew, commissionID, nil
+}
+
+func (s *SyncCommission) mapModelToTableCommission(model *models.Commission) *wdk.TableCommission {
+	return &wdk.TableCommission{
+		CreatedAt:     model.CreatedAt,
+		UpdatedAt:     model.UpdatedAt,
+		CommissionID:  model.ID,
+		UserID:        model.UserID,
+		TransactionID: model.TransactionID,
+		Satoshis:      must.ConvertToInt64FromUnsigned(model.Satoshis),
+		KeyOffset:     model.KeyOffset,
+		IsRedeemed:    model.IsRedeemed,
+		LockingScript: primitives.ExplicitByteArray(model.LockingScript),
+	}
+}

--- a/pkg/storage/internal/sync/chunk_processor.go
+++ b/pkg/storage/internal/sync/chunk_processor.go
@@ -141,6 +141,24 @@ func (p *ChunkProcessor) Process() (*wdk.ProcessSyncChunkResult, error) {
 		}
 	}
 
+	for _, certificate := range p.chunk.Certificates {
+		if err = p.upsertCertificate(certificate); err != nil {
+			return nil, fmt.Errorf("failed to upsert certificate: %w", err)
+		}
+	}
+
+	for _, certificateField := range p.chunk.CertificateFields {
+		if err = p.upsertCertificateField(certificateField); err != nil {
+			return nil, fmt.Errorf("failed to upsert certificate field: %w", err)
+		}
+	}
+
+	for _, commission := range p.chunk.Commissions {
+		if err = p.upsertCommission(commission); err != nil {
+			return nil, fmt.Errorf("failed to upsert commission: %w", err)
+		}
+	}
+
 	p.logger.DebugContext(p.ctx, "updating sync state on chunk processed")
 	err = p.repo.UpdateSyncState(p.ctx, p.syncState)
 	if err != nil {
@@ -660,6 +678,144 @@ func (p *ChunkProcessor) upsertTagMap(chunkTagMap *wdk.TableOutputTagMap) error 
 	return nil
 }
 
+func (p *ChunkProcessor) upsertCertificate(chunkCertificate *wdk.TableCertificate) error {
+	if p.chunk.User != nil && p.chunk.User.UserID != chunkCertificate.UserID {
+		return fmt.Errorf("chunk certificate user ID %d does not match chunk user ID %d", chunkCertificate.UserID, p.chunk.User.UserID)
+	}
+
+	p.logger.DebugContext(p.ctx, "upserting certificate",
+		slog.String("serialNumber", string(chunkCertificate.SerialNumber)),
+		slog.String("certifier", string(chunkCertificate.Certifier)),
+	)
+
+	verifier := ""
+	if chunkCertificate.Verifier != nil {
+		verifier = string(*chunkCertificate.Verifier)
+	}
+
+	isNew, certificateID, err := p.repo.UpsertCertificateForSync(p.ctx, &pkgentity.Certificate{
+		CreatedAt:          chunkCertificate.CreatedAt,
+		UpdatedAt:          chunkCertificate.UpdatedAt,
+		UserID:             p.user.ID,
+		Type:               string(chunkCertificate.Type),
+		SerialNumber:       string(chunkCertificate.SerialNumber),
+		Certifier:          string(chunkCertificate.Certifier),
+		Subject:            string(chunkCertificate.Subject),
+		Verifier:           verifier,
+		RevocationOutpoint: string(chunkCertificate.RevocationOutpoint),
+		Signature:          string(chunkCertificate.Signature),
+		IsDeleted:          chunkCertificate.IsDeleted,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to upsert certificate %q: %w", chunkCertificate.SerialNumber, err)
+	}
+
+	readerID, err := to.IntFromUnsigned(chunkCertificate.CertificateID)
+	if err != nil {
+		return fmt.Errorf("failed to convert certificate ID %d to int: %w", chunkCertificate.CertificateID, err)
+	}
+
+	p.incrementOperations(isNew)
+	err = p.updateSyncState(wdk.CertificateEntityName, chunkCertificate.UpdatedAt, idDictionary{
+		readerID: readerID,
+		writerID: certificateID,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update sync state for certificate %q: %w", chunkCertificate.SerialNumber, err)
+	}
+
+	return nil
+}
+
+func (p *ChunkProcessor) upsertCertificateField(chunkField *wdk.TableCertificateField) error {
+	if p.chunk.User != nil && p.chunk.User.UserID != chunkField.UserID {
+		return fmt.Errorf("chunk certificate field user ID %d does not match chunk user ID %d", chunkField.UserID, p.chunk.User.UserID)
+	}
+
+	p.logger.DebugContext(p.ctx, "upserting certificate field",
+		logging.Number("certificateID", chunkField.CertificateID),
+		slog.String("fieldName", chunkField.FieldName),
+	)
+
+	certificateIDOnWriterSide, err := translateID(p, wdk.CertificateEntityName, chunkField.CertificateID)
+	if err != nil {
+		return fmt.Errorf("failed to translate certificate ID %d: %w", chunkField.CertificateID, err)
+	}
+
+	isNew, err := p.repo.UpsertCertificateFieldForSync(p.ctx, &pkgentity.CertificateField{
+		CreatedAt:     chunkField.CreatedAt,
+		UpdatedAt:     chunkField.UpdatedAt,
+		UserID:        p.user.ID,
+		CertificateID: certificateIDOnWriterSide,
+		FieldName:     chunkField.FieldName,
+		FieldValue:    chunkField.FieldValue,
+		MasterKey:     string(chunkField.MasterKey),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to upsert certificate field %q for certificate ID %d: %w", chunkField.FieldName, chunkField.CertificateID, err)
+	}
+
+	// certificateField has no ID map (see wdk.SyncMapEntity comment).
+	p.incrementOperations(isNew)
+	err = p.updateSyncState(wdk.CertificateFieldEntityName, chunkField.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("failed to update sync state for certificate field %q: %w", chunkField.FieldName, err)
+	}
+
+	return nil
+}
+
+func (p *ChunkProcessor) upsertCommission(chunkCommission *wdk.TableCommission) error {
+	if p.chunk.User != nil && p.chunk.User.UserID != chunkCommission.UserID {
+		return fmt.Errorf("chunk commission user ID %d does not match chunk user ID %d", chunkCommission.UserID, p.chunk.User.UserID)
+	}
+
+	p.logger.DebugContext(p.ctx, "upserting commission",
+		logging.Number("commissionID", chunkCommission.CommissionID),
+		logging.Number("transactionID", chunkCommission.TransactionID),
+	)
+
+	transactionIDOnWriterSide, err := translateID(p, wdk.TransactionEntityName, chunkCommission.TransactionID)
+	if err != nil {
+		return fmt.Errorf("failed to translate transaction ID %d: %w", chunkCommission.TransactionID, err)
+	}
+
+	satoshis, err := to.UInt64(chunkCommission.Satoshis)
+	if err != nil {
+		return fmt.Errorf("failed to convert commission satoshis %d to uint64: %w", chunkCommission.Satoshis, err)
+	}
+
+	isNew, commissionID, err := p.repo.UpsertCommissionForSync(p.ctx, &pkgentity.Commission{
+		CreatedAt:     chunkCommission.CreatedAt,
+		UpdatedAt:     chunkCommission.UpdatedAt,
+		UserID:        p.user.ID,
+		TransactionID: transactionIDOnWriterSide,
+		Satoshis:      satoshis,
+		KeyOffset:     chunkCommission.KeyOffset,
+		IsRedeemed:    chunkCommission.IsRedeemed,
+		LockingScript: []byte(chunkCommission.LockingScript),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to upsert commission for transaction ID %d: %w", chunkCommission.TransactionID, err)
+	}
+
+	readerID, err := to.IntFromUnsigned(chunkCommission.CommissionID)
+	if err != nil {
+		return fmt.Errorf("failed to convert commission ID %d to int: %w", chunkCommission.CommissionID, err)
+	}
+
+	p.incrementOperations(isNew)
+	err = p.updateSyncState(wdk.CommissionEntityName, chunkCommission.UpdatedAt, idDictionary{
+		readerID: readerID,
+		writerID: commissionID,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update sync state for commission %d: %w", chunkCommission.CommissionID, err)
+	}
+
+	return nil
+}
+
 func (p *ChunkProcessor) incrementOperations(isCreateOperation bool) {
 	if isCreateOperation {
 		p.result.Inserts++
@@ -708,7 +864,10 @@ func (p *ChunkProcessor) emptyChunk() bool {
 		len(p.chunk.TxLabels) == 0 &&
 		len(p.chunk.TxLabelMaps) == 0 &&
 		len(p.chunk.OutputTags) == 0 &&
-		len(p.chunk.OutputTagMaps) == 0
+		len(p.chunk.OutputTagMaps) == 0 &&
+		len(p.chunk.Certificates) == 0 &&
+		len(p.chunk.CertificateFields) == 0 &&
+		len(p.chunk.Commissions) == 0
 }
 
 func (p *ChunkProcessor) getBasketNameByNumID(basketNumID uint) (string, error) {

--- a/pkg/storage/internal/sync/chunker_certificates.go
+++ b/pkg/storage/internal/sync/chunker_certificates.go
@@ -1,0 +1,98 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-softwarelab/common/pkg/must"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/queryopts"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+)
+
+type chunkerCertificates struct {
+	repo Repository
+}
+
+func newChunkerCertificates(repo Repository) *chunkerCertificates {
+	return &chunkerCertificates{
+		repo: repo,
+	}
+}
+
+func (c *chunkerCertificates) Name() string {
+	return "certificates"
+}
+
+func (c *chunkerCertificates) MaxPageSize() uint64 {
+	return maximumAvailablePageSize
+}
+
+func (c *chunkerCertificates) IsApplicable(requestedEntities OffsetsLookup) bool {
+	_, ok := requestedEntities[wdk.CertificateEntityName]
+	return ok
+}
+
+func (c *chunkerCertificates) FirstPage(offsetsLookup OffsetsLookup) *queryopts.Paging {
+	offset := offsetsLookup[wdk.CertificateEntityName]
+	return &queryopts.Paging{
+		Offset: must.ConvertToIntFromUnsigned(offset),
+	}
+}
+
+func (c *chunkerCertificates) Process(ctx context.Context, userID int, page *queryopts.Paging, since *time.Time, result *wdk.SyncChunk) (num uint64, err error) {
+	opts := chunkerQueryOptions(page, since)
+
+	rows, err := c.repo.FindCertificatesForSync(ctx, userID, opts...)
+	if err != nil {
+		return 0, fmt.Errorf("fetch certificates by user id: %w", err)
+	}
+
+	result.Certificates = append(result.Certificates, rows...)
+
+	return must.ConvertToUInt64(len(rows)), nil
+}
+
+type chunkerCertificateFields struct {
+	repo Repository
+}
+
+func newChunkerCertificateFields(repo Repository) *chunkerCertificateFields {
+	return &chunkerCertificateFields{
+		repo: repo,
+	}
+}
+
+func (c *chunkerCertificateFields) Name() string {
+	return "certificate_fields"
+}
+
+func (c *chunkerCertificateFields) MaxPageSize() uint64 {
+	return maximumAvailablePageSize
+}
+
+func (c *chunkerCertificateFields) IsApplicable(requestedEntities OffsetsLookup) bool {
+	_, ok := requestedEntities[wdk.CertificateFieldEntityName]
+	return ok
+}
+
+func (c *chunkerCertificateFields) FirstPage(offsetsLookup OffsetsLookup) *queryopts.Paging {
+	offset := offsetsLookup[wdk.CertificateFieldEntityName]
+	return &queryopts.Paging{
+		Offset: must.ConvertToIntFromUnsigned(offset),
+	}
+}
+
+func (c *chunkerCertificateFields) Process(ctx context.Context, userID int, page *queryopts.Paging, since *time.Time, result *wdk.SyncChunk) (num uint64, err error) {
+	opts := chunkerQueryOptions(page, since)
+
+	rows, err := c.repo.FindCertificateFieldsForSync(ctx, userID, opts...)
+	if err != nil {
+		return 0, fmt.Errorf("fetch certificate fields by user id: %w", err)
+	}
+
+	result.CertificateFields = append(result.CertificateFields, rows...)
+
+	return must.ConvertToUInt64(len(rows)), nil
+}

--- a/pkg/storage/internal/sync/chunker_commissions.go
+++ b/pkg/storage/internal/sync/chunker_commissions.go
@@ -1,0 +1,55 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-softwarelab/common/pkg/must"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/queryopts"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+)
+
+type chunkerCommissions struct {
+	repo Repository
+}
+
+func newChunkerCommissions(repo Repository) *chunkerCommissions {
+	return &chunkerCommissions{
+		repo: repo,
+	}
+}
+
+func (c *chunkerCommissions) Name() string {
+	return "commissions"
+}
+
+func (c *chunkerCommissions) MaxPageSize() uint64 {
+	return maximumAvailablePageSize
+}
+
+func (c *chunkerCommissions) IsApplicable(requestedEntities OffsetsLookup) bool {
+	_, ok := requestedEntities[wdk.CommissionEntityName]
+	return ok
+}
+
+func (c *chunkerCommissions) FirstPage(offsetsLookup OffsetsLookup) *queryopts.Paging {
+	offset := offsetsLookup[wdk.CommissionEntityName]
+	return &queryopts.Paging{
+		Offset: must.ConvertToIntFromUnsigned(offset),
+	}
+}
+
+func (c *chunkerCommissions) Process(ctx context.Context, userID int, page *queryopts.Paging, since *time.Time, result *wdk.SyncChunk) (num uint64, err error) {
+	opts := chunkerQueryOptions(page, since)
+
+	rows, err := c.repo.FindCommissionsForSync(ctx, userID, opts...)
+	if err != nil {
+		return 0, fmt.Errorf("fetch commissions by user id: %w", err)
+	}
+
+	result.Commissions = append(result.Commissions, rows...)
+
+	return must.ConvertToUInt64(len(rows)), nil
+}

--- a/pkg/storage/internal/sync/chunkers.go
+++ b/pkg/storage/internal/sync/chunkers.go
@@ -10,5 +10,8 @@ func all(repo Repository) []Chunker {
 		newChunkerLabelsMap(repo),
 		newChunkerTags(repo),
 		newChunkerTagsMap(repo),
+		newChunkerCertificates(repo),
+		newChunkerCertificateFields(repo),
+		newChunkerCommissions(repo),
 	}
 }

--- a/pkg/storage/internal/sync/repos.interface.go
+++ b/pkg/storage/internal/sync/repos.interface.go
@@ -46,4 +46,13 @@ type Repository interface {
 	FindTagByNumIDForSync(ctx context.Context, labelNumID uint) (*entity.Tag, error)
 	DeleteTagMapForSync(ctx context.Context, entity *entity.TagMap) (deleted bool, err error)
 	UpsertTagMapForSync(ctx context.Context, entity *entity.TagMap) (isNew bool, err error)
+
+	FindCertificatesForSync(ctx context.Context, userID int, opts ...queryopts.Options) ([]*wdk.TableCertificate, error)
+	UpsertCertificateForSync(ctx context.Context, entity *pkgentity.Certificate) (isNew bool, certificateID uint, err error)
+
+	FindCertificateFieldsForSync(ctx context.Context, userID int, opts ...queryopts.Options) ([]*wdk.TableCertificateField, error)
+	UpsertCertificateFieldForSync(ctx context.Context, entity *pkgentity.CertificateField) (isNew bool, err error)
+
+	FindCommissionsForSync(ctx context.Context, userID int, opts ...queryopts.Options) ([]*wdk.TableCommission, error)
+	UpsertCommissionForSync(ctx context.Context, entity *pkgentity.Commission) (isNew bool, commissionID uint, err error)
 }

--- a/pkg/storage/internal/testabilities/assertions_sync_chunk.go
+++ b/pkg/storage/internal/testabilities/assertions_sync_chunk.go
@@ -173,6 +173,9 @@ func (s *syncChunkAssertion) AllCountZero() ValidSyncChunkAssertion {
 	s.LabelsMapCount(0)
 	s.TagsCount(0)
 	s.TagsMapCount(0)
+	require.Empty(s, s.chunk.Certificates)
+	require.Empty(s, s.chunk.CertificateFields)
+	require.Empty(s, s.chunk.Commissions)
 	return s
 }
 

--- a/pkg/storage/provider_get_sync_chunk_test.go
+++ b/pkg/storage/provider_get_sync_chunk_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-softwarelab/common/pkg/to"
+	"github.com/stretchr/testify/require"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
@@ -118,7 +119,11 @@ func TestGetSyncChunk(t *testing.T) {
 		WithOutputTag(chunk.Outputs[10].OutputID, fixtures.CreateActionTestTag, fixtures.FaucetTag(1)).
 		WithOutputTag(chunk.Outputs[11].OutputID, fixtures.CreateActionTestTag, fixtures.FaucetTag(0))
 
-	// TODO: Remember to add more assertions for other entities when implemented
+	// certificates / certificate fields / commissions are empty in this seed
+	// (no certs or commissions created by OwnsTransaction fixtures).
+	require.Empty(t, chunk.Certificates)
+	require.Empty(t, chunk.CertificateFields)
+	require.Empty(t, chunk.Commissions)
 }
 
 func TestGetSyncChunkNoOffsets(t *testing.T) {

--- a/pkg/storage/provider_sync_cert_commission_test.go
+++ b/pkg/storage/provider_sync_cert_commission_test.go
@@ -1,0 +1,91 @@
+package storage_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/storage/internal/testabilities"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk/primitives"
+)
+
+// TestGetSyncChunk_CertificatesAndFields verifies getSyncChunk returns certificate
+// entities that were previously inserted (issue #850).
+func TestGetSyncChunk_CertificatesAndFields(t *testing.T) {
+	given, then, cleanup := testabilities.NewSync(t)
+	defer cleanup()
+
+	givenProvider := given.Provider()
+	activeStorage := givenProvider.GORM()
+
+	// Seed a certificate with one field for Alice.
+	certToInsert := fixtures.DefaultInsertCertAuth(testusers.Alice.ID, primitives.PubKeyHex(testusers.Alice.PubKey(t)))
+	certID, err := activeStorage.InsertCertificateAuth(t.Context(), testusers.Alice.AuthID(), certToInsert)
+	require.NoError(t, err)
+	require.NotZero(t, certID)
+
+	args := given.RequestSyncChunk(testusers.Alice).Args()
+
+	chunk, err := activeStorage.GetSyncChunk(t.Context(), args)
+	thenChunk := then.Chunk(chunk).WithoutError(err)
+	thenChunk.WithGeneralInfo(&args)
+
+	require.Len(t, chunk.Certificates, 1)
+	require.Equal(t, certID, chunk.Certificates[0].CertificateID)
+	require.Equal(t, fixtures.SerialNumber, string(chunk.Certificates[0].SerialNumber))
+	require.Equal(t, fixtures.Certifier, string(chunk.Certificates[0].Certifier))
+	require.False(t, chunk.Certificates[0].IsDeleted)
+
+	require.Len(t, chunk.CertificateFields, 1)
+	require.Equal(t, certID, chunk.CertificateFields[0].CertificateID)
+	require.Equal(t, "exampleField", chunk.CertificateFields[0].FieldName)
+	require.Equal(t, "exampleValue", chunk.CertificateFields[0].FieldValue)
+}
+
+// TestSyncProcess_CertificatesAndFields verifies certificates and fields survive
+// SyncToWriter end-to-end (processSyncChunk path of issue #850). Soft-delete
+// merge is covered by syncrepo unit tests (TestUpsertCertificateForSync_*).
+func TestSyncProcess_CertificatesAndFields(t *testing.T) {
+	givenSourceDB, cleanup := testabilities.GivenSyncFixture(t)
+	defer cleanup()
+
+	sourceProvider := givenSourceDB.Provider().GORM()
+	sourceStorageManager := givenSourceDB.StorageManagerForUser(testusers.Alice, sourceProvider)
+
+	// Seed certificate on source.
+	certToInsert := fixtures.DefaultInsertCertAuth(testusers.Alice.ID, primitives.PubKeyHex(testusers.Alice.PubKey(t)))
+	sourceCertID, err := sourceProvider.InsertCertificateAuth(t.Context(), testusers.Alice.AuthID(), certToInsert)
+	require.NoError(t, err)
+	require.NotZero(t, sourceCertID)
+
+	// Backup storage (empty).
+	givenBackupDB, cleanup := testabilities.GivenCustomStorage(t, fixtures.SecondStorageServerPrivKey, fixtures.SecondStorageName)
+	defer cleanup()
+	backupProvider := givenBackupDB.Provider().GORMWithCleanDatabase()
+
+	_, err = sourceStorageManager.MakeAvailable(t.Context())
+	require.NoError(t, err)
+
+	inserts, updates, err := sourceStorageManager.SyncToWriter(t.Context(), backupProvider)
+	require.NoError(t, err)
+	assert.Greater(t, inserts, 0)
+	_ = updates
+
+	// Verify certificate landed on backup via ListCertificates.
+	result, err := backupProvider.ListCertificates(t.Context(), testusers.Alice.AuthID(), wdk.ListCertificatesArgs{})
+	require.NoError(t, err)
+	require.Equal(t, primitives.PositiveInteger(1), result.TotalCertificates)
+	require.Len(t, result.Certificates, 1)
+	require.Equal(t, fixtures.SerialNumber, string(result.Certificates[0].SerialNumber))
+	require.Equal(t, fixtures.Certifier, string(result.Certificates[0].Certifier))
+	require.Equal(t, "exampleValue", result.Certificates[0].Fields[primitives.StringUnder50Bytes("exampleField")])
+
+	// Second sync should be a no-op (or only minor updates), not re-insert the cert.
+	inserts2, _, err := sourceStorageManager.SyncToWriter(t.Context(), backupProvider)
+	require.NoError(t, err)
+	assert.Equal(t, 0, inserts2)
+}


### PR DESCRIPTION
## Summary

Fixes #850 — `processSyncChunk` and `getSyncChunk` previously handled 9 of 12 `SyncChunk` entity arrays and silently dropped `certificates`, `certificateFields`, and `commissions`.

This PR implements full sync support for those three entities, following existing patterns (e.g. labels/tags/transactions):

- **syncrepo**: `Find*ForSync` + `Upsert*ForSync` for certificates, certificate fields, and commissions with BRC-40 stale-chunk guards (`incoming.updated_at > existing.updated_at`)
- **chunk_processor**: Process branches, ID-map handling (certificate + commission; certificateField has no ID map per `wdk.SyncMapEntity`), `emptyChunk` updates
- **chunkers**: registered for getSyncChunk responses; request-offset fixtures include the three entities
- **relinquish**: bumps `updated_at` on soft-delete so since-filter can surface deleted certificates on subsequent syncs

## Test plan

- [x] `go test ./pkg/internal/storage/repo/syncrepo/ -count=1` (create/update/stale-skip + soft-delete for cert; field + commission paths)
- [x] `go test ./pkg/storage/ -run 'TestGetSyncChunk|TestSyncProcess_Certificates|TestInsertCertificate|TestListCertificates' -count=1`
- [x] Integration: getSyncChunk returns inserted certs/fields; SyncToWriter copies certs+fields to backup storage