### PR TITLE
fix: broadcast unknown txs on internalizeAction (#818)

### DIFF
--- a/pkg/storage/internal/actions/actions.go
+++ b/pkg/storage/internal/actions/actions.go
@@ -81,7 +81,7 @@ func New(
 			beefVerifier,
 			scriptsVerifier,
 			services,
-			processAction.backgroundBroadcaster,
+			processAction,
 		),
 		process:               processAction,
 		listOutputs:           newListOutputs(logger, repos.Outputs, repos.KnownTx, repos.Transactions),

--- a/pkg/storage/internal/actions/internalize.go
+++ b/pkg/storage/internal/actions/internalize.go
@@ -18,7 +18,6 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/history"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/txutils"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/logging"
-	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/storage/internal/service"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/tracing"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk/primitives"
@@ -31,17 +30,18 @@ type OutputToInternalize struct {
 }
 
 type internalize struct {
-	logger                *slog.Logger
-	txRepo                TransactionsRepo
-	basketRepo            BasketRepo
-	knownTxRepo           KnownTxRepo
-	outputRepo            OutputRepo
-	random                wdk.Randomizer
-	beefVerifier          wdk.BeefVerifier
-	scriptsVerifier       wdk.ScriptsVerifier
-	blockHeaderService    wdk.BlockHeaderLoader
-	backgroundBroadcaster *service.BackgroundBroadcaster
-	uow                   UnitOfWork
+	logger             *slog.Logger
+	txRepo             TransactionsRepo
+	basketRepo         BasketRepo
+	knownTxRepo        KnownTxRepo
+	outputRepo         OutputRepo
+	random             wdk.Randomizer
+	beefVerifier       wdk.BeefVerifier
+	scriptsVerifier    wdk.ScriptsVerifier
+	blockHeaderService wdk.BlockHeaderLoader
+	// process is used to reuse ProcessAction's broadcast path (broadcastTxs) for unknown unproven txs.
+	process *process
+	uow     UnitOfWork
 }
 
 func newInternalizeAction(
@@ -55,21 +55,21 @@ func newInternalizeAction(
 	beefVerifier wdk.BeefVerifier,
 	scriptsVerifier wdk.ScriptsVerifier,
 	blockHeader wdk.BlockHeaderLoader,
-	backgroundBroadcaster *service.BackgroundBroadcaster,
+	processAction *process,
 ) *internalize {
 	logger = logging.Child(logger, "internalizeAction")
 	return &internalize{
-		logger:                logger,
-		txRepo:                txRepo,
-		basketRepo:            basketRepo,
-		knownTxRepo:           knownTxRepo,
-		outputRepo:            outputRepo,
-		uow:                   uow,
-		random:                random,
-		beefVerifier:          beefVerifier,
-		scriptsVerifier:       scriptsVerifier,
-		blockHeaderService:    blockHeader,
-		backgroundBroadcaster: backgroundBroadcaster,
+		logger:             logger,
+		txRepo:             txRepo,
+		basketRepo:         basketRepo,
+		knownTxRepo:        knownTxRepo,
+		outputRepo:         outputRepo,
+		uow:                uow,
+		random:             random,
+		beefVerifier:       beefVerifier,
+		scriptsVerifier:    scriptsVerifier,
+		blockHeaderService: blockHeader,
+		process:            processAction,
 	}
 }
 
@@ -157,6 +157,7 @@ func (in *internalize) Internalize(ctx context.Context, userID int, args *wdk.In
 	var outputs []*OutputToInternalize
 	var cumulativeSatoshis satoshi.Value
 	var isMerge bool
+	var shouldBroadcast bool
 
 	err = in.uow.Do(ctx, func(txCtx context.Context, repos Providers) error {
 		var uowErr error
@@ -243,7 +244,7 @@ func (in *internalize) Internalize(ctx context.Context, userID int, args *wdk.In
 				slog.String("description", string(args.Description)),
 			)
 
-			uowErr = in.storeNewTx(txCtx, userID, args, txID, tx, cumulativeSatoshis, outputs, beef, repos)
+			shouldBroadcast, uowErr = in.storeNewTx(txCtx, userID, args, txID, tx, cumulativeSatoshis, outputs, repos)
 			if uowErr != nil {
 				return fmt.Errorf("failed to store new transaction: %w", uowErr)
 			}
@@ -252,6 +253,7 @@ func (in *internalize) Internalize(ctx context.Context, userID int, args *wdk.In
 				txCtx, "New transaction stored successfully",
 				logging.UserID(userID),
 				slog.String("txID", txID),
+				slog.Bool("shouldBroadcast", shouldBroadcast),
 				slog.String("description", string(args.Description)),
 			)
 		}
@@ -273,6 +275,47 @@ func (in *internalize) Internalize(ctx context.Context, userID int, args *wdk.In
 		}
 	}
 
+	result := &wdk.InternalizeActionResult{
+		Accepted: true,
+		IsMerge:  isMerge,
+		TxID:     txID,
+		Satoshis: cumulativeSatoshis.Int64(),
+	}
+
+	// Broadcast unknown unproven txs immediately via ProcessAction's BackgroundBroadcast path
+	// (same post + status apply as delayed/monitor workers), matching TypeScript shareReqsWithWorld.
+	// Uses the already-verified request BEEF rather than rebuilding from KnownTx so partial/shared
+	// KnownTx rows (e.g. another user's in-flight send with incomplete raw bytes) cannot corrupt
+	// the post. Soft outcomes populate SendWithResults / NotDelayedResults; hard errors leave the
+	// tx for SendWaitingTransactions without rejecting the internalize.
+	if shouldBroadcast && in.process != nil {
+		in.logger.DebugContext(
+			ctx, "Broadcasting newly internalized unproven transaction",
+			logging.UserID(userID),
+			slog.String("txID", txID),
+		)
+
+		var reviewResults []wdk.ReviewActionResult
+		reviewResults, err = in.process.BackgroundBroadcast(ctx, beef, []string{txID})
+		if err != nil {
+			in.logger.WarnContext(
+				ctx, "broadcast after internalize failed; leaving tx for monitor retry",
+				logging.UserID(userID),
+				slog.String("txID", txID),
+				slog.String("error", err.Error()),
+			)
+			// Surface that a send was attempted so callers can observe in-flight status.
+			result.SendWithResults = []wdk.SendWithResult{{
+				TxID:   primitives.TXIDHexString(txID),
+				Status: wdk.SendWithResultStatusSending,
+			}}
+			err = nil
+		} else {
+			result.NotDelayedResults = reviewResults
+			result.SendWithResults = sendWithResultsFromReview(reviewResults)
+		}
+	}
+
 	in.logger.DebugContext(
 		ctx, "InternalizeAction completed successfully",
 		logging.UserID(userID),
@@ -280,15 +323,12 @@ func (in *internalize) Internalize(ctx context.Context, userID int, args *wdk.In
 		slog.Bool("accepted", true),
 		slog.Bool("isMerge", isMerge),
 		logging.Number("satoshis", cumulativeSatoshis),
+		slog.Int("sendWithResultsCount", len(result.SendWithResults)),
+		slog.Int("notDelayedResultsCount", len(result.NotDelayedResults)),
 		slog.String("description", string(args.Description)),
 	)
 
-	return &wdk.InternalizeActionResult{
-		Accepted: true,
-		IsMerge:  isMerge,
-		TxID:     txID,
-		Satoshis: cumulativeSatoshis.Int64(),
-	}, nil
+	return result, nil
 }
 
 func (in *internalize) updateKnownTxAsMined(ctx context.Context, userID int, txID string, tx *transaction.Transaction) error {
@@ -398,6 +438,10 @@ func (in *internalize) upsertExistingTx(ctx context.Context, existingTx *pkgenti
 	return nil
 }
 
+// storeNewTx persists a newly internalized transaction.
+// It returns shouldBroadcast=true when the tx is unknown/unproven (no mining proof and no prior
+// network-acceptance evidence) so the caller can broadcast via ProcessAction's path and surface
+// SendWithResults / NotDelayedResults on the InternalizeActionResult.
 func (in *internalize) storeNewTx(
 	ctx context.Context,
 	userID int,
@@ -406,15 +450,14 @@ func (in *internalize) storeNewTx(
 	tx *transaction.Transaction,
 	cumulativeSatoshis satoshi.Value,
 	outputs []*OutputToInternalize,
-	beef *transaction.Beef,
 	repos Providers,
-) error {
+) (shouldBroadcast bool, err error) {
 	isMined := tx.MerklePath != nil
 
 	// check if transaction already exists in DB with a confirmed broadcast status
 	statuses, err := repos.KnownTxRepo().FindKnownTxStatuses(ctx, txID)
 	if err != nil {
-		return fmt.Errorf("failed to find existing known tx status: %w", err)
+		return false, fmt.Errorf("failed to find existing known tx status: %w", err)
 	}
 
 	alreadySent := false
@@ -427,13 +470,17 @@ func (in *internalize) storeNewTx(
 	knownTxStatus := wdk.ProvenTxStatusUnsent
 	txStatus := wdk.TxStatusSending
 	utxoStatus := wdk.UTXOStatusSending
-	shouldPushToBroadcaster := true
-
+	// Broadcast only truly unknown unproven txs. Skip when the network already accepted the
+	// tx, it is mined, or another path already has an in-flight broadcast (Sending/Unsent/…).
+	shouldBroadcast = true
 	if isMined || alreadySent {
 		knownTxStatus = wdk.ProvenTxStatusUnmined
 		txStatus = wdk.TxStatusUnproven
 		utxoStatus = wdk.UTXOStatusUnproven
-		shouldPushToBroadcaster = false
+		shouldBroadcast = false
+	} else if existingStatus, ok := statuses[txID]; ok && existingStatus.IsInFlight() {
+		// KnownTx already tracked as in-flight by another user/path — do not re-broadcast.
+		shouldBroadcast = false
 	}
 
 	skipForStatuses := []wdk.ProvenTxReqStatus{wdk.ProvenTxStatusCompleted}
@@ -451,12 +498,12 @@ func (in *internalize) storeNewTx(
 		SkipForStatuses: skipForStatuses,
 	}, history.NewBuilder().InternalizeAction(userID))
 	if err != nil {
-		return fmt.Errorf("failed to upsert known tx: %w", err)
+		return false, fmt.Errorf("failed to upsert known tx: %w", err)
 	}
 
 	reference, err := in.random.Base64(referenceLength)
 	if err != nil {
-		return fmt.Errorf("failed to generate random reference: %w", err)
+		return false, fmt.Errorf("failed to generate random reference: %w", err)
 	}
 
 	err = repos.TransactionsRepo().CreateTransaction(ctx, &entity.NewTx{
@@ -476,19 +523,10 @@ func (in *internalize) storeNewTx(
 		Labels: args.Labels,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create transaction: %w", err)
+		return false, fmt.Errorf("failed to create transaction: %w", err)
 	}
 
-	if shouldPushToBroadcaster && in.backgroundBroadcaster != nil {
-		in.logger.DebugContext(
-			ctx, "Pushing unmined internalized tx to background broadcaster",
-			logging.UserID(userID),
-			slog.String("txID", txID),
-		)
-		in.backgroundBroadcaster.Add(beef, []string{txID})
-	}
-
-	return nil
+	return shouldBroadcast, nil
 }
 
 func (in *internalize) makeOutputs(
@@ -642,4 +680,25 @@ func (in *internalize) utxoStatusByTxStatusForMerge(txStatus wdk.TxStatus) (wdk.
 	default:
 		return "", fmt.Errorf("unsupported transaction status for UTXO: %s", txStatus)
 	}
+}
+
+// sendWithResultsFromReview maps ProcessAction / BackgroundBroadcast review results to the
+// SendWithResult statuses callers expect on InternalizeActionResult (and ProcessActionResult).
+func sendWithResultsFromReview(review []wdk.ReviewActionResult) []wdk.SendWithResult {
+	out := make([]wdk.SendWithResult, 0, len(review))
+	for _, r := range review {
+		sw := wdk.SendWithResult{TxID: r.TxID}
+		switch r.Status {
+		case wdk.ReviewActionResultStatusSuccess:
+			sw.Status = wdk.SendWithResultStatusUnproven
+		case wdk.ReviewActionResultStatusServiceError:
+			sw.Status = wdk.SendWithResultStatusSending
+		case wdk.ReviewActionResultStatusDoubleSpend, wdk.ReviewActionResultStatusInvalidTx:
+			sw.Status = wdk.SendWithResultStatusFailed
+		default:
+			sw.Status = wdk.SendWithResultStatusSending
+		}
+		out = append(out, sw)
+	}
+	return out
 }

--- a/pkg/storage/internal/integrationtests/internalize_create_process_test.go
+++ b/pkg/storage/internal/integrationtests/internalize_create_process_test.go
@@ -79,11 +79,24 @@ func TestInternalizeThenCreateThenProcess(t *testing.T) {
 		// then:
 		require.NoError(t, err)
 
+		// Unknown unproven internalize broadcasts immediately and surfaces send/review fields
+		// (issue #818 / TS shareReqsWithWorld). Exact reference string is from TestRandomizer.
 		require.JSONEq(t, `{
 		  "accepted": true,
 		  "isMerge": false,
 		  "txid": "756754d5ad8f00e05c36d89a852971c0a1dc0c10f20cd7840ead347aff475ef6",
-		  "satoshis": 99904
+		  "satoshis": 99904,
+		  "sendWithResults": [
+		    {"txid": "756754d5ad8f00e05c36d89a852971c0a1dc0c10f20cd7840ead347aff475ef6", "status": "unproven"}
+		  ],
+		  "notDelayedResults": [
+		    {
+		      "txid": "756754d5ad8f00e05c36d89a852971c0a1dc0c10f20cd7840ead347aff475ef6",
+		      "status": "success",
+		      "reference": "YWFhYWFhYWFhYWFh",
+		      "labels": ["label1", "label2"]
+		    }
+		  ]
 		}`, string(resultJSON))
 	})
 

--- a/pkg/storage/provider_internalize_action_test.go
+++ b/pkg/storage/provider_internalize_action_test.go
@@ -64,9 +64,11 @@ func TestInternalizeAction_UpdateKnownTxAsMined_HappyPath(t *testing.T) {
 	// then:
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, actualResult)
+	// Mined txs are not re-broadcast: no send/review result fields.
+	assert.Empty(t, actualResult.SendWithResults)
+	assert.Empty(t, actualResult.NotDelayedResults)
 
 	// and db state:
-	time.Sleep(200 * time.Millisecond) // wait for background broadcaster
 	thenDBState := testabilities.ThenDBState(t, activeStorage)
 	thenDBState.HasKnownTX(txID.String()).WithBlockHash(to.Ptr(pkgtestabilities.TestBlockHash))
 }
@@ -110,12 +112,20 @@ func TestInternalizeActionWalletPaymentHappyPath(t *testing.T) {
 	assert.Equal(t, int64(fixtures.ExpectedValueToInternalize), result.Satoshis)
 	assert.Equal(t, "03895fb984362a4196bc9931629318fcbb2aeba7c6293638119ea653fa31d119", result.TxID)
 
+	// Immediate broadcast via ProcessAction path surfaces send/review results (TS shareReqsWithWorld).
+	require.Len(t, result.SendWithResults, 1)
+	assert.Equal(t, result.TxID, string(result.SendWithResults[0].TxID))
+	assert.Equal(t, wdk.SendWithResultStatusUnproven, result.SendWithResults[0].Status)
+	require.Len(t, result.NotDelayedResults, 1)
+	assert.Equal(t, result.TxID, string(result.NotDelayedResults[0].TxID))
+	assert.Equal(t, wdk.ReviewActionResultStatusSuccess, result.NotDelayedResults[0].Status)
+
 	// and db state:
-	time.Sleep(200 * time.Millisecond) // wait for background broadcaster
 	thenDBState := testabilities.ThenDBState(t, activeStorage)
 	thenDBState.HasKnownTX(result.TxID).
 		NotMined().
 		WithStatus(wdk.ProvenTxStatusUnmined).
+		WithAttempts(1).
 		TxNotes(func(then testabilities.TxNotesAssertion) {
 			then.
 				Count(4).
@@ -153,12 +163,17 @@ func TestInternalizeActionBasketInsertionHappyPath(t *testing.T) {
 	assert.Equal(t, int64(0), result.Satoshis)
 	assert.Equal(t, "03895fb984362a4196bc9931629318fcbb2aeba7c6293638119ea653fa31d119", result.TxID)
 
+	require.Len(t, result.SendWithResults, 1)
+	assert.Equal(t, wdk.SendWithResultStatusUnproven, result.SendWithResults[0].Status)
+	require.Len(t, result.NotDelayedResults, 1)
+	assert.Equal(t, wdk.ReviewActionResultStatusSuccess, result.NotDelayedResults[0].Status)
+
 	// and db state:
-	time.Sleep(200 * time.Millisecond) // wait for background broadcaster
 	thenDBState := testabilities.ThenDBState(t, activeStorage)
 	thenDBState.HasKnownTX(result.TxID).
 		NotMined().
 		WithStatus(wdk.ProvenTxStatusUnmined).
+		WithAttempts(1).
 		TxNotes(func(then testabilities.TxNotesAssertion) {
 			then.
 				Count(4).
@@ -211,7 +226,6 @@ func TestInternalizeActionErrorCases(t *testing.T) {
 			require.Error(t, err)
 
 			// and db state:
-			time.Sleep(200 * time.Millisecond) // wait for background broadcaster
 			thenDBState := testabilities.ThenDBState(t, activeStorage)
 			thenDBState.AllOutputs(testusers.Alice).WithCount(0)
 		})
@@ -249,7 +263,6 @@ func TestInternalizeActionForAlreadyStoredTransaction(t *testing.T) {
 		assert.Equal(t, int64(0), result.Satoshis)
 
 		// and db state:
-		time.Sleep(200 * time.Millisecond) // wait for background broadcaster
 		thenDBState := testabilities.ThenDBState(t, activeStorage)
 		thenDBState.HasKnownTX(result.TxID).
 			NotMined().
@@ -324,9 +337,7 @@ func TestInternalizeActionForAlreadyStoredTransaction(t *testing.T) {
 		assert.True(t, result.IsMerge)
 		assert.Equal(t, int64(0), result.Satoshis)
 
-		time.Sleep(200 * time.Millisecond) // wait for background broadcaster
 		// and db state:
-		time.Sleep(200 * time.Millisecond) // wait for background broadcaster
 		thenDBState := testabilities.ThenDBState(t, activeStorage)
 		thenDBState.HasKnownTX(result.TxID).
 			NotMined().
@@ -376,7 +387,6 @@ func TestInternalizeActionForAlreadyStoredTransaction(t *testing.T) {
 		assert.Equal(t, int64(-alreadyOwnedSatoshis), result.Satoshis)
 
 		// and db state:
-		time.Sleep(200 * time.Millisecond) // wait for background broadcaster
 		thenDBState := testabilities.ThenDBState(t, activeStorage)
 		thenDBState.HasKnownTX(result.TxID).
 			NotMined().
@@ -441,7 +451,6 @@ func TestInternalizeActionForAlreadyStoredTransaction(t *testing.T) {
 		assert.Equal(t, int64(fixtures.DefaultCreateActionOutputSatoshis), result.Satoshis)
 
 		// and db state:
-		time.Sleep(200 * time.Millisecond) // wait for background broadcaster
 		thenDBState := testabilities.ThenDBState(t, activeStorage)
 		thenDBState.HasKnownTX(result.TxID).
 			NotMined().
@@ -484,7 +493,6 @@ func TestInternalizeActionForAlreadyStoredTransaction(t *testing.T) {
 		require.NoError(t, err)
 
 		// and db state:
-		time.Sleep(200 * time.Millisecond) // wait for background broadcaster
 		thenDBState := testabilities.ThenDBState(t, activeStorage)
 		thenDBState.HasUserTransactionByReference(testusers.Alice, fixtures.FaucetReference(ownedTxSpec.ID().String())).
 			WithLabels(initialLabel, labelToAdd)
@@ -555,7 +563,6 @@ func TestInternalizeTheSameTxByDifferentUsers(t *testing.T) {
 	assert.Equal(t, int64(0), result.Satoshis)
 
 	// and db state:
-	time.Sleep(200 * time.Millisecond) // wait for background broadcaster
 	thenDBState := testabilities.ThenDBState(t, activeStorage)
 	thenDBState.HasKnownTX(result.TxID).
 		NotMined().
@@ -571,11 +578,9 @@ func TestInternalizeTheSameTxByDifferentUsers(t *testing.T) {
 // accepts it. Because AlreadySent(reorg)=false now, storeNewTx takes the fresh-tx branch
 // (re-queued for broadcast) rather than flipping the KnownTx to unmined-without-evidence.
 //
-// The background broadcaster is held for the duration of the assertions so we observe the
-// deterministic synchronous storeNewTx write (BackgroundBroadcast posts to ARC before any
-// DB write, so holding the ARC POST freezes the state). Under the OLD semantics this branch
-// would set knownTxStatus=unmined + txStatus=unproven with NO broadcast queued; under the
-// corrected semantics it sets knownTxStatus=unsent + txStatus=sending and queues a re-broadcast.
+// Internalize now broadcasts synchronously via ProcessAction's path. ARC POST is held so
+// InternalizeAction blocks after storeNewTx commits, letting us assert the intermediate
+// unsent/sending state before the broadcast mutates KnownTx.
 func TestInternalizeAction_ReorgedKnownTx_DoesNotClaimNetworkAcceptance(t *testing.T) {
 	given, cleanup := testabilities.Given(t)
 	defer cleanup()
@@ -610,36 +615,56 @@ func TestInternalizeAction_ReorgedKnownTx_DoesNotClaimNetworkAcceptance(t *testi
 		NotMined().
 		WasBroadcast(true)
 
-	// and: hold the background broadcaster so the fresh-tx branch's synchronous DB write is
-	// observable before any post-broadcast mutation. Release before cleanup so the provider's
-	// broadcaster Stop() (which wg.Wait()s in-flight workers) does not hang.
+	// Hold ARC POST so storeNewTx's unsent write is observable before broadcast applies results.
+	// Ensure release on all exit paths (success, failure, timeout) — but only once.
 	givenProvider.ARC().HoldBroadcasting()
-	defer givenProvider.ARC().ReleaseBroadcasting()
+	released := false
+	releaseARC := func() {
+		if !released {
+			released = true
+			givenProvider.ARC().ReleaseBroadcasting()
+		}
+	}
+	defer releaseARC()
+
+	type internalizeOutcome struct {
+		result *wdk.InternalizeActionResult
+		err    error
+	}
+	done := make(chan internalizeOutcome, 1)
 
 	// when: a DIFFERENT user internalizes the same tx (fresh entry, not a merge).
-	result, err := activeStorage.InternalizeAction(
-		t.Context(),
-		testusers.Bob.AuthID(), // NOTE: different user -> storeNewTx path, not merge
-		wdk.InternalizeActionArgs{
-			Tx: txSpec.AtomicBEEF().Bytes(),
-			Outputs: []*wdk.InternalizeOutput{
-				{
-					OutputIndex: 0,
-					Protocol:    wdk.BasketInsertionProtocol,
-					InsertionRemittance: &wdk.BasketInsertion{
-						Basket: fixtures.CustomBasket,
+	// Runs in a goroutine because broadcast is now synchronous and will block on the ARC hold.
+	go func() {
+		result, internalizeErr := activeStorage.InternalizeAction(
+			t.Context(),
+			testusers.Bob.AuthID(), // NOTE: different user -> storeNewTx path, not merge
+			wdk.InternalizeActionArgs{
+				Tx: txSpec.AtomicBEEF().Bytes(),
+				Outputs: []*wdk.InternalizeOutput{
+					{
+						OutputIndex: 0,
+						Protocol:    wdk.BasketInsertionProtocol,
+						InsertionRemittance: &wdk.BasketInsertion{
+							Basket: fixtures.CustomBasket,
+						},
 					},
 				},
+				Description: "internalize reorged tx",
 			},
-			Description: "internalize reorged tx",
-		},
-	)
+		)
+		done <- internalizeOutcome{result: result, err: internalizeErr}
+	}()
 
-	// then: internalize is consistent (accepted, fresh entry).
-	require.NoError(t, err)
-	assert.True(t, result.Accepted)
-	assert.False(t, result.IsMerge)
-	assert.Equal(t, txID, result.TxID)
+	// Wait until storeNewTx has committed the fresh-send state (KnownTx=unsent or submitting/sending).
+	require.Eventually(t, func() bool {
+		found, findErr := activeStorage.KnownTxEntity().Read().TxID(txID).Find(t.Context())
+		if findErr != nil || len(found) == 0 {
+			return false
+		}
+		status := found[0].Status
+		return status == wdk.ProvenTxStatusUnsent || status == wdk.ProvenTxStatusSending
+	}, 5*time.Second, 20*time.Millisecond)
 
 	// and db state: the shared KnownTx is NOT flipped to unmined-without-evidence.
 	//
@@ -648,8 +673,13 @@ func TestInternalizeAction_ReorgedKnownTx_DoesNotClaimNetworkAcceptance(t *testi
 	// skipForStatuses={completed, unmined, sending, unsent}. reorg is not in that skip list,
 	// so upsertKnownTx rewrites the row to unsent (re-queued for broadcast). It stays NotMined
 	// and keeps was_broadcast=true so proof re-sync remains eligible.
+	//
+	// Status may already be "sending" if MarkKnownTxsAsSubmitting ran before we observe.
+	found, findErr := activeStorage.KnownTxEntity().Read().TxID(txID).Find(t.Context())
+	require.NoError(t, findErr)
+	require.NotEmpty(t, found)
+	assert.Contains(t, []wdk.ProvenTxReqStatus{wdk.ProvenTxStatusUnsent, wdk.ProvenTxStatusSending}, found[0].Status)
 	thenDBState.HasKnownTX(txID).
-		WithStatus(wdk.ProvenTxStatusUnsent).
 		NotMined().
 		WasBroadcast(true)
 
@@ -660,10 +690,103 @@ func TestInternalizeAction_ReorgedKnownTx_DoesNotClaimNetworkAcceptance(t *testi
 	// and: the internalized output landed for Bob.
 	thenDBState.AllOutputs(testusers.Bob).WithCountHavingTxID(1)
 
+	// Release broadcast and wait for InternalizeAction to finish.
+	releaseARC()
+	var outcome internalizeOutcome
+	select {
+	case outcome = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for InternalizeAction to complete after releasing ARC hold")
+	}
+
+	// then: internalize is consistent (accepted, fresh entry).
+	require.NoError(t, outcome.err)
+	require.NotNil(t, outcome.result)
+	assert.True(t, outcome.result.Accepted)
+	assert.False(t, outcome.result.IsMerge)
+	assert.Equal(t, txID, outcome.result.TxID)
+	// Broadcast was attempted after store — result fields present when soft-success.
+	require.NotEmpty(t, outcome.result.SendWithResults)
+
 	// NOTE (concern, out of W1-6 scope): a full AssertStorageInvariants is intentionally NOT
 	// gated here. HandleReorg nulls the KnownTx proof but leaves Alice's original user
 	// transaction at status=completed, which violates money-safety invariant #2 ("no completed
 	// user transaction without a merkle proof"). That gap is pre-existing in HandleReorg and is
 	// independent of W1-6 (it reproduces right after HandleReorg, before this internalize). It
 	// is reported as a concern, not fixed in this task.
+}
+
+// TestInternalizeAction_BroadcastServiceError_SurfacesResultFields pins issue #818:
+// when a new unproven tx is internalized and the immediate broadcast returns a soft service
+// error, InternalizeAction remains accepted and exposes sendWithResults / notDelayedResults
+// so callers can observe broadcast status (matching TS shareReqsWithWorld).
+func TestInternalizeAction_BroadcastServiceError_SurfacesResultFields(t *testing.T) {
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+
+	// given:
+	givenProvider := given.Provider()
+	activeStorage := givenProvider.GORM()
+	args := fixtures.DefaultInternalizeActionArgs(t, wdk.WalletPaymentProtocol)
+	txID := "03895fb984362a4196bc9931629318fcbb2aeba7c6293638119ea653fa31d119"
+
+	// and: ARC cannot confirm anything about this tx (empty response body) — bare service error.
+	givenProvider.ARC().WhenQueryingTx(txID).WillReturnNoBody()
+
+	// when:
+	result, err := activeStorage.InternalizeAction(
+		t.Context(),
+		testusers.Alice.AuthID(),
+		args,
+	)
+
+	// then: internalize is still accepted; broadcast outcome is surfaced for the caller.
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.Accepted)
+	assert.False(t, result.IsMerge)
+	assert.Equal(t, txID, result.TxID)
+
+	require.Len(t, result.SendWithResults, 1)
+	assert.Equal(t, txID, string(result.SendWithResults[0].TxID))
+	// Service error keeps the send in-flight (sending), not terminal failure.
+	assert.Equal(t, wdk.SendWithResultStatusSending, result.SendWithResults[0].Status)
+
+	require.Len(t, result.NotDelayedResults, 1)
+	assert.Equal(t, txID, string(result.NotDelayedResults[0].TxID))
+	assert.Equal(t, wdk.ReviewActionResultStatusServiceError, result.NotDelayedResults[0].Status)
+
+	// and db: KnownTx stays retryable (sending), matching ProcessAction service-error semantics.
+	thenDBState := testabilities.ThenDBState(t, activeStorage)
+	thenDBState.HasKnownTX(txID).WithStatus(wdk.ProvenTxStatusSending)
+	thenDBState.HasUserTransactionByTxID(testusers.Alice, txID).WithStatus(wdk.TxStatusSending)
+}
+
+// TestInternalizeAction_MergePath_OmitsBroadcastResultFields ensures merge internalizes do not
+// re-broadcast or populate send/review result fields.
+func TestInternalizeAction_MergePath_OmitsBroadcastResultFields(t *testing.T) {
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+
+	// given:
+	activeStorage := given.Provider().GORM()
+	const alreadyOwnedSatoshis = 100_000
+	ownedTxSpec, _ := given.Faucet(activeStorage, testusers.Alice).TopUp(alreadyOwnedSatoshis)
+
+	args := fixtures.DefaultInternalizeActionArgs(t, wdk.WalletPaymentProtocol)
+	args.Tx = ownedTxSpec.AtomicBEEF().Bytes()
+
+	// when:
+	result, err := activeStorage.InternalizeAction(
+		t.Context(),
+		testusers.Alice.AuthID(),
+		args,
+	)
+
+	// then:
+	require.NoError(t, err)
+	assert.True(t, result.Accepted)
+	assert.True(t, result.IsMerge)
+	assert.Empty(t, result.SendWithResults)
+	assert.Empty(t, result.NotDelayedResults)
 }

--- a/pkg/wdk/storage_internalize_action_args.go
+++ b/pkg/wdk/storage_internalize_action_args.go
@@ -106,9 +106,15 @@ type InternalizeActionArgs struct {
 }
 
 // InternalizeActionResult represents the result of an internalize action with a status indicating if it was accepted or not.
+//
+// SendWithResults and NotDelayedResults are populated when a new (non-merge) unproven transaction is
+// broadcast immediately after storage, matching ProcessAction / TypeScript shareReqsWithWorld behavior.
+// They are omitted for merges and for transactions that already have mining proof or prior acceptance evidence.
 type InternalizeActionResult struct {
-	Accepted bool   `json:"accepted"`
-	IsMerge  bool   `json:"isMerge"`
-	TxID     string `json:"txid"`
-	Satoshis int64  `json:"satoshis"`
+	Accepted          bool                 `json:"accepted"`
+	IsMerge           bool                 `json:"isMerge"`
+	TxID              string               `json:"txid"`
+	Satoshis          int64                `json:"satoshis"`
+	SendWithResults   []SendWithResult     `json:"sendWithResults,omitempty"`
+	NotDelayedResults []ReviewActionResult `json:"notDelayedResults,omitempty"`
 }


### PR DESCRIPTION
## Summary
Fixes #818

- After storing a **new unproven** internalized transaction, immediately broadcast via ProcessAction's `BackgroundBroadcast` path (same post + status apply as delayed/monitor workers), using the already-verified request BEEF.
- Surface `sendWithResults` and `notDelayedResults` on `wdk.InternalizeActionResult` so RPC callers can observe broadcast outcomes (TS `shareReqsWithWorld` parity).
- Skip re-broadcast when KnownTx is already in-flight (`IsInFlight`) or network-accepted / mined.
- Soft broadcast failures leave the tx for monitor/`SendWaitingTransactions` retry without rejecting the internalize; hard post errors still report a `sending` sendWith result.

## Test plan
- [x] `go test ./pkg/storage/ -run TestInternalizeAction -count=1`
- [x] `go test ./pkg/storage/internal/integrationtests/ -count=1`
- [x] `go test ./pkg/storage/ ./pkg/storage/internal/actions/ ./pkg/wdk/ -count=1`
- [x] New coverage: success result fields, serviceError result fields, merge omits fields, reorg intermediate unsent/sending under ARC hold