### PR TITLE
[00/11] ci: skip postgres suite on docs/plan-only PRs

### DIFF
--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -7,10 +7,8 @@ on:
     branches: [main, master]
   pull_request:
 
-permissions:
-  contents: read
-  pull-requests: read # paths filter via gh api on pull_request
-
+# Permissions are declared per-job (Sonar githubactions:S8264) so each job gets
+# only what it needs — not a workflow-wide read grant.
 jobs:
   # Decide whether this PR (or push) touches Go sources that postgres tests exercise.
   # Plan/docs-only PRs skip the expensive Postgres service job entirely.
@@ -20,6 +18,9 @@ jobs:
     name: 📁 Postgres paths filter
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read # gh api lists PR files for the paths filter
     outputs:
       run-tests: ${{ steps.filter.outputs.run-tests }}
     steps:
@@ -58,6 +59,8 @@ jobs:
     if: needs.changes.outputs.run-tests == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    permissions:
+      contents: read # checkout only
     services:
       postgres:
         image: postgres:17-alpine
@@ -90,6 +93,7 @@ jobs:
     if: always() && needs.changes.result == 'success'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions: {} # no GITHUB_TOKEN / API access required
     steps:
       - name: Roll up postgres result
         run: |

--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -9,9 +9,53 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read # paths filter via gh api on pull_request
 
 jobs:
-  test-postgres:
+  # Decide whether this PR (or push) touches Go sources that postgres tests exercise.
+  # Plan/docs-only PRs skip the expensive Postgres service job entirely.
+  # The rollup job below keeps the required `test-postgres` check name green when skipped
+  # (same short-circuit idea as fortress.yml paths-check).
+  changes:
+    name: 📁 Postgres paths filter
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      run-tests: ${{ steps.filter.outputs.run-tests }}
+    steps:
+      - name: Detect Go / workflow changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Full pipeline on main/master pushes (and any non-PR event).
+          if [[ "$EVENT" != "pull_request" ]]; then
+            echo "run-tests=true" >> "$GITHUB_OUTPUT"
+            echo "Non-PR event — run postgres tests"
+            exit 0
+          fi
+
+          files=$(gh api --paginate "/repos/${REPO}/pulls/${PR_NUMBER}/files" --jq '.[].filename')
+          echo "Changed files:"
+          printf '%s\n' "$files"
+
+          # Run only when a file can affect Postgres storage/monitor suites or this workflow.
+          if printf '%s\n' "$files" | grep -qE '(\.go$|^go\.mod$|^go\.sum$|^\.github/workflows/postgres-tests\.yml$)'; then
+            echo "run-tests=true" >> "$GITHUB_OUTPUT"
+            echo "Go or workflow sources changed — run postgres tests"
+          else
+            echo "run-tests=false" >> "$GITHUB_OUTPUT"
+            echo "Docs/plan-only (or non-Go) PR — skip postgres tests"
+          fi
+
+  test-postgres-run:
+    name: Run Postgres suite
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     services:
@@ -37,3 +81,29 @@ jobs:
         env:
           TEST_DB_MODE: postgres
         run: go test -race -p 1 -timeout 25m ./pkg/internal/storage/... ./pkg/storage/... ./pkg/internal/testabilities/... ./pkg/monitor/...
+
+  # Required check name remains `test-postgres`. Always runs so plan/docs-only PRs
+  # get a green status without starting the Postgres service container.
+  test-postgres:
+    name: test-postgres
+    needs: [changes, test-postgres-run]
+    if: always() && needs.changes.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Roll up postgres result
+        run: |
+          set -euo pipefail
+          RUN="${{ needs.changes.outputs.run-tests }}"
+          RESULT="${{ needs.test-postgres-run.result }}"
+          echo "run-tests=${RUN} suite-result=${RESULT}"
+          if [[ "$RUN" != "true" ]]; then
+            echo "Skipped postgres suite (no Go sources changed on this PR)."
+            exit 0
+          fi
+          if [[ "$RESULT" == "success" ]]; then
+            echo "Postgres suite passed."
+            exit 0
+          fi
+          echo "Postgres suite did not succeed (result=${RESULT})."
+          exit 1

--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -76,8 +76,8 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
       - name: Run storage-related tests on Postgres


### PR DESCRIPTION
## Summary
Plan-only / docs-only PRs were still running the full `postgres-tests` workflow (~15 minutes) even though Fortress already short-circuits its heavy jobs via `paths-check`.

## Change
- Add a paths filter job: run the suite only when the PR changes `.go`, `go.mod`, `go.sum`, or this workflow.
- Keep the required check name `test-postgres` as a lightweight always-on rollup so branch protection stays green when the suite is skipped.
- Non-PR events (push to main) still run the full suite.

## Test plan
- [ ] This PR itself (workflow change) should **run** the postgres suite (workflow file is in the filter).
- [x] A pure `plans/*.md` PR should show `test-postgres` green in seconds without starting Postgres.