### PR TITLE
fix: remediate SonarCloud security findings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 # =============================================================================
 FROM alpine:3.20
 
-RUN apk add --no-cache ca-certificates tzdata curl postgresql-client
+RUN apk add --no-cache ca-certificates tzdata curl postgresql-client \
+    && adduser -D -H -u 1000 app
 
 WORKDIR /app
 
@@ -41,11 +42,11 @@ COPY --from=builder /out/infra /app/infra
 COPY infra-config-docker.yaml /app/infra-config.yaml
 
 # Create a data directory (in case any local files are written)
-RUN mkdir -p /app/data
+RUN mkdir -p /app/data \
+    && chown -R app:app /app
 
-# Run as root for development convenience (mounted config files, etc.)
-# For production you can switch to a non-root user.
-# USER 1000
+# Run as non-root to limit container privilege (docker:S6471)
+USER app
 
 EXPOSE 8100
 

--- a/conformance/scripts/refresh-vectors.sh
+++ b/conformance/scripts/refresh-vectors.sh
@@ -36,7 +36,9 @@ VECTOR_PATHS=(
 )
 
 # Resolve ref → full commit SHA so the pin is immutable.
-SHA="$(curl -sSL \
+# --proto / --proto-redir restrict both the initial request and any redirects
+# to HTTPS (shell:S6506).
+SHA="$(curl --proto '=https' --proto-redir '=https' -sSL \
   -H 'Accept: application/vnd.github+json' \
   "https://api.github.com/repos/${UPSTREAM_REPO}/commits/${REF}" \
   | sed -n 's/^[[:space:]]*"sha":[[:space:]]*"\([0-9a-f]\{40\}\)".*/\1/p' \
@@ -54,7 +56,7 @@ for path in "${VECTOR_PATHS[@]}"; do
   dest="$ROOT_DIR/$path"
   mkdir -p "$(dirname "$dest")"
   echo "  $path"
-  curl -fsSL "$url" -o "$dest"
+  curl --proto '=https' --proto-redir '=https' -fsSL "$url" -o "$dest"
 done
 
 cat > "$SOURCE_FILE" <<EOF

--- a/infra-config-docker.yaml
+++ b/infra-config-docker.yaml
@@ -180,7 +180,9 @@ wallet_services:
     storage_path: ""
     p2p_storage_path: ""
 
-  exchangerates_api_key: bd539d2ff492bcb5619d5f27726a766f
+  # Leave empty in the public docker config; override via env/volume when needed.
+  # (yaml:S6418 — do not hard-code API keys in committed config files.)
+  exchangerates_api_key: ""
 
   fiat_exchange_rates:
     base: USD


### PR DESCRIPTION
## Summary
Remediates all open SonarCloud security findings on `main` for this project:

### Vulnerabilities
([issues view](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&types=VULNERABILITY&severities=BLOCKER%2CCRITICAL%2CMAJOR%2CMINOR&inNewCodePeriod=true&sinceLeakPeriod=true&id=bsv-blockchain_go-wallet-toolbox))

| Severity | Rule | Location | Fix |
|---|---|---|---|
| BLOCKER | `yaml:S6418` | `infra-config-docker.yaml` | Clear hard-coded `exchangerates_api_key` (use `""`, same as throughput docker config) |
| MAJOR | `shell:S6506` | `conformance/scripts/refresh-vectors.sh` (×2) | Add `curl --proto '=https' --proto-redir '=https'` so requests and redirects stay on HTTPS |

### Security hotspot
([hotspots view](https://sonarcloud.io/project/security_hotspots?id=bsv-blockchain_go-wallet-toolbox&branch=main&issueStatuses=OPEN,CONFIRMED&sinceLeakPeriod=true))

| Severity | Rule | Location | Fix |
|---|---|---|---|
| MEDIUM | `docker:S6471` | `Dockerfile` | Create non-root `app` user (uid 1000), `chown /app`, `USER app` — matches `Dockerfile.throughput` |

## Test plan
- [ ] SonarCloud PR analysis: no open `VULNERABILITY` issues / no remaining TO_REVIEW hotspot for these keys
- [ ] `bash -n conformance/scripts/refresh-vectors.sh` passes
- [ ] `docker build -t go-wallet-toolbox-infra .` succeeds
- [ ] Container runs as non-root: `docker run --rm --entrypoint id go-wallet-toolbox-infra` → uid 1000 (`app`)
- [ ] `docker compose up infra` still starts with the mounted config