### PR TITLE
ci: publish infra Docker image to GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,85 @@
+# ------------------------------------------------------------------------------------
+#  Build and Push Docker Image (infra server)
+#
+#  Builds the Dockerfile (cmd/infra storage server) and pushes to GHCR.
+#  Triggers on version tags and manual workflow_dispatch so existing releases
+#  can be published without cutting a new fortress release.
+# ------------------------------------------------------------------------------------
+
+name: Build and Push Docker Image
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image version tag (e.g. v0.184.0). Defaults to git describe."
+        required: false
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+permissions: {}
+
+jobs:
+  build-and-push:
+    name: Build and push infra image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine image tags
+        id: tags
+        run: |
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            VERSION="${{ github.ref_name }}"
+          elif [[ -n "${{ inputs.tag }}" ]]; then
+            VERSION="${{ inputs.tag }}"
+          else
+            VERSION="$(git describe --tags --always)"
+          fi
+          SHA_SHORT="$(git rev-parse --short HEAD)"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "sha_short=${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+          echo "Publishing tags: ${VERSION}, sha-${SHA_SHORT}"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.tags.outputs.version }}
+            type=raw,value=sha-${{ steps.tags.outputs.sha_short }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,19 +34,29 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Determine image tags
         id: tags
+        env:
+          # Pass workflow inputs / github context via env to avoid script injection (S7630).
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            VERSION="${{ github.ref_name }}"
-          elif [[ -n "${{ inputs.tag }}" ]]; then
-            VERSION="${{ inputs.tag }}"
+          if [[ "${REF_TYPE}" == "tag" ]]; then
+            VERSION="${REF_NAME}"
+          elif [[ -n "${INPUT_TAG}" ]]; then
+            VERSION="${INPUT_TAG}"
           else
             VERSION="$(git describe --tags --always)"
+          fi
+          # Restrict version tag characters to reduce risk from untrusted workflow inputs.
+          if [[ ! "${VERSION}" =~ ^[A-Za-z0-9._+-]+$ ]]; then
+            echo "Invalid image version tag: ${VERSION}" >&2
+            exit 1
           fi
           SHA_SHORT="$(git rev-parse --short HEAD)"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
@@ -54,18 +64,18 @@ jobs:
           echo "Publishing tags: ${VERSION}, sha-${SHA_SHORT}"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -73,7 +83,7 @@ jobs:
             type=raw,value=sha-${{ steps.tags.outputs.sha_short }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/docker-publish.yml` to build the existing `Dockerfile` (`cmd/infra` storage server) and push to `ghcr.io/bsv-blockchain/go-wallet-toolbox`.
- Triggers on `v*` tags and `workflow_dispatch` (optional tag input), so we can publish an image for the current release without a new fortress cut.
- Tags: requested/semver version + `sha-<short>`.

## Context
Needed so `bsva-infra-flux` can deploy go-wallet-toolbox (mainnet, US) with a pinned image, analogous to TypeScript `wallet-infra`.

## After merge
Run the workflow manually for the current release, e.g.:

```bash
gh workflow run docker-publish.yml --ref main -f tag=v0.184.0
```

or push/republish a tag that matches the commit on main.

## Test plan
- [ ] Workflow runs successfully on `workflow_dispatch` with `tag=v0.184.0` (or next release tag)
- [ ] Image pullable: `docker pull ghcr.io/bsv-blockchain/go-wallet-toolbox:v0.184.0`
- [ ] Container starts with mounted config + `INFRA_SERVER_PRIVATE_KEY` (or fails clearly if missing)