### PR TITLE
feat: mainnet throughput demo dashboard

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -152,3 +152,10 @@ infra-config-docker-throughput.yaml:generic-api-key:201
 # Exact fingerprints from Gitleaks PR #960 review comments (false positives)
 781411a5124676f3d121a0d8a2266613c9bf1d53:infra-config-docker-throughput.yaml:generic-api-key:19
 781411a5124676f3d121a0d8a2266613c9bf1d53:infra-config-docker-throughput.yaml:generic-api-key:201
+
+# infra-config-docker-throughput-mainnet.yaml — same local Docker dev key as
+# infra-config-docker.yaml (not a production secret; false positive).
+infra-config-docker-throughput-mainnet.yaml:generic-api-key:31
+# Exact fingerprint from Gitleaks PR #966 review comment
+4758c36718411130aedbf63edfd9901855d321da:infra-config-docker-throughput-mainnet.yaml:generic-api-key:21
+

--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,0 +1,15 @@
+# SDD Progress — throughput demo dashboard
+
+Branch: `feat/throughput-demo-dashboard`
+Baseline: `4758c367` — chore(dashboard): baseline throughput demo scaffold
+
+## Tasks
+
+- [ ] Task 1: Stream package harden
+- [ ] Task 2: Funding package harden
+- [ ] Task 3: Metrics sampler + tests
+- [ ] Task 4: Web UI polish
+- [ ] Task 5: Packaging + docs
+- [ ] Task 6: Config + connect
+- [ ] Task 7: API + main wiring + API tests
+- [ ] Task 8: Final verification + whole-branch review

--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -2,16 +2,23 @@
 
 Branch: `feat/throughput-demo-dashboard`
 Baseline: `4758c367` — chore(dashboard): baseline throughput demo scaffold
-Briefs: `067c9685`
+HEAD: `dac48529`
 
 ## Tasks
 
-- [x] Task 1: Stream package harden — complete (`8d1a1d34`, review implementer-clean)
-- [x] Task 2: Funding package harden — complete (`a7e21f17`)
-- [x] Task 3: Metrics sampler + tests — complete (`be9b1c20`)
-- [x] Task 4: Web UI polish — complete (`79a5e31d`)
-- [x] Task 5: Packaging + docs — complete (`0d7cd4ec`)
-- Wave 1 merge: `0d7cd4ec`, `go test ./cmd/throughput_dashboard/...` PASS
-- [ ] Task 6: Config + connect
-- [ ] Task 7: API + main wiring + API tests
-- [ ] Task 8: Final verification + whole-branch review
+- [x] Task 1: Stream package harden — `8d1a1d34`
+- [x] Task 2: Funding package harden — `a7e21f17`
+- [x] Task 3: Metrics sampler + tests — `be9b1c20`
+- [x] Task 4: Web UI polish — `79a5e31d`
+- [x] Task 5: Packaging + docs — `0d7cd4ec`
+- [x] Wave 1 merge — tests green
+- [x] Task 6: Config + connect — `2fa07149`
+- [x] Task 7: API + main wiring + API tests — `dac48529`
+- [x] Task 8: Final verification + whole-branch review — **Approved**
+
+## Final verification
+
+- `go test ./cmd/throughput_dashboard/...` PASS
+- builds OK
+- compose config OK
+- Final review: no Critical/Important findings

--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -2,14 +2,16 @@
 
 Branch: `feat/throughput-demo-dashboard`
 Baseline: `4758c367` — chore(dashboard): baseline throughput demo scaffold
+Briefs: `067c9685`
 
 ## Tasks
 
-- [ ] Task 1: Stream package harden
-- [ ] Task 2: Funding package harden
-- [ ] Task 3: Metrics sampler + tests
-- [ ] Task 4: Web UI polish
-- [ ] Task 5: Packaging + docs
+- [x] Task 1: Stream package harden — complete (`8d1a1d34`, review implementer-clean)
+- [x] Task 2: Funding package harden — complete (`a7e21f17`)
+- [x] Task 3: Metrics sampler + tests — complete (`be9b1c20`)
+- [x] Task 4: Web UI polish — complete (`79a5e31d`)
+- [x] Task 5: Packaging + docs — complete (`0d7cd4ec`)
+- Wave 1 merge: `0d7cd4ec`, `go test ./cmd/throughput_dashboard/...` PASS
 - [ ] Task 6: Config + connect
 - [ ] Task 7: API + main wiring + API tests
 - [ ] Task 8: Final verification + whole-branch review

--- a/.superpowers/sdd/task-1-brief.md
+++ b/.superpowers/sdd/task-1-brief.md
@@ -1,0 +1,25 @@
+# Task 1 — Stream package harden
+
+## Owns exclusively
+`cmd/throughput_dashboard/internal/stream/**` only. Do not edit other packages.
+
+## Goal
+Harden the controllable createAction event stream: hashed OP_RETURN + Start/Stop controller + solid tests.
+
+## Requirements
+1. `HashPayload(iteration, ts)` returns `sha256(strconv.FormatUint(iteration,10) + ts.UTC().Format(time.RFC3339Nano))` (32 bytes).
+2. `OpReturnLockingScriptForHash` / `OpReturnLockingScriptForIteration` build OP_RETURN locking scripts pushing the hash.
+3. `Controller` with Start/Stop/Running/Stats; rate-limited producer; worker pool; each action unique hash/iteration.
+4. `CreateAction` options: `AcceptDelayedBroadcast: true`, satoshis 0, single OP_RETURN output.
+5. Tests: hash determinism; OP_RETURN contains hash; start/stop; failure counting. **Do not** require Succeeded==Attempted after Stop (cancel may fail in-flight).
+6. `go test ./cmd/throughput_dashboard/internal/stream/... -count=1` must PASS.
+
+## Baseline
+Code already exists from scaffold commit `4758c367`. Review, fix gaps, improve tests, commit improvements.
+
+## Commit
+`feat(dashboard): harden stream controller and hashed opreturn`
+
+## Report
+Write full report to `.superpowers/sdd/task-1-report.md` in the worktree.
+Return status DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT, commits, test summary.

--- a/.superpowers/sdd/task-1-report.md
+++ b/.superpowers/sdd/task-1-report.md
@@ -32,12 +32,12 @@
 `go test ./cmd/throughput_dashboard/internal/stream/... -count=1` — **PASS** (also `-race` PASS).
 
 ## Requirements checklist
-1. HashPayload formula — yes  
-2. OpReturn locking scripts push hash — yes  
-3. Controller Start/Stop/Running/Stats + rate limit + worker pool + unique iteration/hash — yes  
-4. CreateAction: ADB true, 0 sats, single OP_RETURN — yes (asserted in tests)  
-5. Tests cover hash, OP_RETURN, start/stop, failures; no Succeeded==Attempted after Stop — yes  
-6. Package tests pass — yes  
+1. HashPayload formula — yes
+2. OpReturn locking scripts push hash — yes
+3. Controller Start/Stop/Running/Stats + rate limit + worker pool + unique iteration/hash — yes
+4. CreateAction: ADB true, 0 sats, single OP_RETURN — yes (asserted in tests)
+5. Tests cover hash, OP_RETURN, start/stop, failures; no Succeeded==Attempted after Stop — yes
+6. Package tests pass — yes
 
 ## Concerns
 None.

--- a/.superpowers/sdd/task-1-report.md
+++ b/.superpowers/sdd/task-1-report.md
@@ -1,0 +1,49 @@
+# Task 1 Report — Stream package harden
+
+## Status
+**DONE**
+
+## Commit
+- `f2e740424f1b3d642f4421e7adf7e051a6f442cf` — `feat(dashboard): harden stream controller and hashed opreturn`
+
+## Scope
+`cmd/throughput_dashboard/internal/stream/**` only.
+
+## What changed
+
+### `opreturn.go`
+- `HashPayload(iteration, ts)` documents/implements `sha256(FormatUint(iteration,10) + ts.UTC().Format(RFC3339Nano))` (always 32 bytes).
+- `OpReturnLockingScriptForHash` rejects empty **and** non-32-byte payloads.
+- `OpReturnLockingScriptForIteration` unchanged composition: hash then OP_RETURN push.
+
+### `controller.go`
+- Fixed misleading Start comment (not idempotent; errors if already running).
+- Snapshot TPS/workers/originator at Start and pass into `run`/`runOne` (no mid-run field races).
+- **Stop/Start generation race fix**: Stop only clears controller state if `c.done` still matches the generation it cancelled; `run` similarly only marks stopped for its own `done`. Prevents a concurrent Start from being torn down by a late Stop.
+- CreateAction args remain: single 0-sat OP_RETURN output, `AcceptDelayedBroadcast: true`.
+- In-flight cancel still increments `Failed` (documented; tests do not require Succeeded==Attempted after Stop).
+
+### Tests
+- Hash: determinism, UTC normalization, iteration/time uniqueness.
+- OP_RETURN: contains hash + OP_RETURN; rejects empty/wrong length; iteration helper.
+- Controller: start/stop, double-start error, failure counting, CreateAction arg shape (ADB/satoshis/single OP_RETURN/unique scripts/originator), restart after stop, option overrides, defaults, SnapshotAndDelta, parent-context cancel.
+
+## Test summary
+`go test ./cmd/throughput_dashboard/internal/stream/... -count=1` — **PASS** (also `-race` PASS).
+
+## Requirements checklist
+1. HashPayload formula — yes  
+2. OpReturn locking scripts push hash — yes  
+3. Controller Start/Stop/Running/Stats + rate limit + worker pool + unique iteration/hash — yes  
+4. CreateAction: ADB true, 0 sats, single OP_RETURN — yes (asserted in tests)  
+5. Tests cover hash, OP_RETURN, start/stop, failures; no Succeeded==Attempted after Stop — yes  
+6. Package tests pass — yes  
+
+## Concerns
+None.
+
+## Self-review
+- No secrets.
+- testify/require used.
+- No edits outside stream package (report path is SDD artifact).
+- Race on Stop clearing a newer Start generation fixed and covered indirectly via restart + parent-cancel tests.

--- a/.superpowers/sdd/task-2-brief.md
+++ b/.superpowers/sdd/task-2-brief.md
@@ -1,0 +1,26 @@
+# Task 2 — Funding package harden
+
+## Owns exclusively
+`cmd/throughput_dashboard/internal/funding/**` only.
+
+## Goal
+Solid BRC-29 deposit address + internalize path for browser WalletClient top-ups.
+
+## Requirements
+1. Derive address with AnyoneKey sender + KeyID prefix `SfKxPIJNgdI=` / suffix `NaGLC6fMH50=`.
+2. Mainnet vs testnet via `defs.BSVNetwork`.
+3. Return locking script as **hex** (`hex.EncodeToString`) for WalletClient.
+4. `Internalize`: prefer `atomic_tx_hex`; else `txid` + services.GetBEEF.
+5. Remittance = AnyoneKey wallet-payment protocol (`sdk.InternalizeProtocolWalletPayment`).
+6. Validate output pays operator address when parseable.
+7. Unit tests for DeriveInfo + AnyonePaymentRemittance; add internalize unit tests with fakes if practical (no live network).
+8. `go test ./cmd/throughput_dashboard/internal/funding/... -count=1` PASS.
+
+## Baseline
+Scaffold at `4758c367`. Harden/complete/tests.
+
+## Commit
+`feat(dashboard): harden funding address and internalize`
+
+## Report
+`.superpowers/sdd/task-2-report.md`

--- a/.superpowers/sdd/task-2-report.md
+++ b/.superpowers/sdd/task-2-report.md
@@ -1,9 +1,9 @@
 # Task 2 Report — Funding package harden
 
-**Status:** complete  
-**Commit:** `49b4199c` — `feat(dashboard): harden funding address and internalize`  
-**Baseline:** `4758c367` — chore(dashboard): baseline throughput demo scaffold  
-**Branch:** `feat/throughput-demo-dashboard`  
+**Status:** complete
+**Commit:** `49b4199c` — `feat(dashboard): harden funding address and internalize`
+**Baseline:** `4758c367` — chore(dashboard): baseline throughput demo scaffold
+**Branch:** `feat/throughput-demo-dashboard`
 **Exclusive scope:** `cmd/throughput_dashboard/internal/funding/**`
 
 ## Summary

--- a/.superpowers/sdd/task-2-report.md
+++ b/.superpowers/sdd/task-2-report.md
@@ -1,0 +1,81 @@
+# Task 2 Report — Funding package harden
+
+**Status:** complete  
+**Commit:** `49b4199c` — `feat(dashboard): harden funding address and internalize`  
+**Baseline:** `4758c367` — chore(dashboard): baseline throughput demo scaffold  
+**Branch:** `feat/throughput-demo-dashboard`  
+**Exclusive scope:** `cmd/throughput_dashboard/internal/funding/**`
+
+## Summary
+
+Hardened the BRC-29 deposit address derivation and WalletClient internalize path for operator top-ups. Production API used by `internal/api` remains compatible (`Internalize` gains optional `...InternalizeOption` only).
+
+## Requirements checklist
+
+| # | Requirement | Result |
+|---|-------------|--------|
+| 1 | Derive address with AnyoneKey sender + KeyID prefix `SfKxPIJNgdI=` / suffix `NaGLC6fMH50=` | Pass — constants + `brc29.AddressForSelf(anyonePub, keyID, priv, …)` |
+| 2 | Mainnet vs testnet via `defs.BSVNetwork` | Pass — `network.Validate()` + `WithMainNet` / `WithTestNet` |
+| 3 | Return locking script as **hex** (`hex.EncodeToString`) | Pass — `Info.LockingScriptHex` |
+| 4 | Prefer `atomic_tx_hex`; else `txid` + services.GetBEEF | Pass — atomic first; txid path via `AtomicBeefSource` (default = services.GetBEEF) |
+| 5 | Remittance = AnyoneKey wallet-payment protocol | Pass — `sdk.InternalizeProtocolWalletPayment` + `AnyonePaymentRemittance()` |
+| 6 | Validate output pays operator address when parseable | Pass — `validateOutputPaysAddress`; skip if unparseable |
+| 7 | Unit tests for DeriveInfo + AnyonePaymentRemittance; internalize with fakes | Pass — see tests below |
+| 8 | `go test ./cmd/throughput_dashboard/internal/funding/... -count=1` | **PASS** (19 tests) |
+
+## Changes
+
+### `address.go`
+- Nil private-key guard
+- `network.Validate()` before derivation
+- Explicit switch on `defs.NetworkTestnet` vs mainnet
+- Documented default suggested satoshis (`100_000`)
+- Unchanged public constants and `Info` JSON shape for the dashboard UI
+
+### `internalize.go`
+- Nil wallet guard
+- `AtomicBeefSource` interface + `WithAtomicBeefSource` option (test injection; production still uses `services.New` + `GetBEEF` + `AtomicBytes`)
+- Prefers `atomic_tx_hex` over `txid` even when both present (asserted in tests)
+- Logs resolved txid from parsed atomic when request omits `txid`
+- Shared `parseTx` (BEEF then raw) for validation and logging
+- Variadic `opts ...InternalizeOption` — **backward compatible** with existing API caller
+
+### Tests
+**`address_test.go` (7):**
+- `TestDeriveInfoMainnet` — hex lock script, AnyoneKey sender, BRC-29 cross-check
+- `TestDeriveInfoTestnet` — test network + address differs from mainnet
+- `TestDeriveInfoDefaultSuggested` — zero → 100_000
+- `TestDeriveInfoNilPriv` / `TestDeriveInfoInvalidNetwork`
+- `TestAnyonePaymentRemittance` — decoded prefix/suffix + AnyoneKey
+- `TestDerivationConstantsMatchFaucet` — `SfKxPIJNgdI=` / `NaGLC6fMH50=`
+
+**`internalize_test.go` (12):**
+- Missing tx fields, nil wallet, bad hex
+- Atomic path success: protocol, remittance, originator, bytes
+- Prefer atomic over txid (beef source not called)
+- TxID path with fake `AtomicBeefSource`
+- Beef source error propagation
+- Wrong address rejection, output index OOR
+- Skip validation when unparseable
+- Wallet error wrap, invalid expected address
+
+## Test command
+
+```bash
+go test ./cmd/throughput_dashboard/internal/funding/... -count=1
+# ok  .../funding  ~0.7–0.9s  (19 tests)
+```
+
+## Concerns / follow-ups
+
+1. **Live GetBEEF path** is not integration-tested (by design: no live network). Covered via injectable `AtomicBeefSource`. Mainnet reliability still depends on ARC/WoC credentials at runtime.
+2. **Unparseable atomic** still reaches `InternalizeAction` when validation is skipped — intentional so partial BEEF shapes the wallet understands can proceed; bad data fails at the wallet.
+3. **API package** (`handleInternalize`) was not modified (out of ownership). Existing call site continues to work without options.
+4. Parallel Task 1/4 agents may land other package commits on the same branch; this commit only touches `funding/**`.
+
+## Files touched
+
+- `cmd/throughput_dashboard/internal/funding/address.go`
+- `cmd/throughput_dashboard/internal/funding/address_test.go`
+- `cmd/throughput_dashboard/internal/funding/internalize.go`
+- `cmd/throughput_dashboard/internal/funding/internalize_test.go` (new)

--- a/.superpowers/sdd/task-3-brief.md
+++ b/.superpowers/sdd/task-3-brief.md
@@ -1,0 +1,28 @@
+# Task 3 — Metrics sampler + tests
+
+## Owns exclusively
+`cmd/throughput_dashboard/internal/metrics/**` only.
+
+## Goal
+Reliable sampling of stream TPS + basket inventory + top-up events; **unit tests** (currently missing).
+
+## Requirements
+1. Poll: default Balance, fuel/reserve ListOutputs TotalOutputs, stream Stats deltas.
+2. Fuel runway_seconds ≈ fuel_count / target_tps when target_tps > 0.
+3. Emit `tick` events each sample; `topup` when fuel or reserve count increases.
+4. Event ring (max ~200) + Subscribe/Unsubscribe for SSE (non-blocking send).
+5. **Add tests** with fake WalletAPI + controllable stream.Controller (or interface if you must inject — prefer fakes against existing types without changing other packages; if Controller is concrete, construct with fake ActionCreator).
+6. Thread-safe.
+7. `go test ./cmd/throughput_dashboard/internal/metrics/... -count=1` PASS.
+
+## Baseline
+`sampler.go` exists without tests at `4758c367`.
+
+## Commit
+`feat(dashboard): metrics sampler tests and harden`
+
+## Report
+`.superpowers/sdd/task-3-report.md`
+
+## Note
+Package currently imports `stream.Controller` concretely. You may only edit metrics package — work with exported stream APIs. If a pure interface would help but requires stream changes, document as concern and use fake ActionCreator + real Controller for tests instead.

--- a/.superpowers/sdd/task-3-report.md
+++ b/.superpowers/sdd/task-3-report.md
@@ -1,0 +1,27 @@
+# Task 3 Report — Metrics sampler + tests
+
+## status
+PASS
+
+## commits
+- `a1b09cb9` — `feat(dashboard): metrics sampler tests and harden` (metrics package only: `sampler_test.go`)
+
+## test summary
+`go test ./cmd/throughput_dashboard/internal/metrics/... -count=1` — **PASS** (18 tests)
+
+Coverage:
+- NewSampler defaults (interval, water marks, maxEvents, nil logger)
+- Tick sampling: Balance, fuel/reserve ListOutputs (baskets + limit + originator), runway_seconds = fuel/target_tps (and 0 when target_tps=0)
+- Tick event emission into ring + LastTick fields
+- Topup on fuel increase / reserve increase / both; no topup on first sample, decrease, or unchanged
+- Stream TPS deltas via real `stream.Controller` + fake ActionCreator (activity then idle)
+- Subscribe receives tick + topup; Unsubscribe closes channel; double-unsubscribe safe
+- Non-blocking emit when subscriber buffer full
+- Event ring cap (~maxEvents) + RecentEvents copy independence
+- Run immediate sample + ticker, exits on context cancel
+- Wallet Balance/ListOutputs errors do not panic; still emit tick
+- Concurrent LastTick/RecentEvents/Subscribe while Run samples
+
+## concerns
+- Package still depends on concrete `*stream.Controller`. Stream counters are not injectable without starting the stream; TPS delta tests use a real Controller + fake ActionCreator as specified. A `StatsProvider` interface in metrics (or stream) would make unit tests fully deterministic without sleep, but would require stream/API surface changes outside this package’s ownership — not done.
+- No code harden changes were required in `sampler.go`; behavior already matched the brief (ring, non-blocking SSE send, topup detection, runway math, thread-safe LastTick/Subscribe).

--- a/.superpowers/sdd/task-4-brief.md
+++ b/.superpowers/sdd/task-4-brief.md
@@ -1,0 +1,25 @@
+# Task 4 — Web UI polish
+
+## Owns exclusively
+`cmd/throughput_dashboard/web/**` only. No Go files.
+
+## Goal
+Polished demo UI for start/stop stream, gauges, charts, top-ups, WalletClient funding.
+
+## Requirements
+1. Start/Stop stream; TPS and workers inputs; POST `/api/stream/start|stop`.
+2. Charts: TPS succeeded/failed and fuel/reserve (Chart.js CDN OK).
+3. Balances from status/SSE ticks; mainnet warning banner.
+4. Top-up event log from SSE `topup`.
+5. Funding: load `/api/funding`, pay with `@bsv/sdk` WalletClient (esm.sh), POST `/api/funding/internalize` with atomic_tx_hex or txid.
+6. Graceful errors if WalletClient/CDN missing.
+7. Dark, readable demo aesthetic; mobile-ish responsive.
+
+## Baseline
+`index.html`, `app.js`, `style.css` at `4758c367`. Polish UX, robustness of funding parsing, accessibility of controls.
+
+## Commit
+`feat(dashboard): polish throughput demo web UI`
+
+## Report
+`.superpowers/sdd/task-4-report.md`

--- a/.superpowers/sdd/task-4-report.md
+++ b/.superpowers/sdd/task-4-report.md
@@ -1,0 +1,47 @@
+# Task 4 Report — Web UI polish
+
+## Status
+**done**
+
+## Commits
+- `feat(dashboard): polish throughput demo web UI` (web-only under `cmd/throughput_dashboard/web/**`)
+
+## Summary of UI changes
+
+### Controls (start/stop)
+- TPS / workers inputs with bounds, numeric `inputmode`, disabled while stream is running
+- Busy labels (“Starting…”, “Stopping…”) and inline stream status (ok/err/info) instead of only `alert`
+- Stream state shown as a running/stopped pill; counters keep tabular mono formatting
+
+### Charts
+- Chart.js line charts for TPS succeeded/failed and fuel/reserve inventory
+- Soft fills, tooltips, reduced motion-friendly static updates
+- If Chart.js CDN fails: fallback messages; gauges still update via status/SSE
+
+### Balances & network
+- Balances / runway / water marks from `/api/status` and SSE `tick`
+- Mainnet warning banner + badge; non-mainnet hides banner and shows network badge as OK
+- Live SSE connection chip (Connecting / Live / Reconnecting / offline) with poll backup every 5s
+- Deduped tick application so poll + SSE do not double-plot chart points
+
+### Top-ups
+- SSE `topup` event log with basket tags, timestamps, empty state, capped list, dedupe keys
+
+### Funding (WalletClient)
+- Load `/api/funding`, show deposit address, copy button, suggested satoshis
+- Pay via dynamic `import` of `@bsv/sdk` WalletClient (multi-CDN fallback URLs)
+- Robust parsing of createAction results: hex / base64 / Uint8Array / nested beef fields / txid variants; optional output-index match on locking script
+- `POST /api/funding/internalize` with `atomic_tx_hex` and/or `txid` + `output_index`
+- Manual internalize panel (txid / atomic hex / vout) when WalletClient or CDN is unavailable
+- Graceful error copy when CDN, wallet extension, or API fails
+
+### Aesthetic / a11y
+- Dark demo theme refined (gradients, focus rings, hover states, empty log panel)
+- IBM Plex Sans/Mono loaded; responsive single-column under 960px
+- Skip link, `aria-live` status regions, labeled controls, `prefers-reduced-motion`
+
+## Concerns
+- `@bsv/sdk` version pins: tried `1.9.25` (not published on esm.sh); UI tries `1.4.20` then unversioned `@bsv/sdk` — MetaNet host wallet shapes still vary; manual internalize is the safety net
+- Chart.js and Google Fonts still need network; offline demo loses charts/fonts but keeps control plane
+- No automated browser tests in this task (static assets only)
+- Did not modify any Go packages (task boundary respected)

--- a/.superpowers/sdd/task-5-brief.md
+++ b/.superpowers/sdd/task-5-brief.md
@@ -1,0 +1,29 @@
+# Task 5 — Packaging + docs
+
+## Owns exclusively
+- `Dockerfile.dashboard`
+- `docker-compose.throughput-dashboard.yaml`
+- `infra-config-docker-throughput-mainnet.yaml`
+- `docs/throughput-dashboard.md`
+- Cross-links only: `docs/throughput-docker.md`, `README.md` (docs list line only)
+
+Do not edit `cmd/throughput_dashboard/**`.
+
+## Goal
+Mainnet demo stack packaging + operator runbook ready to run.
+
+## Requirements
+1. Mainnet infra yaml: `bsv_network: main`, throughput strategy, expected_tx_size 200, target_tps 1000, fee 100 sat/kb.
+2. Compose: db (5433 host), infra (8101 host), dashboard (127.0.0.1:8200); PRIVATE_KEY required.
+3. Dockerfile builds `infra_throughput` + `throughput_dashboard`.
+4. Runbook: fund → FuelKeeper → start stream; safety checklist.
+5. Validate: `PRIVATE_KEY=00 docker compose -f docker-compose.throughput-dashboard.yaml config` exits 0.
+
+## Baseline
+Files exist at `4758c367`. Verify completeness, fix gaps, improve docs clarity.
+
+## Commit
+`docs(dashboard): mainnet compose packaging and runbook`
+
+## Report
+`.superpowers/sdd/task-5-report.md`

--- a/.superpowers/sdd/task-5-report.md
+++ b/.superpowers/sdd/task-5-report.md
@@ -1,0 +1,19 @@
+# Task 5 Report — Packaging + docs
+
+## status
+**done**
+
+## commits
+- `c1925196` — `docs(dashboard): mainnet compose packaging and runbook`
+
+## validation result
+- `PRIVATE_KEY=00 docker compose -f docker-compose.throughput-dashboard.yaml config` → **exit 0**
+- Without `PRIVATE_KEY` → exit 1 (required-variable interpolation)
+- Asserts: `bsv_network: main`, strategy `throughput`, `expected_tx_size_bytes: 200`, `target_tps: 1000`, fee `sat/kb` 100
+- Host ports: db `127.0.0.1:5433`, infra `127.0.0.1:8101`, dashboard `127.0.0.1:8200`
+- Dockerfile builds `./cmd/infra_throughput` + `./cmd/throughput_dashboard`
+
+## concerns
+- ARC token in mainnet yaml remains `mainnet_placeholder`; operators must set `INFRA_WALLET_SERVICES_ARC_TOKEN` for reliable mainnet broadcast (documented in runbook).
+- Did not build/run full image stack (compose config-only validation as required).
+- Infra host publish was tightened to `127.0.0.1:8101` (baseline was `8101:8100`); matches dashboard/db localhost-only safety. Intra-compose traffic still uses `http://infra:8100`.

--- a/.superpowers/sdd/task-6-brief.md
+++ b/.superpowers/sdd/task-6-brief.md
@@ -1,0 +1,18 @@
+# Task 6 — Config + connect
+
+## Owns exclusively
+- `cmd/throughput_dashboard/internal/config/**`
+- `cmd/throughput_dashboard/internal/connect/**`
+
+## Requirements
+1. Env config mainnet defaults: BSV_NETWORK=main, SERVER_URL http://127.0.0.1:8101, HTTP_ADDR 127.0.0.1:8200, TPS=10, WORKERS=8
+2. PRIVATE_KEY required
+3. `DemoThroughput()` → expected_tx_size 200, output sats 0, target_tps 1000; denom 20 with DefaultFeeModel+DefaultCommission
+4. Connect: wallet.NewWithStorageFactory + storage.NewClient; retry Balance probe with backoff (~30s window)
+5. Config tests cover defaults + overrides + DemoThroughput
+6. Optional connect unit test only if pure helpers are extractable without network
+
+## Done
+`go test ./cmd/throughput_dashboard/internal/config/... ./cmd/throughput_dashboard/internal/connect/... -count=1` PASS
+Commit: `feat(dashboard): config defaults and connect retries`
+Report: `.superpowers/sdd/task-6-report.md`

--- a/.superpowers/sdd/task-6-report.md
+++ b/.superpowers/sdd/task-6-report.md
@@ -35,12 +35,12 @@ go test ./cmd/throughput_dashboard/internal/config/... ./cmd/throughput_dashboar
 **PASS** (config: 9 tests; connect: 4 tests). Also `-race` **PASS**.
 
 ## Requirements checklist
-1. Mainnet defaults (SERVER_URL, BSV_NETWORK, HTTP_ADDR, TPS, WORKERS) — yes  
-2. PRIVATE_KEY required — yes  
-3. DemoThroughput shape + denom 20 — yes (asserted)  
-4. Connect NewWithStorageFactory + NewClient + Balance retry ~30s — yes  
-5. Config tests: defaults + overrides + DemoThroughput — yes (+ validation edges)  
-6. Optional connect unit tests for pure helpers — yes (`retryWithBackoff`)  
+1. Mainnet defaults (SERVER_URL, BSV_NETWORK, HTTP_ADDR, TPS, WORKERS) — yes
+2. PRIVATE_KEY required — yes
+3. DemoThroughput shape + denom 20 — yes (asserted)
+4. Connect NewWithStorageFactory + NewClient + Balance retry ~30s — yes
+5. Config tests: defaults + overrides + DemoThroughput — yes (+ validation edges)
+6. Optional connect unit tests for pure helpers — yes (`retryWithBackoff`)
 
 ## Concerns
 - None for this package scope. Full wallet connect still needs live infra; only backoff helper is unit-tested (by design).

--- a/.superpowers/sdd/task-6-report.md
+++ b/.superpowers/sdd/task-6-report.md
@@ -1,0 +1,47 @@
+# Task 6 Report — Config + connect
+
+## Status
+**DONE**
+
+## Commit
+- `4aa3b631` — `feat(dashboard): config defaults and connect retries`
+
+## Scope
+`cmd/throughput_dashboard/internal/config/**` and `cmd/throughput_dashboard/internal/connect/**` only.
+
+## What was verified / changed
+
+### `config` (implementation already on branch; tests expanded)
+- **ConfigFromEnv** mainnet-first defaults:
+  - `BSV_NETWORK=main`
+  - `SERVER_URL=http://127.0.0.1:8101`
+  - `HTTP_ADDR=127.0.0.1:8200`
+  - `TPS=10`, `WORKERS=8`, `SAMPLE_SECONDS=1`
+  - `ORIGINATOR=throughput-dashboard.local`
+- `PRIVATE_KEY` required
+- Positive int validation for TPS / WORKERS / SAMPLE_SECONDS; `BSV_NETWORK` parsed via `defs.ParseBSVNetworkStr`
+- **DemoThroughput()**: `ExpectedTxSizeBytes=200`, `ExpectedOutputSatoshis=0`, `TargetTPS=1000` on top of `DefaultUTXOManagement().Throughput`
+- Denomination with `DefaultFeeModel()` (100 sat/kb) + `DefaultCommission()` (disabled) → **20 sats**
+
+### `connect` (implementation already on branch; pure-helper tests added)
+- `Wallet(...)`: `wallet.NewWithStorageFactory` + `storage.NewClient`; Balance probe as first storage RPC
+- Retry window **30s**, exponential backoff 1s → max 5s; closes partial wallets between attempts; ctx cancel aborts
+- Unit tests for `retryWithBackoff` only (no network): success after failures, window exhaust, cancel, onRetry callback
+
+## Test summary
+```text
+go test ./cmd/throughput_dashboard/internal/config/... ./cmd/throughput_dashboard/internal/connect/... -count=1
+```
+**PASS** (config: 9 tests; connect: 4 tests). Also `-race` **PASS**.
+
+## Requirements checklist
+1. Mainnet defaults (SERVER_URL, BSV_NETWORK, HTTP_ADDR, TPS, WORKERS) — yes  
+2. PRIVATE_KEY required — yes  
+3. DemoThroughput shape + denom 20 — yes (asserted)  
+4. Connect NewWithStorageFactory + NewClient + Balance retry ~30s — yes  
+5. Config tests: defaults + overrides + DemoThroughput — yes (+ validation edges)  
+6. Optional connect unit tests for pure helpers — yes (`retryWithBackoff`)  
+
+## Concerns
+- None for this package scope. Full wallet connect still needs live infra; only backoff helper is unit-tested (by design).
+- `DemoThroughput` inherits other DefaultUTXOManagement throughput knobs (pool headroom, fanout, top-up interval); only size/output/TPS are overridden — matches mainnet yaml profile intent.

--- a/.superpowers/sdd/task-7-brief.md
+++ b/.superpowers/sdd/task-7-brief.md
@@ -1,0 +1,22 @@
+# Task 7 — API + main wiring + API tests
+
+## Owns exclusively
+- `cmd/throughput_dashboard/internal/api/**`
+- `cmd/throughput_dashboard/main.go`
+
+Do not edit stream/funding/metrics/config/connect/web packages (consume as libraries).
+
+## Requirements
+1. Routes: GET /api/status, POST /api/stream/start|stop, GET /api/events (SSE), GET /api/funding, POST /api/funding/internalize, static embed /
+2. main wires: config, connect wallet, FuelKeeper, stream.Controller, metrics.Sampler, api.Server, graceful shutdown
+3. //go:embed web/*
+4. **HTTP tests** for at least start/stop/status JSON (use fakes/interfaces or httptest for handler)
+5. If funding Internalize signature changed in Task 2, adapt call sites in api only
+6. `go test ./cmd/throughput_dashboard/... -count=1` PASS
+7. `go build ./cmd/throughput_dashboard` PASS
+
+## Commit
+`feat(dashboard): API control plane and main wiring tests`
+
+## Report
+`.superpowers/sdd/task-7-report.md`

--- a/.superpowers/sdd/task-7-report.md
+++ b/.superpowers/sdd/task-7-report.md
@@ -1,0 +1,73 @@
+# Task 7 Report — API + main wiring + API tests
+
+## Status
+**PASS**
+
+## What was done
+
+### Verified existing control plane (no production edits required)
+- `cmd/throughput_dashboard/main.go` already wires:
+  - `config.ConfigFromEnv` + `DemoThroughput` denomination/pool
+  - `connect.Wallet` → operator wallet
+  - `fuelkeeper.New` + `keeper.Run` (background)
+  - `stream.NewController`
+  - `metrics.NewSampler` + `sampler.Run` (background)
+  - `//go:embed web/*` + `api.New` + `http.Server`
+  - graceful shutdown: stream `Stop` + HTTP `Shutdown` on SIGINT/SIGTERM
+- `cmd/throughput_dashboard/internal/api/server.go` already exposes:
+  - `GET /api/status`
+  - `POST /api/stream/start` / `POST /api/stream/stop`
+  - `GET /api/events` (SSE)
+  - `GET /api/funding`
+  - `POST /api/funding/internalize`
+  - static `GET /` from embedded `WebFS`
+  - CORS preflight
+
+### Funding.Internalize adaptation
+Current signature (Task 2) matches the call site already in `handleInternalize`:
+
+```go
+funding.Internalize(ctx, wallet, network, expectedAddress, req, originator, logger, opts...)
+```
+
+No api package changes required.
+
+### Added HTTP handler tests
+New file: `cmd/throughput_dashboard/internal/api/server_test.go`
+
+| Test | Coverage |
+|------|----------|
+| `TestStatus_JSONShape` | network/mainnet/server_url/originator/tick/events + CORS header |
+| `TestStatus_IncludesTickAfterSample` | tick gauges after sampler `Run` |
+| `TestStreamStartStop_StatusRunning` | start with tps/workers, double-start 409, stop, stop-idempotent |
+| `TestStreamStart_EmptyBodyUsesDefaults` | empty body keeps controller defaults |
+| `TestFunding_ReturnsDepositAddress` | BRC-29 deposit JSON shape |
+| `TestInternalize_AtomicPath` | atomic_tx_hex → wallet InternalizeAction |
+| `TestInternalize_InvalidJSON` | 400 |
+| `TestInternalize_MissingFields` | 400 when neither atomic nor txid |
+| `TestCORS_Options` | OPTIONS → 204 |
+| `TestStatic_Index` | embedded-style MapFS index |
+| `TestEvents_SSEHeadersAndInitialTick` | `text/event-stream`, initial tick event, client cancel exit |
+
+Fakes: `stream.ActionCreator`, `metrics.WalletAPI`, `funding.ActionInternalizer`; real `stream.Controller` + `metrics.Sampler` under `httptest`.
+
+## Commits
+- `feat(dashboard): API control plane and main wiring tests` (this task)
+
+## Test summary
+```
+go test ./cmd/throughput_dashboard/... -count=1
+  ok  .../internal/api
+  ok  .../internal/config
+  ok  .../internal/funding
+  ok  .../internal/metrics
+  ok  .../internal/stream
+
+go build ./cmd/throughput_dashboard  → PASS
+```
+
+## Concerns
+1. **No main.go unit tests** — wiring is integration-level (needs PRIVATE_KEY + live storage). Covered by compile + structural review of `run()`.
+2. **SSE test uses httptest** — adequate for headers/first event/cancel; not a long-lived multi-subscriber stress test.
+3. **Internalize test uses unparseable atomic hex** — exercises wallet path after decode (validation skipped when unparseable); address-strict path remains covered in `funding` package tests.
+4. **Task 6 (config/connect)** was still open in progress ledger when this ran; api/main already consume those packages as libraries.

--- a/.superpowers/sdd/task-8-final-review.md
+++ b/.superpowers/sdd/task-8-final-review.md
@@ -1,0 +1,48 @@
+# Task 8 — Final whole-branch review
+
+**Branch:** `feat/throughput-demo-dashboard`  
+**HEAD:** `dac48529`  
+**Merge-base main:** `a853dceb`  
+**Verdict:** **Approved**
+
+## Spec compliance
+
+| Criterion | Status |
+|---|---|
+| Mainnet-first dashboard + FuelKeeper + start/stop stream | ✅ |
+| OP_RETURN = sha256(iteration ‖ RFC3339Nano) | ✅ |
+| UI/API: TPS, balances, top-ups, WalletClient funding | ✅ |
+| Mainnet compose stack | ✅ |
+| No secrets; unit tests for stream/funding/config/metrics/api | ✅ |
+
+## Findings
+
+### Critical
+None.
+
+### Important
+None.
+
+### Minor (non-blocking)
+- CORS `Access-Control-Allow-Origin: *` on control plane (localhost demo OK)
+- ARC token placeholder in mainnet yaml — documented env override
+- WalletClient CDN version fallbacks
+- Compose `depends_on: infra` without healthcheck (infra may still be booting)
+- No end-to-end browser tests
+
+## Verification run (controller)
+
+```
+go test ./cmd/throughput_dashboard/... -count=1  # all packages PASS
+go build ./cmd/throughput_dashboard              # OK
+go build ./cmd/infra_throughput                  # OK
+PRIVATE_KEY=00 docker compose -f docker-compose.throughput-dashboard.yaml config  # OK
+```
+
+## SDD summary
+
+Wave 1 (parallel worktrees): Tasks 1–5  
+Wave 2 (parallel worktrees): Tasks 6–7  
+Wave 3: Final review Task 8  
+
+All product success criteria met; ready for PR when desired.

--- a/.superpowers/sdd/task-8-final-review.md
+++ b/.superpowers/sdd/task-8-final-review.md
@@ -1,8 +1,8 @@
 # Task 8 — Final whole-branch review
 
-**Branch:** `feat/throughput-demo-dashboard`  
-**HEAD:** `dac48529`  
-**Merge-base main:** `a853dceb`  
+**Branch:** `feat/throughput-demo-dashboard`
+**HEAD:** `dac48529`
+**Merge-base main:** `a853dceb`
 **Verdict:** **Approved**
 
 ## Spec compliance
@@ -41,8 +41,8 @@ PRIVATE_KEY=00 docker compose -f docker-compose.throughput-dashboard.yaml config
 
 ## SDD summary
 
-Wave 1 (parallel worktrees): Tasks 1–5  
-Wave 2 (parallel worktrees): Tasks 6–7  
-Wave 3: Final review Task 8  
+Wave 1 (parallel worktrees): Tasks 1–5
+Wave 2 (parallel worktrees): Tasks 6–7
+Wave 3: Final review Task 8
 
 All product success criteria met; ready for PR when desired.

--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+
+# =============================================================================
+# Builder stage — throughput infra + dashboard
+# =============================================================================
+FROM golang:1.26-alpine AS builder
+
+RUN apk add --no-cache ca-certificates git tzdata
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-s -w" \
+    -o /out/infra \
+    ./cmd/infra_throughput
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-s -w" \
+    -o /out/dashboard \
+    ./cmd/throughput_dashboard
+
+# =============================================================================
+# Runtime stage
+# =============================================================================
+FROM alpine:3.20
+
+RUN apk add --no-cache ca-certificates curl postgresql-client tzdata \
+    && adduser -D -H -u 1000 app
+
+WORKDIR /app
+
+COPY --from=builder /out/infra /app/infra
+COPY --from=builder /out/dashboard /app/dashboard
+
+# Default mainnet throughput config; override via volume mount in compose
+COPY infra-config-docker-throughput-mainnet.yaml /app/infra-config-throughput.yaml
+
+RUN mkdir -p /app/data \
+    && chown -R app:app /app
+
+USER app
+
+EXPOSE 8100 8200
+
+ENTRYPOINT ["/app/infra"]

--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # =============================================================================
-# Builder stage — throughput infra + dashboard
+# Builder stage — throughput infra + dashboard (mainnet demo stack)
 # =============================================================================
 FROM golang:1.26-alpine AS builder
 
@@ -14,6 +14,7 @@ RUN go mod download
 
 COPY . .
 
+# Static Linux binaries; dashboard embeds web/* via go:embed
 RUN CGO_ENABLED=0 GOOS=linux go build \
     -ldflags="-s -w" \
     -o /out/infra \
@@ -36,7 +37,8 @@ WORKDIR /app
 COPY --from=builder /out/infra /app/infra
 COPY --from=builder /out/dashboard /app/dashboard
 
-# Default mainnet throughput config; override via volume mount in compose
+# Default mainnet throughput config; compose volume-mounts the same file as
+# /app/infra-config-throughput.yaml (path expected by cmd/infra_throughput).
 COPY infra-config-docker-throughput-mainnet.yaml /app/infra-config-throughput.yaml
 
 RUN mkdir -p /app/data \
@@ -46,4 +48,5 @@ USER app
 
 EXPOSE 8100 8200
 
+# Default entry is infra; dashboard service overrides entrypoint to /app/dashboard
 ENTRYPOINT ["/app/infra"]

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ For a guided walkthrough (including faucet and local setup), see the examples ov
 - Storage: `./docs/storage.md`
 - Wallet: `./docs/wallet.md`
 - Throughput Docker live-test (privacy vs 1000 TPS stack): `./docs/throughput-docker.md`
-- Throughput demo dashboard (mainnet UI, start/stop stream, WalletClient funding): `./docs/throughput-dashboard.md`
+- Throughput demo dashboard (mainnet compose, fund → FuelKeeper → stream runbook): `./docs/throughput-dashboard.md`
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ For a guided walkthrough (including faucet and local setup), see the examples ov
 - Storage: `./docs/storage.md`
 - Wallet: `./docs/wallet.md`
 - Throughput Docker live-test (privacy vs 1000 TPS stack): `./docs/throughput-docker.md`
+- Throughput demo dashboard (mainnet UI, start/stop stream, WalletClient funding): `./docs/throughput-dashboard.md`
 
 <br/>
 

--- a/cmd/throughput_dashboard/internal/api/server.go
+++ b/cmd/throughput_dashboard/internal/api/server.go
@@ -146,7 +146,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 		case <-s.deps.Done:
 			return
 		case <-keepalive.C:
-			fmt.Fprintf(w, ": keepalive\n\n")
+			_, _ = fmt.Fprintf(w, ": keepalive\n\n")
 			flusher.Flush()
 		case ev, ok := <-ch:
 			if !ok {
@@ -196,14 +196,19 @@ func writeSSE(w http.ResponseWriter, flusher http.Flusher, ev metrics.Event) {
 	if err != nil {
 		return
 	}
-	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Type, b)
+	_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Type, b)
 	flusher.Flush()
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		http.Error(w, `{"error":"encode failed"}`, http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set(headerContentType, "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(v)
+	_, _ = w.Write(append(b, '\n'))
 }
 
 func withCORS(next http.Handler) http.Handler {

--- a/cmd/throughput_dashboard/internal/api/server.go
+++ b/cmd/throughput_dashboard/internal/api/server.go
@@ -1,0 +1,216 @@
+// Package api serves the throughput dashboard HTTP control plane and UI.
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"time"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/funding"
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/metrics"
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/stream"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+)
+
+// Deps wires the HTTP server.
+type Deps struct {
+	Ctrl       *stream.Controller
+	Sampler    *metrics.Sampler
+	Wallet     funding.ActionInternalizer
+	Priv       *ec.PrivateKey
+	Network    defs.BSVNetwork
+	Originator string
+	ServerURL  string
+	Logger     *slog.Logger
+	WebFS      fs.FS
+	ParentCtx  context.Context
+}
+
+// Server is the dashboard HTTP API.
+type Server struct {
+	deps Deps
+	mux  *http.ServeMux
+}
+
+// New builds the HTTP handler.
+func New(deps Deps) *Server {
+	if deps.Logger == nil {
+		deps.Logger = slog.Default()
+	}
+	if deps.ParentCtx == nil {
+		deps.ParentCtx = context.Background()
+	}
+	s := &Server{deps: deps, mux: http.NewServeMux()}
+	s.routes()
+	return s
+}
+
+// Handler returns the root handler.
+func (s *Server) Handler() http.Handler {
+	return withCORS(s.mux)
+}
+
+func (s *Server) routes() {
+	s.mux.HandleFunc("GET /api/status", s.handleStatus)
+	s.mux.HandleFunc("POST /api/stream/start", s.handleStreamStart)
+	s.mux.HandleFunc("POST /api/stream/stop", s.handleStreamStop)
+	s.mux.HandleFunc("GET /api/events", s.handleEvents)
+	s.mux.HandleFunc("GET /api/funding", s.handleFunding)
+	s.mux.HandleFunc("POST /api/funding/internalize", s.handleInternalize)
+
+	if s.deps.WebFS != nil {
+		fileServer := http.FileServer(http.FS(s.deps.WebFS))
+		s.mux.Handle("GET /", fileServer)
+	}
+}
+
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	tick := s.deps.Sampler.LastTick()
+	writeJSON(w, http.StatusOK, map[string]any{
+		"network":    string(s.deps.Network),
+		"server_url": s.deps.ServerURL,
+		"originator": s.deps.Originator,
+		"mainnet":    s.deps.Network == defs.NetworkMainnet,
+		"tick":       tick,
+		"events":     s.deps.Sampler.RecentEvents(),
+	})
+}
+
+type startBody struct {
+	TPS     int `json:"tps"`
+	Workers int `json:"workers"`
+}
+
+func (s *Server) handleStreamStart(w http.ResponseWriter, r *http.Request) {
+	var body startBody
+	if r.Body != nil {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+	}
+	err := s.deps.Ctrl.Start(s.deps.ParentCtx, stream.Options{
+		TPS:        body.TPS,
+		Workers:    body.Workers,
+		Originator: s.deps.Originator,
+	})
+	if err != nil {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "stats": s.deps.Ctrl.Stats()})
+}
+
+func (s *Server) handleStreamStop(w http.ResponseWriter, r *http.Request) {
+	s.deps.Ctrl.Stop()
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "stats": s.deps.Ctrl.Stats()})
+}
+
+func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	// Send current tick immediately.
+	if tick := s.deps.Sampler.LastTick(); tick.Timestamp != "" {
+		writeSSE(w, flusher, metrics.Event{
+			Type:      "tick",
+			Timestamp: tick.Timestamp,
+			Payload:   map[string]any{"tick": tick},
+		})
+	}
+
+	ch := s.deps.Sampler.Subscribe()
+	defer s.deps.Sampler.Unsubscribe(ch)
+
+	keepalive := time.NewTicker(15 * time.Second)
+	defer keepalive.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-s.deps.ParentCtx.Done():
+			return
+		case <-keepalive.C:
+			fmt.Fprintf(w, ": keepalive\n\n")
+			flusher.Flush()
+		case ev, ok := <-ch:
+			if !ok {
+				return
+			}
+			writeSSE(w, flusher, ev)
+		}
+	}
+}
+
+func (s *Server) handleFunding(w http.ResponseWriter, r *http.Request) {
+	info, err := funding.DeriveInfo(s.deps.Priv, s.deps.Network, 0)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, info)
+}
+
+func (s *Server) handleInternalize(w http.ResponseWriter, r *http.Request) {
+	var req funding.InternalizeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json: " + err.Error()})
+		return
+	}
+	info, err := funding.DeriveInfo(s.deps.Priv, s.deps.Network, 0)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if err := funding.Internalize(
+		r.Context(),
+		s.deps.Wallet,
+		s.deps.Network,
+		info.Address,
+		req,
+		s.deps.Originator,
+		s.deps.Logger,
+	); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+func writeSSE(w http.ResponseWriter, flusher http.Flusher, ev metrics.Event) {
+	b, err := json.Marshal(ev)
+	if err != nil {
+		return
+	}
+	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Type, b)
+	flusher.Flush()
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func withCORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/cmd/throughput_dashboard/internal/api/server.go
+++ b/cmd/throughput_dashboard/internal/api/server.go
@@ -95,7 +95,9 @@ func (s *Server) handleStreamStart(w http.ResponseWriter, r *http.Request) {
 	if r.Body != nil {
 		_ = json.NewDecoder(r.Body).Decode(&body)
 	}
-	err := s.deps.Ctrl.Start(s.processContext(), stream.Options{
+	// Process shutdown cancels the stream via Ctrl.Stop() in main; no long-lived
+	// parent context is stored on Server (avoids context-in-struct / cancel leaks).
+	err := s.deps.Ctrl.Start(context.Background(), stream.Options{
 		TPS:        body.TPS,
 		Workers:    body.Workers,
 		Originator: s.deps.Originator,
@@ -187,19 +189,6 @@ func (s *Server) handleInternalize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
-}
-
-// processContext returns a context canceled when the process Done channel closes.
-func (s *Server) processContext() context.Context {
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		select {
-		case <-s.deps.Done:
-			cancel()
-		case <-ctx.Done():
-		}
-	}()
-	return ctx
 }
 
 func writeSSE(w http.ResponseWriter, flusher http.Flusher, ev metrics.Event) {

--- a/cmd/throughput_dashboard/internal/api/server.go
+++ b/cmd/throughput_dashboard/internal/api/server.go
@@ -18,18 +18,21 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
 )
 
+const headerContentType = "Content-Type"
+
 // Deps wires the HTTP server.
 type Deps struct {
 	Ctrl       *stream.Controller
 	Sampler    *metrics.Sampler
-	Wallet     funding.ActionInternalizer
+	Wallet     funding.InternalizeActioner
 	Priv       *ec.PrivateKey
 	Network    defs.BSVNetwork
 	Originator string
 	ServerURL  string
 	Logger     *slog.Logger
 	WebFS      fs.FS
-	ParentCtx  context.Context
+	// Done is closed when the process is shutting down (not a context.Context field).
+	Done <-chan struct{}
 }
 
 // Server is the dashboard HTTP API.
@@ -43,8 +46,8 @@ func New(deps Deps) *Server {
 	if deps.Logger == nil {
 		deps.Logger = slog.Default()
 	}
-	if deps.ParentCtx == nil {
-		deps.ParentCtx = context.Background()
+	if deps.Done == nil {
+		deps.Done = make(chan struct{}) // never closed — no process-wide cancel
 	}
 	s := &Server{deps: deps, mux: http.NewServeMux()}
 	s.routes()
@@ -92,7 +95,7 @@ func (s *Server) handleStreamStart(w http.ResponseWriter, r *http.Request) {
 	if r.Body != nil {
 		_ = json.NewDecoder(r.Body).Decode(&body)
 	}
-	err := s.deps.Ctrl.Start(s.deps.ParentCtx, stream.Options{
+	err := s.deps.Ctrl.Start(s.processContext(), stream.Options{
 		TPS:        body.TPS,
 		Workers:    body.Workers,
 		Originator: s.deps.Originator,
@@ -115,7 +118,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set(headerContentType, "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 
@@ -138,7 +141,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 		select {
 		case <-r.Context().Done():
 			return
-		case <-s.deps.ParentCtx.Done():
+		case <-s.deps.Done:
 			return
 		case <-keepalive.C:
 			fmt.Fprintf(w, ": keepalive\n\n")
@@ -172,19 +175,31 @@ func (s *Server) handleInternalize(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
-	if err := funding.Internalize(
-		r.Context(),
-		s.deps.Wallet,
-		s.deps.Network,
-		info.Address,
-		req,
-		s.deps.Originator,
-		s.deps.Logger,
-	); err != nil {
+	if err := funding.Internalize(r.Context(), funding.InternalizeParams{
+		Wallet:          s.deps.Wallet,
+		Network:         s.deps.Network,
+		ExpectedAddress: info.Address,
+		Request:         req,
+		Originator:      s.deps.Originator,
+		Logger:          s.deps.Logger,
+	}); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// processContext returns a context canceled when the process Done channel closes.
+func (s *Server) processContext() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		select {
+		case <-s.deps.Done:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	return ctx
 }
 
 func writeSSE(w http.ResponseWriter, flusher http.Flusher, ev metrics.Event) {
@@ -197,7 +212,7 @@ func writeSSE(w http.ResponseWriter, flusher http.Flusher, ev metrics.Event) {
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(headerContentType, "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(v)
 }
@@ -206,7 +221,7 @@ func withCORS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.Header().Set("Access-Control-Allow-Headers", headerContentType)
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return

--- a/cmd/throughput_dashboard/internal/api/server_test.go
+++ b/cmd/throughput_dashboard/internal/api/server_test.go
@@ -120,7 +120,7 @@ type testEnv struct {
 	cancel  context.CancelFunc
 }
 
-func newTestEnv(t *testing.T, opts ...func(*api.Deps)) *testEnv {
+func newTestEnv(t *testing.T) *testEnv {
 	t.Helper()
 
 	parent, cancel := context.WithCancel(context.Background())
@@ -157,9 +157,6 @@ func newTestEnv(t *testing.T, opts ...func(*api.Deps)) *testEnv {
 			"index.html": &fstest.MapFile{Data: []byte("<html>dashboard</html>")},
 		},
 	}
-	for _, o := range opts {
-		o(&deps)
-	}
 
 	srv := api.New(deps)
 	return &testEnv{
@@ -179,7 +176,7 @@ func doJSON(t *testing.T, h http.Handler, method, path string, body any) *httpte
 		require.NoError(t, err)
 		rdr = bytes.NewReader(b)
 	}
-	req := httptest.NewRequest(method, path, rdr)
+	req := httptest.NewRequestWithContext(context.Background(), method, path, rdr)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
@@ -254,9 +251,9 @@ func TestStatus_IncludesTickAfterSample(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	body := decodeMap(t, rec)
 	tick := body["tick"].(map[string]any)
-	assert.Equal(t, float64(42), tick["default_sats"])
-	assert.Equal(t, float64(7), tick["fuel_count"])
-	assert.Equal(t, float64(3), tick["reserve_count"])
+	assert.InDelta(t, 42, tick["default_sats"], 0.001)
+	assert.InDelta(t, 7, tick["fuel_count"], 0.001)
+	assert.InDelta(t, 3, tick["reserve_count"], 0.001)
 	streamStats := tick["stream"].(map[string]any)
 	assert.Equal(t, false, streamStats["running"])
 }
@@ -274,8 +271,8 @@ func TestStreamStartStop_StatusRunning(t *testing.T) {
 	assert.Equal(t, true, startBody["ok"])
 	stats := startBody["stats"].(map[string]any)
 	assert.Equal(t, true, stats["running"])
-	assert.Equal(t, float64(25), stats["tps"])
-	assert.Equal(t, float64(3), stats["workers"])
+	assert.InDelta(t, 25, stats["tps"], 0.001)
+	assert.InDelta(t, 3, stats["workers"], 0.001)
 	require.True(t, env.ctrl.Running())
 
 	// Double start → 409 Conflict.
@@ -307,8 +304,8 @@ func TestStreamStart_EmptyBodyUsesDefaults(t *testing.T) {
 	stats := body["stats"].(map[string]any)
 	assert.Equal(t, true, stats["running"])
 	// Defaults from NewController in newTestEnv.
-	assert.Equal(t, float64(10), stats["tps"])
-	assert.Equal(t, float64(2), stats["workers"])
+	assert.InDelta(t, 10, stats["tps"], 0.001)
+	assert.InDelta(t, 2, stats["workers"], 0.001)
 
 	env.ctrl.Stop()
 }
@@ -324,7 +321,7 @@ func TestFunding_ReturnsDepositAddress(t *testing.T) {
 	assert.NotEmpty(t, body["locking_script_hex"])
 	assert.Equal(t, funding.DerivationPrefixB64, body["derivation_prefix_b64"])
 	assert.Equal(t, funding.DerivationSuffixB64, body["derivation_suffix_b64"])
-	assert.Equal(t, float64(100_000), body["suggested_satoshis"])
+	assert.InDelta(t, 100_000, body["suggested_satoshis"], 0.001)
 }
 
 func TestInternalize_AtomicPath(t *testing.T) {
@@ -344,7 +341,7 @@ func TestInternalize_AtomicPath(t *testing.T) {
 func TestInternalize_InvalidJSON(t *testing.T) {
 	env := newTestEnv(t)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/funding/internalize", bytes.NewBufferString("{not-json"))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/funding/internalize", bytes.NewBufferString("{not-json"))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	env.handler.ServeHTTP(rec, req)
@@ -366,7 +363,7 @@ func TestInternalize_MissingFields(t *testing.T) {
 func TestCORS_Options(t *testing.T) {
 	env := newTestEnv(t)
 
-	req := httptest.NewRequest(http.MethodOptions, "/api/status", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodOptions, "/api/status", nil)
 	rec := httptest.NewRecorder()
 	env.handler.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusNoContent, rec.Code)
@@ -377,7 +374,7 @@ func TestCORS_Options(t *testing.T) {
 func TestStatic_Index(t *testing.T) {
 	env := newTestEnv(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	env.handler.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)

--- a/cmd/throughput_dashboard/internal/api/server_test.go
+++ b/cmd/throughput_dashboard/internal/api/server_test.go
@@ -65,7 +65,7 @@ func (f *fakeWalletAPI) ListOutputs(_ context.Context, args sdk.ListOutputsArgs,
 	return &sdk.ListOutputsResult{TotalOutputs: total}, nil
 }
 
-// fakeInternalizer satisfies funding.ActionInternalizer.
+// fakeInternalizer satisfies funding.InternalizeActioner.
 type fakeInternalizer struct {
 	mu   sync.Mutex
 	err  error
@@ -90,6 +90,15 @@ func (f *fakeInternalizer) callCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return len(f.args)
+}
+
+func doneFromCtx(ctx context.Context) <-chan struct{} {
+	ch := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		close(ch)
+	}()
+	return ch
 }
 
 func discardLogger() *slog.Logger {
@@ -126,18 +135,12 @@ func newTestEnv(t *testing.T, opts ...func(*api.Deps)) *testEnv {
 	t.Cleanup(ctrl.Stop)
 
 	walletAPI := &fakeWalletAPI{balance: 100_000, fuelTotal: 50, reserveTotal: 10}
-	sampler := metrics.NewSampler(
-		walletAPI,
-		ctrl,
-		"test-origin",
-		time.Hour, // long interval; tests that need ticks call Run explicitly
-		1000,      // target TPS
-		20,        // denomination
-		1000,      // target pool
-		60,        // low water %
-		100,       // high water %
-		discardLogger(),
-	)
+	sampler := metrics.NewSampler(walletAPI, ctrl, metrics.Config{
+		Originator: "test-origin", Interval: time.Hour,
+		TargetTPS: 1000, Denomination: 20, TargetPool: 1000,
+		LowWaterPercent: 60, HighWaterPercent: 100,
+		Logger: discardLogger(),
+	})
 
 	internalizer := &fakeInternalizer{}
 	deps := api.Deps{
@@ -149,7 +152,7 @@ func newTestEnv(t *testing.T, opts ...func(*api.Deps)) *testEnv {
 		Originator: "test-origin",
 		ServerURL:  "http://127.0.0.1:8101",
 		Logger:     discardLogger(),
-		ParentCtx:  parent,
+		Done: doneFromCtx(parent),
 		WebFS: fstest.MapFS{
 			"index.html": &fstest.MapFile{Data: []byte("<html>dashboard</html>")},
 		},
@@ -222,7 +225,12 @@ func TestStatus_IncludesTickAfterSample(t *testing.T) {
 	t.Cleanup(ctrl.Stop)
 
 	walletAPI := &fakeWalletAPI{balance: 42, fuelTotal: 7, reserveTotal: 3}
-	sampler := metrics.NewSampler(walletAPI, ctrl, "o", 50*time.Millisecond, 10, 20, 100, 60, 100, discardLogger())
+	sampler := metrics.NewSampler(walletAPI, ctrl, metrics.Config{
+		Originator: "o", Interval: 50*time.Millisecond,
+		TargetTPS: 10, Denomination: 20, TargetPool: 100,
+		LowWaterPercent: 60, HighWaterPercent: 100,
+		Logger: discardLogger(),
+	})
 	go sampler.Run(parent)
 
 	// Wait until LastTick is populated.
@@ -239,7 +247,7 @@ func TestStatus_IncludesTickAfterSample(t *testing.T) {
 		Originator: "o",
 		ServerURL:  "http://example",
 		Logger:     discardLogger(),
-		ParentCtx:  parent,
+		Done: doneFromCtx(parent),
 	})
 
 	rec := doJSON(t, srv.Handler(), http.MethodGet, "/api/status", nil)
@@ -385,7 +393,12 @@ func TestEvents_SSEHeadersAndInitialTick(t *testing.T) {
 	t.Cleanup(ctrl.Stop)
 
 	walletAPI := &fakeWalletAPI{fuelTotal: 1}
-	sampler := metrics.NewSampler(walletAPI, ctrl, "o", 50*time.Millisecond, 10, 20, 100, 60, 100, discardLogger())
+	sampler := metrics.NewSampler(walletAPI, ctrl, metrics.Config{
+		Originator: "o", Interval: 50*time.Millisecond,
+		TargetTPS: 10, Denomination: 20, TargetPool: 100,
+		LowWaterPercent: 60, HighWaterPercent: 100,
+		Logger: discardLogger(),
+	})
 	go sampler.Run(parent)
 	require.Eventually(t, func() bool {
 		return sampler.LastTick().Timestamp != ""
@@ -400,7 +413,7 @@ func TestEvents_SSEHeadersAndInitialTick(t *testing.T) {
 		Originator: "o",
 		ServerURL:  "http://example",
 		Logger:     discardLogger(),
-		ParentCtx:  parent,
+		Done: doneFromCtx(parent),
 	})
 
 	ctx, cancelReq := context.WithCancel(context.Background())

--- a/cmd/throughput_dashboard/internal/api/server_test.go
+++ b/cmd/throughput_dashboard/internal/api/server_test.go
@@ -386,6 +386,7 @@ func TestStatic_Index(t *testing.T) {
 // until ServeHTTP has returned — ResponseRecorder is not concurrency-safe.
 type sseRecorder struct {
 	*httptest.ResponseRecorder
+
 	firstWrite chan struct{}
 	once       sync.Once
 }

--- a/cmd/throughput_dashboard/internal/api/server_test.go
+++ b/cmd/throughput_dashboard/internal/api/server_test.go
@@ -1,0 +1,430 @@
+package api_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	sdk "github.com/bsv-blockchain/go-sdk/wallet"
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/api"
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/funding"
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/metrics"
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/stream"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const operatorPrivHex = "0000000000000000000000000000000000000000000000000000000000000001"
+
+// fakeActionCreator satisfies stream.ActionCreator.
+type fakeActionCreator struct {
+	calls atomic.Uint64
+}
+
+func (f *fakeActionCreator) CreateAction(ctx context.Context, _ sdk.CreateActionArgs, _ string) (*sdk.CreateActionResult, error) {
+	f.calls.Add(1)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	return &sdk.CreateActionResult{}, nil
+}
+
+// fakeWalletAPI satisfies metrics.WalletAPI.
+type fakeWalletAPI struct {
+	balance      uint64
+	fuelTotal    uint32
+	reserveTotal uint32
+}
+
+func (f *fakeWalletAPI) Balance(context.Context) (uint64, error) {
+	return f.balance, nil
+}
+
+func (f *fakeWalletAPI) ListOutputs(_ context.Context, args sdk.ListOutputsArgs, _ string) (*sdk.ListOutputsResult, error) {
+	var total uint32
+	switch args.Basket {
+	case wdk.BasketNameForFuel:
+		total = f.fuelTotal
+	case wdk.BasketNameForReserve:
+		total = f.reserveTotal
+	}
+	return &sdk.ListOutputsResult{TotalOutputs: total}, nil
+}
+
+// fakeInternalizer satisfies funding.ActionInternalizer.
+type fakeInternalizer struct {
+	mu   sync.Mutex
+	err  error
+	args []sdk.InternalizeActionArgs
+}
+
+func (f *fakeInternalizer) InternalizeAction(
+	_ context.Context,
+	args sdk.InternalizeActionArgs,
+	_ string,
+) (*sdk.InternalizeActionResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.args = append(f.args, args)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &sdk.InternalizeActionResult{}, nil
+}
+
+func (f *fakeInternalizer) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.args)
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func testPriv(t *testing.T) *ec.PrivateKey {
+	t.Helper()
+	priv, err := ec.PrivateKeyFromHex(operatorPrivHex)
+	require.NoError(t, err)
+	return priv
+}
+
+type testEnv struct {
+	handler http.Handler
+	ctrl    *stream.Controller
+	sampler *metrics.Sampler
+	wallet  *fakeInternalizer
+	cancel  context.CancelFunc
+}
+
+func newTestEnv(t *testing.T, opts ...func(*api.Deps)) *testEnv {
+	t.Helper()
+
+	parent, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	actions := &fakeActionCreator{}
+	ctrl := stream.NewController(actions, stream.Options{
+		TPS:        10,
+		Workers:    2,
+		Originator: "test-origin",
+	}, discardLogger())
+	t.Cleanup(ctrl.Stop)
+
+	walletAPI := &fakeWalletAPI{balance: 100_000, fuelTotal: 50, reserveTotal: 10}
+	sampler := metrics.NewSampler(
+		walletAPI,
+		ctrl,
+		"test-origin",
+		time.Hour, // long interval; tests that need ticks call Run explicitly
+		1000,      // target TPS
+		20,        // denomination
+		1000,      // target pool
+		60,        // low water %
+		100,       // high water %
+		discardLogger(),
+	)
+
+	internalizer := &fakeInternalizer{}
+	deps := api.Deps{
+		Ctrl:       ctrl,
+		Sampler:    sampler,
+		Wallet:     internalizer,
+		Priv:       testPriv(t),
+		Network:    defs.NetworkMainnet,
+		Originator: "test-origin",
+		ServerURL:  "http://127.0.0.1:8101",
+		Logger:     discardLogger(),
+		ParentCtx:  parent,
+		WebFS: fstest.MapFS{
+			"index.html": &fstest.MapFile{Data: []byte("<html>dashboard</html>")},
+		},
+	}
+	for _, o := range opts {
+		o(&deps)
+	}
+
+	srv := api.New(deps)
+	return &testEnv{
+		handler: srv.Handler(),
+		ctrl:    ctrl,
+		sampler: sampler,
+		wallet:  internalizer,
+		cancel:  cancel,
+	}
+}
+
+func doJSON(t *testing.T, h http.Handler, method, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		rdr = bytes.NewReader(b)
+	}
+	req := httptest.NewRequest(method, path, rdr)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func decodeMap(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out), "body=%s", rec.Body.String())
+	return out
+}
+
+func TestStatus_JSONShape(t *testing.T) {
+	env := newTestEnv(t)
+
+	rec := doJSON(t, env.handler, http.MethodGet, "/api/status", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	assert.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
+
+	body := decodeMap(t, rec)
+	assert.Equal(t, "main", body["network"])
+	assert.Equal(t, "http://127.0.0.1:8101", body["server_url"])
+	assert.Equal(t, "test-origin", body["originator"])
+	assert.Equal(t, true, body["mainnet"])
+	require.Contains(t, body, "tick")
+	require.Contains(t, body, "events")
+	_, ok := body["tick"].(map[string]any)
+	require.True(t, ok, "tick must be a JSON object")
+}
+
+func TestStatus_IncludesTickAfterSample(t *testing.T) {
+	// Drive sampler via Subscribe + sample by starting Run briefly.
+	// metrics.Sampler.Run is the public sample loop; use a short interval.
+	parent, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	actions := &fakeActionCreator{}
+	ctrl := stream.NewController(actions, stream.Options{TPS: 1, Workers: 1, Originator: "o"}, discardLogger())
+	t.Cleanup(ctrl.Stop)
+
+	walletAPI := &fakeWalletAPI{balance: 42, fuelTotal: 7, reserveTotal: 3}
+	sampler := metrics.NewSampler(walletAPI, ctrl, "o", 50*time.Millisecond, 10, 20, 100, 60, 100, discardLogger())
+	go sampler.Run(parent)
+
+	// Wait until LastTick is populated.
+	require.Eventually(t, func() bool {
+		return sampler.LastTick().Timestamp != ""
+	}, 2*time.Second, 20*time.Millisecond)
+
+	srv := api.New(api.Deps{
+		Ctrl:       ctrl,
+		Sampler:    sampler,
+		Wallet:     &fakeInternalizer{},
+		Priv:       testPriv(t),
+		Network:    defs.NetworkMainnet,
+		Originator: "o",
+		ServerURL:  "http://example",
+		Logger:     discardLogger(),
+		ParentCtx:  parent,
+	})
+
+	rec := doJSON(t, srv.Handler(), http.MethodGet, "/api/status", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := decodeMap(t, rec)
+	tick := body["tick"].(map[string]any)
+	assert.Equal(t, float64(42), tick["default_sats"])
+	assert.Equal(t, float64(7), tick["fuel_count"])
+	assert.Equal(t, float64(3), tick["reserve_count"])
+	streamStats := tick["stream"].(map[string]any)
+	assert.Equal(t, false, streamStats["running"])
+}
+
+func TestStreamStartStop_StatusRunning(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Start with overrides.
+	rec := doJSON(t, env.handler, http.MethodPost, "/api/stream/start", map[string]any{
+		"tps":     25,
+		"workers": 3,
+	})
+	require.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+	startBody := decodeMap(t, rec)
+	assert.Equal(t, true, startBody["ok"])
+	stats := startBody["stats"].(map[string]any)
+	assert.Equal(t, true, stats["running"])
+	assert.Equal(t, float64(25), stats["tps"])
+	assert.Equal(t, float64(3), stats["workers"])
+	require.True(t, env.ctrl.Running())
+
+	// Double start → 409 Conflict.
+	rec2 := doJSON(t, env.handler, http.MethodPost, "/api/stream/start", map[string]any{"tps": 1})
+	require.Equal(t, http.StatusConflict, rec2.Code)
+	errBody := decodeMap(t, rec2)
+	assert.Contains(t, errBody["error"], "already running")
+
+	// Stop.
+	rec3 := doJSON(t, env.handler, http.MethodPost, "/api/stream/stop", nil)
+	require.Equal(t, http.StatusOK, rec3.Code)
+	stopBody := decodeMap(t, rec3)
+	assert.Equal(t, true, stopBody["ok"])
+	stopStats := stopBody["stats"].(map[string]any)
+	assert.Equal(t, false, stopStats["running"])
+	require.False(t, env.ctrl.Running())
+
+	// Stop when already stopped is still OK.
+	rec4 := doJSON(t, env.handler, http.MethodPost, "/api/stream/stop", nil)
+	require.Equal(t, http.StatusOK, rec4.Code)
+}
+
+func TestStreamStart_EmptyBodyUsesDefaults(t *testing.T) {
+	env := newTestEnv(t)
+
+	rec := doJSON(t, env.handler, http.MethodPost, "/api/stream/start", nil)
+	require.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+	body := decodeMap(t, rec)
+	stats := body["stats"].(map[string]any)
+	assert.Equal(t, true, stats["running"])
+	// Defaults from NewController in newTestEnv.
+	assert.Equal(t, float64(10), stats["tps"])
+	assert.Equal(t, float64(2), stats["workers"])
+
+	env.ctrl.Stop()
+}
+
+func TestFunding_ReturnsDepositAddress(t *testing.T) {
+	env := newTestEnv(t)
+
+	rec := doJSON(t, env.handler, http.MethodGet, "/api/funding", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := decodeMap(t, rec)
+	assert.Equal(t, "main", body["network"])
+	assert.NotEmpty(t, body["address"])
+	assert.NotEmpty(t, body["locking_script_hex"])
+	assert.Equal(t, funding.DerivationPrefixB64, body["derivation_prefix_b64"])
+	assert.Equal(t, funding.DerivationSuffixB64, body["derivation_suffix_b64"])
+	assert.Equal(t, float64(100_000), body["suggested_satoshis"])
+}
+
+func TestInternalize_AtomicPath(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Unparseable atomic hex skips address validation and still reaches wallet.
+	rec := doJSON(t, env.handler, http.MethodPost, "/api/funding/internalize", map[string]any{
+		"atomic_tx_hex": "deadbeef",
+		"output_index":  0,
+	})
+	require.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+	body := decodeMap(t, rec)
+	assert.Equal(t, true, body["ok"])
+	assert.Equal(t, 1, env.wallet.callCount())
+}
+
+func TestInternalize_InvalidJSON(t *testing.T) {
+	env := newTestEnv(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/funding/internalize", bytes.NewBufferString("{not-json"))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	env.handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	body := decodeMap(t, rec)
+	assert.Contains(t, body["error"], "invalid json")
+}
+
+func TestInternalize_MissingFields(t *testing.T) {
+	env := newTestEnv(t)
+
+	rec := doJSON(t, env.handler, http.MethodPost, "/api/funding/internalize", map[string]any{})
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	body := decodeMap(t, rec)
+	assert.Contains(t, body["error"], "atomic_tx_hex or txid")
+	assert.Equal(t, 0, env.wallet.callCount())
+}
+
+func TestCORS_Options(t *testing.T) {
+	env := newTestEnv(t)
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/status", nil)
+	rec := httptest.NewRecorder()
+	env.handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
+	assert.Contains(t, rec.Header().Get("Access-Control-Allow-Methods"), "POST")
+}
+
+func TestStatic_Index(t *testing.T) {
+	env := newTestEnv(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	env.handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "dashboard")
+}
+
+func TestEvents_SSEHeadersAndInitialTick(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	actions := &fakeActionCreator{}
+	ctrl := stream.NewController(actions, stream.Options{TPS: 1, Workers: 1, Originator: "o"}, discardLogger())
+	t.Cleanup(ctrl.Stop)
+
+	walletAPI := &fakeWalletAPI{fuelTotal: 1}
+	sampler := metrics.NewSampler(walletAPI, ctrl, "o", 50*time.Millisecond, 10, 20, 100, 60, 100, discardLogger())
+	go sampler.Run(parent)
+	require.Eventually(t, func() bool {
+		return sampler.LastTick().Timestamp != ""
+	}, 2*time.Second, 20*time.Millisecond)
+
+	srv := api.New(api.Deps{
+		Ctrl:       ctrl,
+		Sampler:    sampler,
+		Wallet:     &fakeInternalizer{},
+		Priv:       testPriv(t),
+		Network:    defs.NetworkMainnet,
+		Originator: "o",
+		ServerURL:  "http://example",
+		Logger:     discardLogger(),
+		ParentCtx:  parent,
+	})
+
+	ctx, cancelReq := context.WithCancel(context.Background())
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/events", nil)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.Handler().ServeHTTP(rec, req)
+	}()
+
+	// Wait for first SSE payload then cancel client.
+	require.Eventually(t, func() bool {
+		return rec.Body.Len() > 0
+	}, 2*time.Second, 20*time.Millisecond)
+	cancelReq()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SSE handler did not exit after client cancel")
+	}
+
+	assert.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))
+	assert.Contains(t, rec.Body.String(), "event: tick")
+	assert.Contains(t, rec.Body.String(), "data:")
+}

--- a/cmd/throughput_dashboard/internal/api/server_test.go
+++ b/cmd/throughput_dashboard/internal/api/server_test.go
@@ -152,7 +152,7 @@ func newTestEnv(t *testing.T, opts ...func(*api.Deps)) *testEnv {
 		Originator: "test-origin",
 		ServerURL:  "http://127.0.0.1:8101",
 		Logger:     discardLogger(),
-		Done: doneFromCtx(parent),
+		Done:       doneFromCtx(parent),
 		WebFS: fstest.MapFS{
 			"index.html": &fstest.MapFile{Data: []byte("<html>dashboard</html>")},
 		},
@@ -226,7 +226,7 @@ func TestStatus_IncludesTickAfterSample(t *testing.T) {
 
 	walletAPI := &fakeWalletAPI{balance: 42, fuelTotal: 7, reserveTotal: 3}
 	sampler := metrics.NewSampler(walletAPI, ctrl, metrics.Config{
-		Originator: "o", Interval: 50*time.Millisecond,
+		Originator: "o", Interval: 50 * time.Millisecond,
 		TargetTPS: 10, Denomination: 20, TargetPool: 100,
 		LowWaterPercent: 60, HighWaterPercent: 100,
 		Logger: discardLogger(),
@@ -247,7 +247,7 @@ func TestStatus_IncludesTickAfterSample(t *testing.T) {
 		Originator: "o",
 		ServerURL:  "http://example",
 		Logger:     discardLogger(),
-		Done: doneFromCtx(parent),
+		Done:       doneFromCtx(parent),
 	})
 
 	rec := doJSON(t, srv.Handler(), http.MethodGet, "/api/status", nil)
@@ -394,7 +394,7 @@ func TestEvents_SSEHeadersAndInitialTick(t *testing.T) {
 
 	walletAPI := &fakeWalletAPI{fuelTotal: 1}
 	sampler := metrics.NewSampler(walletAPI, ctrl, metrics.Config{
-		Originator: "o", Interval: 50*time.Millisecond,
+		Originator: "o", Interval: 50 * time.Millisecond,
 		TargetTPS: 10, Denomination: 20, TargetPool: 100,
 		LowWaterPercent: 60, HighWaterPercent: 100,
 		Logger: discardLogger(),
@@ -413,7 +413,7 @@ func TestEvents_SSEHeadersAndInitialTick(t *testing.T) {
 		Originator: "o",
 		ServerURL:  "http://example",
 		Logger:     discardLogger(),
-		Done: doneFromCtx(parent),
+		Done:       doneFromCtx(parent),
 	})
 
 	ctx, cancelReq := context.WithCancel(context.Background())

--- a/cmd/throughput_dashboard/internal/api/server_test.go
+++ b/cmd/throughput_dashboard/internal/api/server_test.go
@@ -381,6 +381,30 @@ func TestStatic_Index(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "dashboard")
 }
 
+// sseRecorder is an httptest.ResponseRecorder that implements http.Flusher and
+// signals when the first body write completes. Callers must not read Body/Header
+// until ServeHTTP has returned — ResponseRecorder is not concurrency-safe.
+type sseRecorder struct {
+	*httptest.ResponseRecorder
+	firstWrite chan struct{}
+	once       sync.Once
+}
+
+func newSSERecorder() *sseRecorder {
+	return &sseRecorder{
+		ResponseRecorder: httptest.NewRecorder(),
+		firstWrite:       make(chan struct{}),
+	}
+}
+
+func (r *sseRecorder) Write(b []byte) (int, error) {
+	n, err := r.ResponseRecorder.Write(b)
+	r.once.Do(func() { close(r.firstWrite) })
+	return n, err
+}
+
+func (r *sseRecorder) Flush() {}
+
 func TestEvents_SSEHeadersAndInitialTick(t *testing.T) {
 	parent, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -415,7 +439,7 @@ func TestEvents_SSEHeadersAndInitialTick(t *testing.T) {
 
 	ctx, cancelReq := context.WithCancel(context.Background())
 	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/events", nil)
-	rec := httptest.NewRecorder()
+	rec := newSSERecorder()
 
 	done := make(chan struct{})
 	go func() {
@@ -423,10 +447,13 @@ func TestEvents_SSEHeadersAndInitialTick(t *testing.T) {
 		srv.Handler().ServeHTTP(rec, req)
 	}()
 
-	// Wait for first SSE payload then cancel client.
-	require.Eventually(t, func() bool {
-		return rec.Body.Len() > 0
-	}, 2*time.Second, 20*time.Millisecond)
+	// Wait for the handler's first write (without reading the body concurrently —
+	// that races with ResponseRecorder.Write under -race).
+	select {
+	case <-rec.firstWrite:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first SSE write")
+	}
 	cancelReq()
 	select {
 	case <-done:
@@ -434,6 +461,7 @@ func TestEvents_SSEHeadersAndInitialTick(t *testing.T) {
 		t.Fatal("SSE handler did not exit after client cancel")
 	}
 
+	// Safe: handler goroutine has exited.
 	assert.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))
 	assert.Contains(t, rec.Body.String(), "event: tick")
 	assert.Contains(t, rec.Body.String(), "data:")

--- a/cmd/throughput_dashboard/internal/config/config.go
+++ b/cmd/throughput_dashboard/internal/config/config.go
@@ -66,12 +66,17 @@ func ConfigFromEnv() (Config, error) {
 	return cfg, nil
 }
 
-// DemoThroughput returns the fuel profile matching infra-config-docker-throughput-mainnet.yaml.
+// DemoThroughput returns the fuel profile for the local demo dashboard.
+// Denomination shape matches the live-test OP_RETURN config (200 B / 0 output sats
+// → 20 sat fuel). Target pool is intentionally small so FuelKeeper can refill
+// from a modest deposit without minting hundreds of thousands of UTXOs.
 func DemoThroughput() defs.Throughput {
 	base := defs.DefaultUTXOManagement().Throughput
 	base.ExpectedTxSizeBytes = 200
 	base.ExpectedOutputSatoshis = 0
-	base.TargetTPS = 1000
+	base.TargetTPS = 10
+	base.TargetPoolSize = 500 // explicit demo pool (not 1000 TPS × 300s × 1.5)
+	base.FanoutMaxTxsPerRound = 50
 	return base
 }
 

--- a/cmd/throughput_dashboard/internal/config/config.go
+++ b/cmd/throughput_dashboard/internal/config/config.go
@@ -1,0 +1,95 @@
+// Package config loads throughput-dashboard settings from the environment.
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+)
+
+// Config holds dashboard runtime settings.
+type Config struct {
+	ServerURL     string
+	Network       string
+	PrivateKeyHex string
+	Originator    string
+	HTTPAddr      string
+	TPS           int
+	Workers       int
+	SampleSeconds int
+}
+
+// ConfigFromEnv reads configuration from environment variables.
+// PRIVATE_KEY is required. Defaults are mainnet-first and demo-safe.
+func ConfigFromEnv() (Config, error) {
+	cfg := Config{
+		ServerURL:     envOrDefault("SERVER_URL", "http://127.0.0.1:8101"),
+		Network:       envOrDefault("BSV_NETWORK", string(defs.NetworkMainnet)),
+		PrivateKeyHex: os.Getenv("PRIVATE_KEY"),
+		Originator:    envOrDefault("ORIGINATOR", "throughput-dashboard.local"),
+		HTTPAddr:      envOrDefault("HTTP_ADDR", "127.0.0.1:8200"),
+		TPS:           10,
+		Workers:       8,
+		SampleSeconds: 1,
+	}
+
+	if cfg.PrivateKeyHex == "" {
+		return Config{}, fmt.Errorf("PRIVATE_KEY is required")
+	}
+
+	var err error
+	if cfg.TPS, err = envIntOrDefault("TPS", 10); err != nil {
+		return Config{}, err
+	}
+	if cfg.Workers, err = envIntOrDefault("WORKERS", 8); err != nil {
+		return Config{}, err
+	}
+	if cfg.SampleSeconds, err = envIntOrDefault("SAMPLE_SECONDS", 1); err != nil {
+		return Config{}, err
+	}
+
+	if cfg.TPS <= 0 {
+		return Config{}, fmt.Errorf("TPS must be > 0, got %d", cfg.TPS)
+	}
+	if cfg.Workers <= 0 {
+		return Config{}, fmt.Errorf("WORKERS must be > 0, got %d", cfg.Workers)
+	}
+	if cfg.SampleSeconds <= 0 {
+		return Config{}, fmt.Errorf("SAMPLE_SECONDS must be > 0, got %d", cfg.SampleSeconds)
+	}
+	if _, err = defs.ParseBSVNetworkStr(cfg.Network); err != nil {
+		return Config{}, fmt.Errorf("BSV_NETWORK: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// DemoThroughput returns the fuel profile matching infra-config-docker-throughput-mainnet.yaml.
+func DemoThroughput() defs.Throughput {
+	base := defs.DefaultUTXOManagement().Throughput
+	base.ExpectedTxSizeBytes = 200
+	base.ExpectedOutputSatoshis = 0
+	base.TargetTPS = 1000
+	return base
+}
+
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func envIntOrDefault(key string, def int) (int, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return def, nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, fmt.Errorf("%s: invalid integer %q: %w", key, v, err)
+	}
+	return n, nil
+}

--- a/cmd/throughput_dashboard/internal/config/config_test.go
+++ b/cmd/throughput_dashboard/internal/config/config_test.go
@@ -101,10 +101,11 @@ func TestDemoThroughputMatchesLiveTestShape(t *testing.T) {
 	tp := config.DemoThroughput()
 	require.Equal(t, uint64(200), tp.ExpectedTxSizeBytes)
 	require.Equal(t, uint64(0), tp.ExpectedOutputSatoshis)
-	require.Equal(t, uint64(1000), tp.TargetTPS)
+	require.Equal(t, uint64(10), tp.TargetTPS)
+	require.Equal(t, uint64(500), tp.TargetPool())
 
 	// DefaultFeeModel is 100 sat/kb; DefaultCommission disabled →
-	// ceil(200/1000 * 100) + 0 = 20 sats (matches mainnet demo yaml).
+	// ceil(200/1000 * 100) + 0 = 20 sats (matches OP_RETURN demo shape).
 	fee := defs.DefaultFeeModel()
 	require.Equal(t, defs.SatPerKB, fee.Type)
 	require.Equal(t, int64(100), fee.Value)

--- a/cmd/throughput_dashboard/internal/config/config_test.go
+++ b/cmd/throughput_dashboard/internal/config/config_test.go
@@ -1,0 +1,62 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/config"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigFromEnvRequiresPrivateKey(t *testing.T) {
+	t.Setenv("PRIVATE_KEY", "")
+	_, err := config.ConfigFromEnv()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "PRIVATE_KEY")
+}
+
+func TestConfigFromEnvMainnetDefaults(t *testing.T) {
+	t.Setenv("PRIVATE_KEY", "aa")
+	t.Setenv("SERVER_URL", "")
+	t.Setenv("BSV_NETWORK", "")
+	t.Setenv("HTTP_ADDR", "")
+	t.Setenv("TPS", "")
+	t.Setenv("WORKERS", "")
+	t.Setenv("SAMPLE_SECONDS", "")
+	t.Setenv("ORIGINATOR", "")
+
+	cfg, err := config.ConfigFromEnv()
+	require.NoError(t, err)
+	require.Equal(t, "http://127.0.0.1:8101", cfg.ServerURL)
+	require.Equal(t, string(defs.NetworkMainnet), cfg.Network)
+	require.Equal(t, "127.0.0.1:8200", cfg.HTTPAddr)
+	require.Equal(t, 10, cfg.TPS)
+	require.Equal(t, 8, cfg.Workers)
+	require.Equal(t, 1, cfg.SampleSeconds)
+	require.Equal(t, "throughput-dashboard.local", cfg.Originator)
+}
+
+func TestConfigFromEnvOverrides(t *testing.T) {
+	t.Setenv("PRIVATE_KEY", "deadbeef")
+	t.Setenv("SERVER_URL", "http://infra:8100")
+	t.Setenv("BSV_NETWORK", "main")
+	t.Setenv("TPS", "50")
+	t.Setenv("WORKERS", "16")
+
+	cfg, err := config.ConfigFromEnv()
+	require.NoError(t, err)
+	require.Equal(t, "http://infra:8100", cfg.ServerURL)
+	require.Equal(t, 50, cfg.TPS)
+	require.Equal(t, 16, cfg.Workers)
+}
+
+func TestDemoThroughputMatchesLiveTestShape(t *testing.T) {
+	tp := config.DemoThroughput()
+	require.Equal(t, uint64(200), tp.ExpectedTxSizeBytes)
+	require.Equal(t, uint64(0), tp.ExpectedOutputSatoshis)
+	require.Equal(t, uint64(1000), tp.TargetTPS)
+
+	denom, err := tp.Denomination(defs.DefaultFeeModel(), defs.DefaultCommission())
+	require.NoError(t, err)
+	require.Equal(t, uint64(20), denom)
+}

--- a/cmd/throughput_dashboard/internal/config/config_test.go
+++ b/cmd/throughput_dashboard/internal/config/config_test.go
@@ -40,14 +40,61 @@ func TestConfigFromEnvOverrides(t *testing.T) {
 	t.Setenv("PRIVATE_KEY", "deadbeef")
 	t.Setenv("SERVER_URL", "http://infra:8100")
 	t.Setenv("BSV_NETWORK", "main")
+	t.Setenv("HTTP_ADDR", "0.0.0.0:8200")
 	t.Setenv("TPS", "50")
 	t.Setenv("WORKERS", "16")
+	t.Setenv("SAMPLE_SECONDS", "2")
+	t.Setenv("ORIGINATOR", "custom.local")
 
 	cfg, err := config.ConfigFromEnv()
 	require.NoError(t, err)
 	require.Equal(t, "http://infra:8100", cfg.ServerURL)
+	require.Equal(t, "main", cfg.Network)
+	require.Equal(t, "deadbeef", cfg.PrivateKeyHex)
+	require.Equal(t, "0.0.0.0:8200", cfg.HTTPAddr)
 	require.Equal(t, 50, cfg.TPS)
 	require.Equal(t, 16, cfg.Workers)
+	require.Equal(t, 2, cfg.SampleSeconds)
+	require.Equal(t, "custom.local", cfg.Originator)
+}
+
+func TestConfigFromEnvRejectsNonPositiveTPS(t *testing.T) {
+	t.Setenv("PRIVATE_KEY", "aa")
+	t.Setenv("TPS", "0")
+	_, err := config.ConfigFromEnv()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "TPS")
+}
+
+func TestConfigFromEnvRejectsNonPositiveWorkers(t *testing.T) {
+	t.Setenv("PRIVATE_KEY", "aa")
+	t.Setenv("WORKERS", "-1")
+	_, err := config.ConfigFromEnv()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WORKERS")
+}
+
+func TestConfigFromEnvRejectsNonPositiveSampleSeconds(t *testing.T) {
+	t.Setenv("PRIVATE_KEY", "aa")
+	t.Setenv("SAMPLE_SECONDS", "0")
+	_, err := config.ConfigFromEnv()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "SAMPLE_SECONDS")
+}
+
+func TestConfigFromEnvRejectsInvalidInt(t *testing.T) {
+	t.Setenv("PRIVATE_KEY", "aa")
+	t.Setenv("TPS", "not-a-number")
+	_, err := config.ConfigFromEnv()
+	require.Error(t, err)
+}
+
+func TestConfigFromEnvRejectsInvalidNetwork(t *testing.T) {
+	t.Setenv("PRIVATE_KEY", "aa")
+	t.Setenv("BSV_NETWORK", "not-a-network")
+	_, err := config.ConfigFromEnv()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "BSV_NETWORK")
 }
 
 func TestDemoThroughputMatchesLiveTestShape(t *testing.T) {
@@ -56,7 +103,13 @@ func TestDemoThroughputMatchesLiveTestShape(t *testing.T) {
 	require.Equal(t, uint64(0), tp.ExpectedOutputSatoshis)
 	require.Equal(t, uint64(1000), tp.TargetTPS)
 
-	denom, err := tp.Denomination(defs.DefaultFeeModel(), defs.DefaultCommission())
+	// DefaultFeeModel is 100 sat/kb; DefaultCommission disabled →
+	// ceil(200/1000 * 100) + 0 = 20 sats (matches mainnet demo yaml).
+	fee := defs.DefaultFeeModel()
+	require.Equal(t, defs.SatPerKB, fee.Type)
+	require.Equal(t, int64(100), fee.Value)
+
+	denom, err := tp.Denomination(fee, defs.DefaultCommission())
 	require.NoError(t, err)
 	require.Equal(t, uint64(20), denom)
 }

--- a/cmd/throughput_dashboard/internal/connect/connect.go
+++ b/cmd/throughput_dashboard/internal/connect/connect.go
@@ -1,0 +1,116 @@
+// Package connect builds a remote-storage operator wallet with startup retries.
+package connect
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	sdk "github.com/bsv-blockchain/go-sdk/wallet"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/storage"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+)
+
+const (
+	connectRetryWindow  = 30 * time.Second
+	connectRetryInitial = 1 * time.Second
+	connectRetryMax     = 5 * time.Second
+)
+
+// Wallet connects to remote storage, probing with Balance until ready.
+func Wallet(
+	ctx context.Context,
+	network defs.BSVNetwork,
+	priv *ec.PrivateKey,
+	serverURL string,
+	logger *slog.Logger,
+) (*wallet.Wallet, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	var connected *wallet.Wallet
+	err := retryWithBackoff(ctx, connectRetryWindow, connectRetryInitial, connectRetryMax,
+		func() error {
+			if connected != nil {
+				connected.Close()
+				connected = nil
+			}
+			w, err := wallet.NewWithStorageFactory(network, priv, func(userWallet sdk.Interface) (wdk.WalletStorageProvider, func(), error) {
+				return storage.NewClient(serverURL, userWallet)
+			})
+			if err != nil {
+				return err
+			}
+			if _, err = w.Balance(ctx); err != nil {
+				w.Close()
+				return err
+			}
+			connected = w
+			return nil
+		},
+		func(n int, err error, sleep time.Duration) {
+			logger.Warn("storage not ready, retrying",
+				"server_url", serverURL,
+				"attempt", n,
+				"error", err,
+				"retry_in", sleep.String(),
+			)
+		},
+	)
+	if err != nil {
+		if connected != nil {
+			connected.Close()
+		}
+		return nil, fmt.Errorf("infra unreachable at %s: %w", serverURL, err)
+	}
+	return connected, nil
+}
+
+func retryWithBackoff(
+	ctx context.Context,
+	window, initial, maxBackoff time.Duration,
+	attempt func() error,
+	onRetry func(n int, err error, sleep time.Duration),
+) error {
+	deadline := time.Now().Add(window)
+	backoff := initial
+	var lastErr error
+
+	for n := 1; ; n++ {
+		err := attempt()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return fmt.Errorf("after %s (%d attempts): %w", window, n, lastErr)
+		}
+
+		sleep := backoff
+		if sleep > remaining {
+			sleep = remaining
+		}
+		if onRetry != nil {
+			onRetry(n, err, sleep)
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("aborted: %w", ctx.Err())
+		case <-time.After(sleep):
+		}
+
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+}

--- a/cmd/throughput_dashboard/internal/connect/connect.go
+++ b/cmd/throughput_dashboard/internal/connect/connect.go
@@ -35,7 +35,8 @@ func Wallet(
 	}
 
 	var connected *wallet.Wallet
-	err := retryWithBackoff(ctx, connectRetryWindow, connectRetryInitial, connectRetryMax,
+	err := retryWithBackoff(
+		ctx, connectRetryWindow, connectRetryInitial, connectRetryMax,
 		func() error {
 			if connected != nil {
 				connected.Close()
@@ -55,7 +56,8 @@ func Wallet(
 			return nil
 		},
 		func(n int, err error, sleep time.Duration) {
-			logger.Warn("storage not ready, retrying",
+			logger.Warn(
+				"storage not ready, retrying",
 				"server_url", serverURL,
 				"attempt", n,
 				"error", err,

--- a/cmd/throughput_dashboard/internal/connect/connect_test.go
+++ b/cmd/throughput_dashboard/internal/connect/connect_test.go
@@ -1,0 +1,90 @@
+package connect
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryWithBackoffSucceedsAfterFailures(t *testing.T) {
+	var calls atomic.Int32
+	err := retryWithBackoff(
+		context.Background(),
+		2*time.Second,
+		10*time.Millisecond,
+		50*time.Millisecond,
+		func() error {
+			n := calls.Add(1)
+			if n < 3 {
+				return errors.New("not ready")
+			}
+			return nil
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int32(3), calls.Load())
+}
+
+func TestRetryWithBackoffExhaustsWindow(t *testing.T) {
+	err := retryWithBackoff(
+		context.Background(),
+		80*time.Millisecond,
+		20*time.Millisecond,
+		20*time.Millisecond,
+		func() error { return errors.New("down") },
+		nil,
+	)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "after")
+	require.ErrorContains(t, err, "down")
+}
+
+func TestRetryWithBackoffRespectsCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+	}()
+	err := retryWithBackoff(
+		ctx,
+		5*time.Second,
+		100*time.Millisecond,
+		100*time.Millisecond,
+		func() error { return errors.New("down") },
+		nil,
+	)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "aborted")
+}
+
+func TestRetryWithBackoffOnRetryCallback(t *testing.T) {
+	var retries atomic.Int32
+	var calls atomic.Int32
+	err := retryWithBackoff(
+		context.Background(),
+		500*time.Millisecond,
+		5*time.Millisecond,
+		20*time.Millisecond,
+		func() error {
+			n := calls.Add(1)
+			if n < 2 {
+				return errors.New("not ready")
+			}
+			return nil
+		},
+		func(n int, err error, sleep time.Duration) {
+			retries.Add(1)
+			require.Equal(t, 1, n)
+			require.ErrorContains(t, err, "not ready")
+			require.Positive(t, sleep)
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), retries.Load())
+}

--- a/cmd/throughput_dashboard/internal/funding/address.go
+++ b/cmd/throughput_dashboard/internal/funding/address.go
@@ -1,0 +1,95 @@
+// Package funding derives the operator deposit address and internalizes top-ups.
+package funding
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/script"
+	"github.com/bsv-blockchain/go-sdk/transaction/template/p2pkh"
+	sdk "github.com/bsv-blockchain/go-sdk/wallet"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/brc29"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+)
+
+// Fixed BRC-29 derivation used by faucet examples / loadgen bootstrap.
+// Browser WalletClient pays this address; internalize uses AnyoneKey remittance.
+const (
+	DerivationPrefixB64 = "SfKxPIJNgdI="
+	DerivationSuffixB64 = "NaGLC6fMH50="
+)
+
+// Info is returned to the dashboard UI for WalletClient payments.
+type Info struct {
+	Network              string `json:"network"`
+	Address              string `json:"address"`
+	LockingScriptHex     string `json:"locking_script_hex"`
+	DerivationPrefixB64  string `json:"derivation_prefix_b64"`
+	DerivationSuffixB64  string `json:"derivation_suffix_b64"`
+	SenderIdentityKeyHex string `json:"sender_identity_key_hex"` // AnyoneKey — remittance sender
+	OperatorIdentityHex  string `json:"operator_identity_hex"`
+	SuggestedSatoshis    uint64 `json:"suggested_satoshis"`
+}
+
+// DeriveInfo builds the mainnet/testnet BRC-29 deposit address for the operator.
+func DeriveInfo(priv *ec.PrivateKey, network defs.BSVNetwork, suggested uint64) (Info, error) {
+	_, anyonePub := sdk.AnyoneKey()
+	keyID := brc29.KeyID{
+		DerivationPrefix: DerivationPrefixB64,
+		DerivationSuffix: DerivationSuffixB64,
+	}
+
+	var (
+		addr *script.Address
+		err  error
+	)
+	if network == defs.NetworkTestnet {
+		addr, err = brc29.AddressForSelf(anyonePub, keyID, priv, brc29.WithTestNet())
+	} else {
+		addr, err = brc29.AddressForSelf(anyonePub, keyID, priv, brc29.WithMainNet())
+	}
+	if err != nil {
+		return Info{}, fmt.Errorf("derive brc29 address: %w", err)
+	}
+
+	lock, err := p2pkh.Lock(addr)
+	if err != nil {
+		return Info{}, fmt.Errorf("p2pkh lock: %w", err)
+	}
+
+	if suggested == 0 {
+		suggested = 100_000 // 0.001 BSV — enough for demo fan-out rounds
+	}
+
+	return Info{
+		Network:              string(network),
+		Address:              addr.AddressString,
+		LockingScriptHex:     hex.EncodeToString(lock.Bytes()),
+		DerivationPrefixB64:  DerivationPrefixB64,
+		DerivationSuffixB64:  DerivationSuffixB64,
+		SenderIdentityKeyHex: anyonePub.ToDERHex(),
+		OperatorIdentityHex:  priv.PubKey().ToDERHex(),
+		SuggestedSatoshis:    suggested,
+	}, nil
+}
+
+// AnyonePaymentRemittance returns the wallet-payment remittance for faucet-style deposits.
+func AnyonePaymentRemittance() (*sdk.Payment, error) {
+	prefix, err := base64.StdEncoding.DecodeString(DerivationPrefixB64)
+	if err != nil {
+		return nil, fmt.Errorf("decode prefix: %w", err)
+	}
+	suffix, err := base64.StdEncoding.DecodeString(DerivationSuffixB64)
+	if err != nil {
+		return nil, fmt.Errorf("decode suffix: %w", err)
+	}
+	_, anyonePub := sdk.AnyoneKey()
+	return &sdk.Payment{
+		DerivationPrefix:  prefix,
+		DerivationSuffix:  suffix,
+		SenderIdentityKey: anyonePub,
+	}, nil
+}

--- a/cmd/throughput_dashboard/internal/funding/address.go
+++ b/cmd/throughput_dashboard/internal/funding/address.go
@@ -20,6 +20,9 @@ import (
 const (
 	DerivationPrefixB64 = "SfKxPIJNgdI="
 	DerivationSuffixB64 = "NaGLC6fMH50="
+
+	// defaultSuggestedSatoshis is 0.001 BSV — enough for demo fan-out rounds.
+	defaultSuggestedSatoshis uint64 = 100_000
 )
 
 // Info is returned to the dashboard UI for WalletClient payments.
@@ -35,7 +38,15 @@ type Info struct {
 }
 
 // DeriveInfo builds the mainnet/testnet BRC-29 deposit address for the operator.
+// Sender is always AnyoneKey; KeyID prefix/suffix are the fixed faucet constants.
 func DeriveInfo(priv *ec.PrivateKey, network defs.BSVNetwork, suggested uint64) (Info, error) {
+	if priv == nil {
+		return Info{}, fmt.Errorf("operator private key is required")
+	}
+	if err := network.Validate(); err != nil {
+		return Info{}, err
+	}
+
 	_, anyonePub := sdk.AnyoneKey()
 	keyID := brc29.KeyID{
 		DerivationPrefix: DerivationPrefixB64,
@@ -46,9 +57,11 @@ func DeriveInfo(priv *ec.PrivateKey, network defs.BSVNetwork, suggested uint64) 
 		addr *script.Address
 		err  error
 	)
-	if network == defs.NetworkTestnet {
+	switch network {
+	case defs.NetworkTestnet:
 		addr, err = brc29.AddressForSelf(anyonePub, keyID, priv, brc29.WithTestNet())
-	} else {
+	default:
+		// NetworkMainnet (and any future validated mainnet aliases).
 		addr, err = brc29.AddressForSelf(anyonePub, keyID, priv, brc29.WithMainNet())
 	}
 	if err != nil {
@@ -61,7 +74,7 @@ func DeriveInfo(priv *ec.PrivateKey, network defs.BSVNetwork, suggested uint64) 
 	}
 
 	if suggested == 0 {
-		suggested = 100_000 // 0.001 BSV — enough for demo fan-out rounds
+		suggested = defaultSuggestedSatoshis
 	}
 
 	return Info{
@@ -77,6 +90,7 @@ func DeriveInfo(priv *ec.PrivateKey, network defs.BSVNetwork, suggested uint64) 
 }
 
 // AnyonePaymentRemittance returns the wallet-payment remittance for faucet-style deposits.
+// Derivation bytes match DerivationPrefixB64 / DerivationSuffixB64; sender is AnyoneKey.
 func AnyonePaymentRemittance() (*sdk.Payment, error) {
 	prefix, err := base64.StdEncoding.DecodeString(DerivationPrefixB64)
 	if err != nil {

--- a/cmd/throughput_dashboard/internal/funding/address.go
+++ b/cmd/throughput_dashboard/internal/funding/address.go
@@ -60,9 +60,10 @@ func DeriveInfo(priv *ec.PrivateKey, network defs.BSVNetwork, suggested uint64) 
 	switch network {
 	case defs.NetworkTestnet:
 		addr, err = brc29.AddressForSelf(anyonePub, keyID, priv, brc29.WithTestNet())
-	default:
-		// NetworkMainnet (and any future validated mainnet aliases).
+	case defs.NetworkMainnet:
 		addr, err = brc29.AddressForSelf(anyonePub, keyID, priv, brc29.WithMainNet())
+	default:
+		return Info{}, fmt.Errorf("unsupported network: %s", network)
 	}
 	if err != nil {
 		return Info{}, fmt.Errorf("derive brc29 address: %w", err)

--- a/cmd/throughput_dashboard/internal/funding/address_test.go
+++ b/cmd/throughput_dashboard/internal/funding/address_test.go
@@ -1,32 +1,120 @@
 package funding_test
 
 import (
+	"encoding/base64"
+	"encoding/hex"
 	"testing"
 
 	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	sdk "github.com/bsv-blockchain/go-sdk/wallet"
 	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/funding"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/brc29"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDeriveInfoMainnet(t *testing.T) {
-	priv, err := ec.NewPrivateKey()
+// Fixed operator key for deterministic address regression checks.
+const operatorPrivHex = "0000000000000000000000000000000000000000000000000000000000000001"
+
+func testOperatorPriv(t *testing.T) *ec.PrivateKey {
+	t.Helper()
+	priv, err := ec.PrivateKeyFromHex(operatorPrivHex)
 	require.NoError(t, err)
+	return priv
+}
+
+func TestDeriveInfoMainnet(t *testing.T) {
+	priv := testOperatorPriv(t)
 
 	info, err := funding.DeriveInfo(priv, defs.NetworkMainnet, 50_000)
 	require.NoError(t, err)
 	require.Equal(t, "main", info.Network)
 	require.NotEmpty(t, info.Address)
 	require.NotEmpty(t, info.LockingScriptHex)
+	// Locking script must be valid hex for WalletClient.
+	_, err = hex.DecodeString(info.LockingScriptHex)
+	require.NoError(t, err)
 	require.Equal(t, funding.DerivationPrefixB64, info.DerivationPrefixB64)
+	require.Equal(t, funding.DerivationSuffixB64, info.DerivationSuffixB64)
 	require.Equal(t, uint64(50_000), info.SuggestedSatoshis)
 	require.Equal(t, priv.PubKey().ToDERHex(), info.OperatorIdentityHex)
+
+	_, anyonePub := sdk.AnyoneKey()
+	require.Equal(t, anyonePub.ToDERHex(), info.SenderIdentityKeyHex)
+
+	// Cross-check against brc29.AddressForSelf with the same inputs.
+	keyID := brc29.KeyID{
+		DerivationPrefix: funding.DerivationPrefixB64,
+		DerivationSuffix: funding.DerivationSuffixB64,
+	}
+	expected, err := brc29.AddressForSelf(anyonePub, keyID, priv, brc29.WithMainNet())
+	require.NoError(t, err)
+	require.Equal(t, expected.AddressString, info.Address)
+}
+
+func TestDeriveInfoTestnet(t *testing.T) {
+	priv := testOperatorPriv(t)
+
+	info, err := funding.DeriveInfo(priv, defs.NetworkTestnet, 1_000)
+	require.NoError(t, err)
+	require.Equal(t, "test", info.Network)
+	require.NotEmpty(t, info.Address)
+	require.NotEqual(t, "", info.LockingScriptHex)
+	require.Equal(t, uint64(1_000), info.SuggestedSatoshis)
+
+	_, anyonePub := sdk.AnyoneKey()
+	keyID := brc29.KeyID{
+		DerivationPrefix: funding.DerivationPrefixB64,
+		DerivationSuffix: funding.DerivationSuffixB64,
+	}
+	expected, err := brc29.AddressForSelf(anyonePub, keyID, priv, brc29.WithTestNet())
+	require.NoError(t, err)
+	require.Equal(t, expected.AddressString, info.Address)
+
+	// Mainnet and testnet addresses must differ for the same key.
+	main, err := funding.DeriveInfo(priv, defs.NetworkMainnet, 1_000)
+	require.NoError(t, err)
+	require.NotEqual(t, main.Address, info.Address)
+}
+
+func TestDeriveInfoDefaultSuggested(t *testing.T) {
+	priv := testOperatorPriv(t)
+	info, err := funding.DeriveInfo(priv, defs.NetworkMainnet, 0)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100_000), info.SuggestedSatoshis)
+}
+
+func TestDeriveInfoNilPriv(t *testing.T) {
+	_, err := funding.DeriveInfo(nil, defs.NetworkMainnet, 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "private key")
+}
+
+func TestDeriveInfoInvalidNetwork(t *testing.T) {
+	priv := testOperatorPriv(t)
+	_, err := funding.DeriveInfo(priv, defs.BSVNetwork("not-a-network"), 0)
+	require.Error(t, err)
 }
 
 func TestAnyonePaymentRemittance(t *testing.T) {
 	p, err := funding.AnyonePaymentRemittance()
 	require.NoError(t, err)
-	require.NotEmpty(t, p.DerivationPrefix)
-	require.NotEmpty(t, p.DerivationSuffix)
+	require.NotNil(t, p)
+
+	wantPrefix, err := base64.StdEncoding.DecodeString(funding.DerivationPrefixB64)
+	require.NoError(t, err)
+	wantSuffix, err := base64.StdEncoding.DecodeString(funding.DerivationSuffixB64)
+	require.NoError(t, err)
+	require.Equal(t, wantPrefix, p.DerivationPrefix)
+	require.Equal(t, wantSuffix, p.DerivationSuffix)
+
+	_, anyonePub := sdk.AnyoneKey()
 	require.NotNil(t, p.SenderIdentityKey)
+	require.Equal(t, anyonePub.ToDERHex(), p.SenderIdentityKey.ToDERHex())
+}
+
+func TestDerivationConstantsMatchFaucet(t *testing.T) {
+	// Keep faucet / loadgen / dashboard derivation aligned.
+	require.Equal(t, "SfKxPIJNgdI=", funding.DerivationPrefixB64)
+	require.Equal(t, "NaGLC6fMH50=", funding.DerivationSuffixB64)
 }

--- a/cmd/throughput_dashboard/internal/funding/address_test.go
+++ b/cmd/throughput_dashboard/internal/funding/address_test.go
@@ -59,7 +59,7 @@ func TestDeriveInfoTestnet(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "test", info.Network)
 	require.NotEmpty(t, info.Address)
-	require.NotEqual(t, "", info.LockingScriptHex)
+	require.NotEmpty(t, info.LockingScriptHex)
 	require.Equal(t, uint64(1_000), info.SuggestedSatoshis)
 
 	_, anyonePub := sdk.AnyoneKey()

--- a/cmd/throughput_dashboard/internal/funding/address_test.go
+++ b/cmd/throughput_dashboard/internal/funding/address_test.go
@@ -1,0 +1,32 @@
+package funding_test
+
+import (
+	"testing"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/funding"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeriveInfoMainnet(t *testing.T) {
+	priv, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+
+	info, err := funding.DeriveInfo(priv, defs.NetworkMainnet, 50_000)
+	require.NoError(t, err)
+	require.Equal(t, "main", info.Network)
+	require.NotEmpty(t, info.Address)
+	require.NotEmpty(t, info.LockingScriptHex)
+	require.Equal(t, funding.DerivationPrefixB64, info.DerivationPrefixB64)
+	require.Equal(t, uint64(50_000), info.SuggestedSatoshis)
+	require.Equal(t, priv.PubKey().ToDERHex(), info.OperatorIdentityHex)
+}
+
+func TestAnyonePaymentRemittance(t *testing.T) {
+	p, err := funding.AnyonePaymentRemittance()
+	require.NoError(t, err)
+	require.NotEmpty(t, p.DerivationPrefix)
+	require.NotEmpty(t, p.DerivationSuffix)
+	require.NotNil(t, p.SenderIdentityKey)
+}

--- a/cmd/throughput_dashboard/internal/funding/internalize.go
+++ b/cmd/throughput_dashboard/internal/funding/internalize.go
@@ -97,11 +97,21 @@ func Internalize(
 		}
 	}
 
-	// Validate the claimed output pays the operator deposit address when possible.
+	// Resolve which vout pays the operator deposit. Local wallets often put
+	// change at vout 0 and the payment later — never assume the preferred index.
+	outputIndex := req.OutputIndex
 	if expectedAddress != "" {
-		if err := validateOutputPaysAddress(atomic, req.OutputIndex, expectedAddress); err != nil {
+		resolved, err := resolvePaymentOutputIndex(atomic, req.OutputIndex, expectedAddress)
+		if err != nil {
 			return err
 		}
+		if resolved != req.OutputIndex {
+			logger.Info("funding payment vout differs from requested index",
+				"requested", req.OutputIndex,
+				"resolved", resolved,
+			)
+		}
+		outputIndex = resolved
 	}
 
 	remittance, err := AnyonePaymentRemittance()
@@ -113,7 +123,7 @@ func Internalize(
 		Tx: atomic,
 		Outputs: []sdk.InternalizeOutput{
 			{
-				OutputIndex:       req.OutputIndex,
+				OutputIndex:       outputIndex,
 				Protocol:          sdk.InternalizeProtocolWalletPayment,
 				PaymentRemittance: remittance,
 			},
@@ -133,7 +143,7 @@ func Internalize(
 			}
 		}
 	}
-	logger.Info("funding internalized", "output_index", req.OutputIndex, "txid", logTxID)
+	logger.Info("funding internalized", "output_index", outputIndex, "txid", logTxID)
 	return nil
 }
 
@@ -171,27 +181,46 @@ func parseTx(atomic []byte) (*transaction.Transaction, error) {
 	return tx, nil
 }
 
-func validateOutputPaysAddress(atomic []byte, outputIndex uint32, expectedAddress string) error {
+// resolvePaymentOutputIndex returns the vout that pays expectedAddress.
+// Prefer preferredIndex when it matches; otherwise scan all outputs (wallets
+// commonly place change at vout 0 and the deposit later). If the tx cannot be
+// parsed, preferredIndex is returned unchanged so InternalizeAction can try.
+func resolvePaymentOutputIndex(atomic []byte, preferredIndex uint32, expectedAddress string) (uint32, error) {
 	addr, err := script.NewAddressFromString(expectedAddress)
 	if err != nil {
-		return fmt.Errorf("parse expected address: %w", err)
+		return 0, fmt.Errorf("parse expected address: %w", err)
 	}
 	expectedLock, err := p2pkh.Lock(addr)
 	if err != nil {
-		return fmt.Errorf("expected lock: %w", err)
+		return 0, fmt.Errorf("expected lock: %w", err)
 	}
 
-	// Try BEEF first, then raw tx.
 	tx, err := parseTx(atomic)
 	if err != nil {
 		// Skip strict validation if we cannot parse; InternalizeAction will fail if bad.
-		return nil
+		return preferredIndex, nil
 	}
-	if outputIndex >= uint32(len(tx.Outputs)) {
-		return fmt.Errorf("output_index %d out of range (tx has %d outputs)", outputIndex, len(tx.Outputs))
+	if len(tx.Outputs) == 0 {
+		return 0, fmt.Errorf("transaction has no outputs")
 	}
-	if !tx.Outputs[outputIndex].LockingScript.Equals(expectedLock) {
-		return fmt.Errorf("output[%d] does not pay operator deposit address", outputIndex)
+
+	pays := func(i int) bool {
+		out := tx.Outputs[i]
+		return out != nil && out.LockingScript != nil && out.LockingScript.Equals(expectedLock)
 	}
-	return nil
+
+	if int(preferredIndex) < len(tx.Outputs) && pays(int(preferredIndex)) {
+		return preferredIndex, nil
+	}
+
+	for i := range tx.Outputs {
+		if pays(i) {
+			return uint32(i), nil //nolint:gosec // output index fits uint32
+		}
+	}
+
+	return 0, fmt.Errorf(
+		"no output pays operator deposit address %s (tx has %d outputs; requested vout %d often is wallet change — payment may be a later vout)",
+		expectedAddress, len(tx.Outputs), preferredIndex,
+	)
 }

--- a/cmd/throughput_dashboard/internal/funding/internalize.go
+++ b/cmd/throughput_dashboard/internal/funding/internalize.go
@@ -16,14 +16,14 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/services"
 )
 
-// ActionInternalizer is the wallet surface for InternalizeAction.
-type ActionInternalizer interface {
+// InternalizeActioner is the wallet surface for InternalizeAction.
+type InternalizeActioner interface {
 	InternalizeAction(ctx context.Context, args sdk.InternalizeActionArgs, originator string) (*sdk.InternalizeActionResult, error)
 }
 
-// AtomicBeefSource fetches atomic BEEF bytes for a txid when AtomicTxHex is empty.
+// AtomicBeefer fetches atomic BEEF bytes for a txid when AtomicTxHex is empty.
 // Production uses services.GetBEEF; tests inject a fake via WithAtomicBeefSource.
-type AtomicBeefSource interface {
+type AtomicBeefer interface {
 	AtomicBeef(ctx context.Context, txID string) ([]byte, error)
 }
 
@@ -31,21 +31,31 @@ type AtomicBeefSource interface {
 type InternalizeRequest struct {
 	// AtomicTxHex is preferred: atomic BEEF or raw tx hex from WalletClient.
 	AtomicTxHex string `json:"atomic_tx_hex"`
-	// TxID is used when AtomicTxHex is empty (fetch BEEF via services / AtomicBeefSource).
+	// TxID is used when AtomicTxHex is empty (fetch BEEF via services / AtomicBeefer).
 	TxID string `json:"txid"`
 	// OutputIndex defaults to 0.
 	OutputIndex uint32 `json:"output_index"`
 }
 
+// InternalizeParams groups the arguments for Internalize.
+type InternalizeParams struct {
+	Wallet          InternalizeActioner
+	Network         defs.BSVNetwork
+	ExpectedAddress string
+	Request         InternalizeRequest
+	Originator      string
+	Logger          *slog.Logger
+}
+
 type internalizeOptions struct {
-	beefSource AtomicBeefSource
+	beefSource AtomicBeefer
 }
 
 // InternalizeOption configures Internalize (optional; production callers omit).
 type InternalizeOption func(*internalizeOptions)
 
 // WithAtomicBeefSource overrides the default services.GetBEEF path (unit tests).
-func WithAtomicBeefSource(src AtomicBeefSource) InternalizeOption {
+func WithAtomicBeefSource(src AtomicBeefer) InternalizeOption {
 	return func(o *internalizeOptions) {
 		o.beefSource = src
 	}
@@ -53,20 +63,12 @@ func WithAtomicBeefSource(src AtomicBeefSource) InternalizeOption {
 
 // Internalize credits a WalletClient (or external) payment into the operator default basket.
 // Prefers AtomicTxHex; otherwise fetches BEEF by TxID. Remittance is always AnyoneKey wallet-payment.
-func Internalize(
-	ctx context.Context,
-	w ActionInternalizer,
-	network defs.BSVNetwork,
-	expectedAddress string,
-	req InternalizeRequest,
-	originator string,
-	logger *slog.Logger,
-	opts ...InternalizeOption,
-) error {
+func Internalize(ctx context.Context, p InternalizeParams, opts ...InternalizeOption) error {
+	logger := p.Logger
 	if logger == nil {
 		logger = slog.Default()
 	}
-	if w == nil {
+	if p.Wallet == nil {
 		return fmt.Errorf("wallet is required")
 	}
 
@@ -75,45 +77,61 @@ func Internalize(
 		opt(&cfg)
 	}
 
-	if req.AtomicTxHex == "" && req.TxID == "" {
-		return fmt.Errorf("atomic_tx_hex or txid is required")
+	atomic, err := loadAtomicTx(ctx, p, cfg, logger)
+	if err != nil {
+		return err
 	}
 
-	var atomic []byte
-	var err error
-	if req.AtomicTxHex != "" {
-		atomic, err = hex.DecodeString(req.AtomicTxHex)
-		if err != nil {
-			return fmt.Errorf("decode atomic_tx_hex: %w", err)
-		}
-	} else {
-		src := cfg.beefSource
-		if src == nil {
-			src = servicesAtomicBeefSource{network: network, logger: logger}
-		}
-		atomic, err = src.AtomicBeef(ctx, req.TxID)
-		if err != nil {
-			return err
-		}
+	outputIndex, err := resolveOutputIndex(atomic, p.Request.OutputIndex, p.ExpectedAddress, logger)
+	if err != nil {
+		return err
 	}
 
-	// Resolve which vout pays the operator deposit. Local wallets often put
-	// change at vout 0 and the payment later — never assume the preferred index.
-	outputIndex := req.OutputIndex
-	if expectedAddress != "" {
-		resolved, err := resolvePaymentOutputIndex(atomic, req.OutputIndex, expectedAddress)
-		if err != nil {
-			return err
-		}
-		if resolved != req.OutputIndex {
-			logger.Info("funding payment vout differs from requested index",
-				"requested", req.OutputIndex,
-				"resolved", resolved,
-			)
-		}
-		outputIndex = resolved
-	}
+	return submitInternalize(ctx, p, atomic, outputIndex, logger)
+}
 
+func loadAtomicTx(ctx context.Context, p InternalizeParams, cfg internalizeOptions, logger *slog.Logger) ([]byte, error) {
+	if p.Request.AtomicTxHex == "" && p.Request.TxID == "" {
+		return nil, fmt.Errorf("atomic_tx_hex or txid is required")
+	}
+	if p.Request.AtomicTxHex != "" {
+		atomic, err := hex.DecodeString(p.Request.AtomicTxHex)
+		if err != nil {
+			return nil, fmt.Errorf("decode atomic_tx_hex: %w", err)
+		}
+		return atomic, nil
+	}
+	src := cfg.beefSource
+	if src == nil {
+		src = servicesAtomicBeefSource{network: p.Network, logger: logger}
+	}
+	return src.AtomicBeef(ctx, p.Request.TxID)
+}
+
+func resolveOutputIndex(atomic []byte, preferred uint32, expectedAddress string, logger *slog.Logger) (uint32, error) {
+	if expectedAddress == "" {
+		return preferred, nil
+	}
+	resolved, err := resolvePaymentOutputIndex(atomic, preferred, expectedAddress)
+	if err != nil {
+		return 0, err
+	}
+	if resolved != preferred {
+		logger.Info("funding payment vout differs from requested index",
+			"requested", preferred,
+			"resolved", resolved,
+		)
+	}
+	return resolved, nil
+}
+
+func submitInternalize(
+	ctx context.Context,
+	p InternalizeParams,
+	atomic []byte,
+	outputIndex uint32,
+	logger *slog.Logger,
+) error {
 	remittance, err := AnyonePaymentRemittance()
 	if err != nil {
 		return err
@@ -131,20 +149,26 @@ func Internalize(
 		Description: "throughput dashboard WalletClient top-up",
 	}
 
-	if _, err := w.InternalizeAction(ctx, args, originator); err != nil {
+	if _, err := p.Wallet.InternalizeAction(ctx, args, p.Originator); err != nil {
 		return fmt.Errorf("internalize: %w", err)
 	}
 
-	logTxID := req.TxID
-	if logTxID == "" {
-		if parsed, parseErr := parseTx(atomic); parseErr == nil && parsed != nil {
-			if h := parsed.TxID(); h != nil {
-				logTxID = h.String()
-			}
-		}
-	}
-	logger.Info("funding internalized", "output_index", outputIndex, "txid", logTxID)
+	logger.Info("funding internalized", "output_index", outputIndex, "txid", logTxID(p.Request, atomic))
 	return nil
+}
+
+func logTxID(req InternalizeRequest, atomic []byte) string {
+	if req.TxID != "" {
+		return req.TxID
+	}
+	parsed, parseErr := parseTx(atomic)
+	if parseErr != nil || parsed == nil {
+		return ""
+	}
+	if h := parsed.TxID(); h != nil {
+		return h.String()
+	}
+	return ""
 }
 
 // servicesAtomicBeefSource is the production BEEF fetcher via pkg/services.
@@ -173,10 +197,7 @@ func (s servicesAtomicBeefSource) AtomicBeef(ctx context.Context, txID string) (
 func parseTx(atomic []byte) (*transaction.Transaction, error) {
 	tx, err := transaction.NewTransactionFromBEEF(atomic)
 	if err != nil {
-		tx, err = transaction.NewTransactionFromBytes(atomic)
-		if err != nil {
-			return nil, err
-		}
+		return transaction.NewTransactionFromBytes(atomic)
 	}
 	return tx, nil
 }

--- a/cmd/throughput_dashboard/internal/funding/internalize.go
+++ b/cmd/throughput_dashboard/internal/funding/internalize.go
@@ -237,7 +237,7 @@ func resolvePaymentOutputIndex(atomic []byte, preferredIndex uint32, expectedAdd
 
 	for i := range tx.Outputs {
 		if pays(i) {
-			return uint32(i), nil //nolint:gosec // output index fits uint32
+			return uint32(i), nil
 		}
 	}
 

--- a/cmd/throughput_dashboard/internal/funding/internalize.go
+++ b/cmd/throughput_dashboard/internal/funding/internalize.go
@@ -21,17 +21,38 @@ type ActionInternalizer interface {
 	InternalizeAction(ctx context.Context, args sdk.InternalizeActionArgs, originator string) (*sdk.InternalizeActionResult, error)
 }
 
+// AtomicBeefSource fetches atomic BEEF bytes for a txid when AtomicTxHex is empty.
+// Production uses services.GetBEEF; tests inject a fake via WithAtomicBeefSource.
+type AtomicBeefSource interface {
+	AtomicBeef(ctx context.Context, txID string) ([]byte, error)
+}
+
 // InternalizeRequest is the body accepted by POST /api/funding/internalize.
 type InternalizeRequest struct {
 	// AtomicTxHex is preferred: atomic BEEF or raw tx hex from WalletClient.
 	AtomicTxHex string `json:"atomic_tx_hex"`
-	// TxID is used when AtomicTxHex is empty (fetch BEEF via services).
+	// TxID is used when AtomicTxHex is empty (fetch BEEF via services / AtomicBeefSource).
 	TxID string `json:"txid"`
 	// OutputIndex defaults to 0.
 	OutputIndex uint32 `json:"output_index"`
 }
 
+type internalizeOptions struct {
+	beefSource AtomicBeefSource
+}
+
+// InternalizeOption configures Internalize (optional; production callers omit).
+type InternalizeOption func(*internalizeOptions)
+
+// WithAtomicBeefSource overrides the default services.GetBEEF path (unit tests).
+func WithAtomicBeefSource(src AtomicBeefSource) InternalizeOption {
+	return func(o *internalizeOptions) {
+		o.beefSource = src
+	}
+}
+
 // Internalize credits a WalletClient (or external) payment into the operator default basket.
+// Prefers AtomicTxHex; otherwise fetches BEEF by TxID. Remittance is always AnyoneKey wallet-payment.
 func Internalize(
 	ctx context.Context,
 	w ActionInternalizer,
@@ -40,10 +61,20 @@ func Internalize(
 	req InternalizeRequest,
 	originator string,
 	logger *slog.Logger,
+	opts ...InternalizeOption,
 ) error {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	if w == nil {
+		return fmt.Errorf("wallet is required")
+	}
+
+	cfg := internalizeOptions{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	if req.AtomicTxHex == "" && req.TxID == "" {
 		return fmt.Errorf("atomic_tx_hex or txid is required")
 	}
@@ -56,18 +87,13 @@ func Internalize(
 			return fmt.Errorf("decode atomic_tx_hex: %w", err)
 		}
 	} else {
-		txIDHash, err := chainhash.NewHashFromHex(req.TxID)
-		if err != nil {
-			return fmt.Errorf("invalid txid: %w", err)
+		src := cfg.beefSource
+		if src == nil {
+			src = servicesAtomicBeefSource{network: network, logger: logger}
 		}
-		srv := services.New(logger, defs.DefaultServicesConfig(network))
-		beef, err := srv.GetBEEF(ctx, req.TxID, nil)
+		atomic, err = src.AtomicBeef(ctx, req.TxID)
 		if err != nil {
-			return fmt.Errorf("get BEEF for %s: %w", req.TxID, err)
-		}
-		atomic, err = beef.AtomicBytes(txIDHash)
-		if err != nil {
-			return fmt.Errorf("atomic bytes: %w", err)
+			return err
 		}
 	}
 
@@ -98,8 +124,51 @@ func Internalize(
 	if _, err := w.InternalizeAction(ctx, args, originator); err != nil {
 		return fmt.Errorf("internalize: %w", err)
 	}
-	logger.Info("funding internalized", "output_index", req.OutputIndex, "txid", req.TxID)
+
+	logTxID := req.TxID
+	if logTxID == "" {
+		if parsed, parseErr := parseTx(atomic); parseErr == nil && parsed != nil {
+			if h := parsed.TxID(); h != nil {
+				logTxID = h.String()
+			}
+		}
+	}
+	logger.Info("funding internalized", "output_index", req.OutputIndex, "txid", logTxID)
 	return nil
+}
+
+// servicesAtomicBeefSource is the production BEEF fetcher via pkg/services.
+type servicesAtomicBeefSource struct {
+	network defs.BSVNetwork
+	logger  *slog.Logger
+}
+
+func (s servicesAtomicBeefSource) AtomicBeef(ctx context.Context, txID string) ([]byte, error) {
+	txIDHash, err := chainhash.NewHashFromHex(txID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid txid: %w", err)
+	}
+	srv := services.New(s.logger, defs.DefaultServicesConfig(s.network))
+	beef, err := srv.GetBEEF(ctx, txID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("get BEEF for %s: %w", txID, err)
+	}
+	atomic, err := beef.AtomicBytes(txIDHash)
+	if err != nil {
+		return nil, fmt.Errorf("atomic bytes: %w", err)
+	}
+	return atomic, nil
+}
+
+func parseTx(atomic []byte) (*transaction.Transaction, error) {
+	tx, err := transaction.NewTransactionFromBEEF(atomic)
+	if err != nil {
+		tx, err = transaction.NewTransactionFromBytes(atomic)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return tx, nil
 }
 
 func validateOutputPaysAddress(atomic []byte, outputIndex uint32, expectedAddress string) error {
@@ -113,13 +182,10 @@ func validateOutputPaysAddress(atomic []byte, outputIndex uint32, expectedAddres
 	}
 
 	// Try BEEF first, then raw tx.
-	tx, err := transaction.NewTransactionFromBEEF(atomic)
+	tx, err := parseTx(atomic)
 	if err != nil {
-		tx, err = transaction.NewTransactionFromBytes(atomic)
-		if err != nil {
-			// Skip strict validation if we cannot parse; InternalizeAction will fail if bad.
-			return nil
-		}
+		// Skip strict validation if we cannot parse; InternalizeAction will fail if bad.
+		return nil
 	}
 	if outputIndex >= uint32(len(tx.Outputs)) {
 		return fmt.Errorf("output_index %d out of range (tx has %d outputs)", outputIndex, len(tx.Outputs))

--- a/cmd/throughput_dashboard/internal/funding/internalize.go
+++ b/cmd/throughput_dashboard/internal/funding/internalize.go
@@ -1,0 +1,131 @@
+package funding
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/script"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/bsv-blockchain/go-sdk/transaction/template/p2pkh"
+	sdk "github.com/bsv-blockchain/go-sdk/wallet"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/services"
+)
+
+// ActionInternalizer is the wallet surface for InternalizeAction.
+type ActionInternalizer interface {
+	InternalizeAction(ctx context.Context, args sdk.InternalizeActionArgs, originator string) (*sdk.InternalizeActionResult, error)
+}
+
+// InternalizeRequest is the body accepted by POST /api/funding/internalize.
+type InternalizeRequest struct {
+	// AtomicTxHex is preferred: atomic BEEF or raw tx hex from WalletClient.
+	AtomicTxHex string `json:"atomic_tx_hex"`
+	// TxID is used when AtomicTxHex is empty (fetch BEEF via services).
+	TxID string `json:"txid"`
+	// OutputIndex defaults to 0.
+	OutputIndex uint32 `json:"output_index"`
+}
+
+// Internalize credits a WalletClient (or external) payment into the operator default basket.
+func Internalize(
+	ctx context.Context,
+	w ActionInternalizer,
+	network defs.BSVNetwork,
+	expectedAddress string,
+	req InternalizeRequest,
+	originator string,
+	logger *slog.Logger,
+) error {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if req.AtomicTxHex == "" && req.TxID == "" {
+		return fmt.Errorf("atomic_tx_hex or txid is required")
+	}
+
+	var atomic []byte
+	var err error
+	if req.AtomicTxHex != "" {
+		atomic, err = hex.DecodeString(req.AtomicTxHex)
+		if err != nil {
+			return fmt.Errorf("decode atomic_tx_hex: %w", err)
+		}
+	} else {
+		txIDHash, err := chainhash.NewHashFromHex(req.TxID)
+		if err != nil {
+			return fmt.Errorf("invalid txid: %w", err)
+		}
+		srv := services.New(logger, defs.DefaultServicesConfig(network))
+		beef, err := srv.GetBEEF(ctx, req.TxID, nil)
+		if err != nil {
+			return fmt.Errorf("get BEEF for %s: %w", req.TxID, err)
+		}
+		atomic, err = beef.AtomicBytes(txIDHash)
+		if err != nil {
+			return fmt.Errorf("atomic bytes: %w", err)
+		}
+	}
+
+	// Validate the claimed output pays the operator deposit address when possible.
+	if expectedAddress != "" {
+		if err := validateOutputPaysAddress(atomic, req.OutputIndex, expectedAddress); err != nil {
+			return err
+		}
+	}
+
+	remittance, err := AnyonePaymentRemittance()
+	if err != nil {
+		return err
+	}
+
+	args := sdk.InternalizeActionArgs{
+		Tx: atomic,
+		Outputs: []sdk.InternalizeOutput{
+			{
+				OutputIndex:       req.OutputIndex,
+				Protocol:          sdk.InternalizeProtocolWalletPayment,
+				PaymentRemittance: remittance,
+			},
+		},
+		Description: "throughput dashboard WalletClient top-up",
+	}
+
+	if _, err := w.InternalizeAction(ctx, args, originator); err != nil {
+		return fmt.Errorf("internalize: %w", err)
+	}
+	logger.Info("funding internalized", "output_index", req.OutputIndex, "txid", req.TxID)
+	return nil
+}
+
+func validateOutputPaysAddress(atomic []byte, outputIndex uint32, expectedAddress string) error {
+	addr, err := script.NewAddressFromString(expectedAddress)
+	if err != nil {
+		return fmt.Errorf("parse expected address: %w", err)
+	}
+	expectedLock, err := p2pkh.Lock(addr)
+	if err != nil {
+		return fmt.Errorf("expected lock: %w", err)
+	}
+
+	// Try BEEF first, then raw tx.
+	tx, err := transaction.NewTransactionFromBEEF(atomic)
+	if err != nil {
+		tx, err = transaction.NewTransactionFromBytes(atomic)
+		if err != nil {
+			// Skip strict validation if we cannot parse; InternalizeAction will fail if bad.
+			return nil
+		}
+	}
+	if outputIndex >= uint32(len(tx.Outputs)) {
+		return fmt.Errorf("output_index %d out of range (tx has %d outputs)", outputIndex, len(tx.Outputs))
+	}
+	if !tx.Outputs[outputIndex].LockingScript.Equals(expectedLock) {
+		return fmt.Errorf("output[%d] does not pay operator deposit address", outputIndex)
+	}
+	return nil
+}

--- a/cmd/throughput_dashboard/internal/funding/internalize.go
+++ b/cmd/throughput_dashboard/internal/funding/internalize.go
@@ -117,7 +117,8 @@ func resolveOutputIndex(atomic []byte, preferred uint32, expectedAddress string,
 		return 0, err
 	}
 	if resolved != preferred {
-		logger.Info("funding payment vout differs from requested index",
+		logger.Info(
+			"funding payment vout differs from requested index",
 			"requested", preferred,
 			"resolved", resolved,
 		)

--- a/cmd/throughput_dashboard/internal/funding/internalize_test.go
+++ b/cmd/throughput_dashboard/internal/funding/internalize_test.go
@@ -1,0 +1,336 @@
+package funding_test
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	"github.com/bsv-blockchain/go-sdk/script"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/bsv-blockchain/go-sdk/transaction/template/p2pkh"
+	sdk "github.com/bsv-blockchain/go-sdk/wallet"
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/funding"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeInternalizer struct {
+	lastArgs       sdk.InternalizeActionArgs
+	lastOriginator string
+	calls          int
+	err            error
+}
+
+func (f *fakeInternalizer) InternalizeAction(
+	_ context.Context,
+	args sdk.InternalizeActionArgs,
+	originator string,
+) (*sdk.InternalizeActionResult, error) {
+	f.calls++
+	f.lastArgs = args
+	f.lastOriginator = originator
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &sdk.InternalizeActionResult{Accepted: true}, nil
+}
+
+type fakeBeefSource struct {
+	atomic []byte
+	err    error
+	calls  int
+	lastID string
+}
+
+func (f *fakeBeefSource) AtomicBeef(_ context.Context, txID string) ([]byte, error) {
+	f.calls++
+	f.lastID = txID
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.atomic, nil
+}
+
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func p2pkhRawTxHex(t *testing.T, address string) string {
+	t.Helper()
+	addr, err := script.NewAddressFromString(address)
+	require.NoError(t, err)
+	lock, err := p2pkh.Lock(addr)
+	require.NoError(t, err)
+
+	tx := transaction.NewTransaction()
+	tx.AddOutput(&transaction.TransactionOutput{
+		Satoshis:      50_000,
+		LockingScript: lock,
+	})
+	return hex.EncodeToString(tx.Bytes())
+}
+
+func TestInternalizeRequiresTxHexOrTxID(t *testing.T) {
+	w := &fakeInternalizer{}
+	err := funding.Internalize(
+		context.Background(),
+		w,
+		defs.NetworkMainnet,
+		"",
+		funding.InternalizeRequest{},
+		"origin",
+		silentLogger(),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "atomic_tx_hex or txid")
+	require.Equal(t, 0, w.calls)
+}
+
+func TestInternalizeNilWallet(t *testing.T) {
+	err := funding.Internalize(
+		context.Background(),
+		nil,
+		defs.NetworkMainnet,
+		"",
+		funding.InternalizeRequest{AtomicTxHex: "00"},
+		"origin",
+		silentLogger(),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wallet")
+}
+
+func TestInternalizeBadAtomicHex(t *testing.T) {
+	w := &fakeInternalizer{}
+	err := funding.Internalize(
+		context.Background(),
+		w,
+		defs.NetworkMainnet,
+		"",
+		funding.InternalizeRequest{AtomicTxHex: "zz"},
+		"origin",
+		silentLogger(),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decode atomic_tx_hex")
+	require.Equal(t, 0, w.calls)
+}
+
+func TestInternalizeAtomicPathSuccess(t *testing.T) {
+	priv := testOperatorPriv(t)
+	info, err := funding.DeriveInfo(priv, defs.NetworkMainnet, 0)
+	require.NoError(t, err)
+
+	rawHex := p2pkhRawTxHex(t, info.Address)
+	w := &fakeInternalizer{}
+
+	err = funding.Internalize(
+		context.Background(),
+		w,
+		defs.NetworkMainnet,
+		info.Address,
+		funding.InternalizeRequest{AtomicTxHex: rawHex, OutputIndex: 0},
+		"throughput-dashboard.local",
+		silentLogger(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, w.calls)
+	require.Equal(t, "throughput-dashboard.local", w.lastOriginator)
+	require.Equal(t, sdk.InternalizeProtocolWalletPayment, w.lastArgs.Outputs[0].Protocol)
+	require.NotNil(t, w.lastArgs.Outputs[0].PaymentRemittance)
+
+	wantRemit, err := funding.AnyonePaymentRemittance()
+	require.NoError(t, err)
+	got := w.lastArgs.Outputs[0].PaymentRemittance
+	require.Equal(t, wantRemit.DerivationPrefix, got.DerivationPrefix)
+	require.Equal(t, wantRemit.DerivationSuffix, got.DerivationSuffix)
+	require.Equal(t, wantRemit.SenderIdentityKey.ToDERHex(), got.SenderIdentityKey.ToDERHex())
+
+	decoded, err := hex.DecodeString(rawHex)
+	require.NoError(t, err)
+	require.Equal(t, decoded, w.lastArgs.Tx)
+}
+
+func TestInternalizePrefersAtomicOverTxID(t *testing.T) {
+	priv := testOperatorPriv(t)
+	info, err := funding.DeriveInfo(priv, defs.NetworkMainnet, 0)
+	require.NoError(t, err)
+
+	rawHex := p2pkhRawTxHex(t, info.Address)
+	w := &fakeInternalizer{}
+	beef := &fakeBeefSource{atomic: []byte("should-not-be-used")}
+
+	err = funding.Internalize(
+		context.Background(),
+		w,
+		defs.NetworkMainnet,
+		info.Address,
+		funding.InternalizeRequest{
+			AtomicTxHex: rawHex,
+			TxID:        "aabbccdd", // ignored when atomic present
+		},
+		"origin",
+		silentLogger(),
+		funding.WithAtomicBeefSource(beef),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 0, beef.calls)
+	require.Equal(t, 1, w.calls)
+}
+
+func TestInternalizeTxIDPathUsesBeefSource(t *testing.T) {
+	priv := testOperatorPriv(t)
+	info, err := funding.DeriveInfo(priv, defs.NetworkMainnet, 0)
+	require.NoError(t, err)
+
+	raw, err := hex.DecodeString(p2pkhRawTxHex(t, info.Address))
+	require.NoError(t, err)
+
+	w := &fakeInternalizer{}
+	beef := &fakeBeefSource{atomic: raw}
+	const txid = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+	err = funding.Internalize(
+		context.Background(),
+		w,
+		defs.NetworkMainnet,
+		info.Address,
+		funding.InternalizeRequest{TxID: txid, OutputIndex: 0},
+		"origin",
+		silentLogger(),
+		funding.WithAtomicBeefSource(beef),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, beef.calls)
+	require.Equal(t, txid, beef.lastID)
+	require.Equal(t, 1, w.calls)
+	require.Equal(t, raw, w.lastArgs.Tx)
+}
+
+func TestInternalizeTxIDBeefSourceError(t *testing.T) {
+	w := &fakeInternalizer{}
+	beef := &fakeBeefSource{err: errors.New("network down")}
+
+	err := funding.Internalize(
+		context.Background(),
+		w,
+		defs.NetworkMainnet,
+		"",
+		funding.InternalizeRequest{TxID: "aa"},
+		"origin",
+		silentLogger(),
+		funding.WithAtomicBeefSource(beef),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "network down")
+	require.Equal(t, 0, w.calls)
+}
+
+func TestInternalizeRejectsWrongAddress(t *testing.T) {
+	priv := testOperatorPriv(t)
+	info, err := funding.DeriveInfo(priv, defs.NetworkMainnet, 0)
+	require.NoError(t, err)
+
+	// Build a payment to a different address.
+	otherPriv, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	otherInfo, err := funding.DeriveInfo(otherPriv, defs.NetworkMainnet, 0)
+	require.NoError(t, err)
+
+	rawHex := p2pkhRawTxHex(t, otherInfo.Address)
+	w := &fakeInternalizer{}
+
+	err = funding.Internalize(
+		context.Background(),
+		w,
+		defs.NetworkMainnet,
+		info.Address,
+		funding.InternalizeRequest{AtomicTxHex: rawHex},
+		"origin",
+		silentLogger(),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not pay operator deposit address")
+	require.Equal(t, 0, w.calls)
+}
+
+func TestInternalizeOutputIndexOutOfRange(t *testing.T) {
+	priv := testOperatorPriv(t)
+	info, err := funding.DeriveInfo(priv, defs.NetworkMainnet, 0)
+	require.NoError(t, err)
+
+	rawHex := p2pkhRawTxHex(t, info.Address)
+	w := &fakeInternalizer{}
+
+	err = funding.Internalize(
+		context.Background(),
+		w,
+		defs.NetworkMainnet,
+		info.Address,
+		funding.InternalizeRequest{AtomicTxHex: rawHex, OutputIndex: 5},
+		"origin",
+		silentLogger(),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "out of range")
+	require.Equal(t, 0, w.calls)
+}
+
+func TestInternalizeSkipsValidationWhenUnparseable(t *testing.T) {
+	// Unparseable atomic bytes: validation is skipped; wallet is still called.
+	w := &fakeInternalizer{}
+	err := funding.Internalize(
+		context.Background(),
+		w,
+		defs.NetworkMainnet,
+		"1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", // valid address form
+		funding.InternalizeRequest{AtomicTxHex: "00"},
+		"origin",
+		silentLogger(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, w.calls)
+}
+
+func TestInternalizePropagatesWalletError(t *testing.T) {
+	priv := testOperatorPriv(t)
+	info, err := funding.DeriveInfo(priv, defs.NetworkMainnet, 0)
+	require.NoError(t, err)
+
+	rawHex := p2pkhRawTxHex(t, info.Address)
+	w := &fakeInternalizer{err: errors.New("wallet reject")}
+
+	err = funding.Internalize(
+		context.Background(),
+		w,
+		defs.NetworkMainnet,
+		info.Address,
+		funding.InternalizeRequest{AtomicTxHex: rawHex},
+		"origin",
+		silentLogger(),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "internalize")
+	require.Contains(t, err.Error(), "wallet reject")
+}
+
+func TestInternalizeInvalidExpectedAddress(t *testing.T) {
+	w := &fakeInternalizer{}
+	err := funding.Internalize(
+		context.Background(),
+		w,
+		defs.NetworkMainnet,
+		"not-an-address",
+		funding.InternalizeRequest{AtomicTxHex: "00"},
+		"origin",
+		silentLogger(),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parse expected address")
+	require.Equal(t, 0, w.calls)
+}
+

--- a/cmd/throughput_dashboard/internal/funding/internalize_test.go
+++ b/cmd/throughput_dashboard/internal/funding/internalize_test.go
@@ -59,6 +59,27 @@ func silentLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
+func doInternalize(
+	ctx context.Context,
+	w funding.InternalizeActioner,
+	network defs.BSVNetwork,
+	addr string,
+	req funding.InternalizeRequest,
+	originator string,
+	logger *slog.Logger,
+	opts ...funding.InternalizeOption,
+) error {
+	return funding.Internalize(ctx, funding.InternalizeParams{
+		Wallet:          w,
+		Network:         network,
+		ExpectedAddress: addr,
+		Request:         req,
+		Originator:      originator,
+		Logger:          logger,
+	}, opts...)
+}
+
+
 func p2pkhLock(t *testing.T, address string) *script.Script {
 	t.Helper()
 	addr, err := script.NewAddressFromString(address)
@@ -96,7 +117,7 @@ func changeThenPaymentRawTxHex(t *testing.T, changeAddress, depositAddress strin
 
 func TestInternalizeRequiresTxHexOrTxID(t *testing.T) {
 	w := &fakeInternalizer{}
-	err := funding.Internalize(
+	err := doInternalize(
 		context.Background(),
 		w,
 		defs.NetworkMainnet,
@@ -111,7 +132,7 @@ func TestInternalizeRequiresTxHexOrTxID(t *testing.T) {
 }
 
 func TestInternalizeNilWallet(t *testing.T) {
-	err := funding.Internalize(
+	err := doInternalize(
 		context.Background(),
 		nil,
 		defs.NetworkMainnet,
@@ -126,7 +147,7 @@ func TestInternalizeNilWallet(t *testing.T) {
 
 func TestInternalizeBadAtomicHex(t *testing.T) {
 	w := &fakeInternalizer{}
-	err := funding.Internalize(
+	err := doInternalize(
 		context.Background(),
 		w,
 		defs.NetworkMainnet,
@@ -148,7 +169,7 @@ func TestInternalizeAtomicPathSuccess(t *testing.T) {
 	rawHex := p2pkhRawTxHex(t, info.Address)
 	w := &fakeInternalizer{}
 
-	err = funding.Internalize(
+	err = doInternalize(
 		context.Background(),
 		w,
 		defs.NetworkMainnet,
@@ -184,7 +205,7 @@ func TestInternalizePrefersAtomicOverTxID(t *testing.T) {
 	w := &fakeInternalizer{}
 	beef := &fakeBeefSource{atomic: []byte("should-not-be-used")}
 
-	err = funding.Internalize(
+	err = doInternalize(
 		context.Background(),
 		w,
 		defs.NetworkMainnet,
@@ -214,7 +235,7 @@ func TestInternalizeTxIDPathUsesBeefSource(t *testing.T) {
 	beef := &fakeBeefSource{atomic: raw}
 	const txid = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 
-	err = funding.Internalize(
+	err = doInternalize(
 		context.Background(),
 		w,
 		defs.NetworkMainnet,
@@ -235,7 +256,7 @@ func TestInternalizeTxIDBeefSourceError(t *testing.T) {
 	w := &fakeInternalizer{}
 	beef := &fakeBeefSource{err: errors.New("network down")}
 
-	err := funding.Internalize(
+	err := doInternalize(
 		context.Background(),
 		w,
 		defs.NetworkMainnet,
@@ -264,7 +285,7 @@ func TestInternalizeRejectsWrongAddress(t *testing.T) {
 	rawHex := p2pkhRawTxHex(t, otherInfo.Address)
 	w := &fakeInternalizer{}
 
-	err = funding.Internalize(
+	err = doInternalize(
 		context.Background(),
 		w,
 		defs.NetworkMainnet,
@@ -293,7 +314,7 @@ func TestInternalizeAutoDetectsPaymentAfterChangeOutput(t *testing.T) {
 	rawHex := changeThenPaymentRawTxHex(t, changeInfo.Address, info.Address)
 	w := &fakeInternalizer{}
 
-	err = funding.Internalize(
+	err = doInternalize(
 		context.Background(),
 		w,
 		defs.NetworkMainnet,
@@ -316,7 +337,7 @@ func TestInternalizeResolvesWrongPreferredIndexWhenPaymentExists(t *testing.T) {
 	w := &fakeInternalizer{}
 
 	// Preferred index out of range, but deposit is on vout 0 — auto-resolve.
-	err = funding.Internalize(
+	err = doInternalize(
 		context.Background(),
 		w,
 		defs.NetworkMainnet,
@@ -333,7 +354,7 @@ func TestInternalizeResolvesWrongPreferredIndexWhenPaymentExists(t *testing.T) {
 func TestInternalizeSkipsValidationWhenUnparseable(t *testing.T) {
 	// Unparseable atomic bytes: validation is skipped; wallet is still called.
 	w := &fakeInternalizer{}
-	err := funding.Internalize(
+	err := doInternalize(
 		context.Background(),
 		w,
 		defs.NetworkMainnet,
@@ -354,7 +375,7 @@ func TestInternalizePropagatesWalletError(t *testing.T) {
 	rawHex := p2pkhRawTxHex(t, info.Address)
 	w := &fakeInternalizer{err: errors.New("wallet reject")}
 
-	err = funding.Internalize(
+	err = doInternalize(
 		context.Background(),
 		w,
 		defs.NetworkMainnet,
@@ -370,7 +391,7 @@ func TestInternalizePropagatesWalletError(t *testing.T) {
 
 func TestInternalizeInvalidExpectedAddress(t *testing.T) {
 	w := &fakeInternalizer{}
-	err := funding.Internalize(
+	err := doInternalize(
 		context.Background(),
 		w,
 		defs.NetworkMainnet,

--- a/cmd/throughput_dashboard/internal/funding/internalize_test.go
+++ b/cmd/throughput_dashboard/internal/funding/internalize_test.go
@@ -59,26 +59,24 @@ func silentLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-func doInternalize(
-	ctx context.Context,
-	w funding.InternalizeActioner,
-	network defs.BSVNetwork,
-	addr string,
-	req funding.InternalizeRequest,
-	originator string,
-	logger *slog.Logger,
-	opts ...funding.InternalizeOption,
-) error {
-	return funding.Internalize(ctx, funding.InternalizeParams{
-		Wallet:          w,
-		Network:         network,
-		ExpectedAddress: addr,
-		Request:         req,
-		Originator:      originator,
-		Logger:          logger,
-	}, opts...)
+func doInternalize(p funding.InternalizeParams, opts ...funding.InternalizeOption) error {
+	return funding.Internalize(context.Background(), p, opts...)
 }
 
+func params(
+	w funding.InternalizeActioner,
+	addr string,
+	req funding.InternalizeRequest,
+) funding.InternalizeParams {
+	return funding.InternalizeParams{
+		Wallet:          w,
+		Network:         defs.NetworkMainnet,
+		ExpectedAddress: addr,
+		Request:         req,
+		Originator:      "origin",
+		Logger:          silentLogger(),
+	}
+}
 
 func p2pkhLock(t *testing.T, address string) *script.Script {
 	t.Helper()
@@ -117,45 +115,21 @@ func changeThenPaymentRawTxHex(t *testing.T, changeAddress, depositAddress strin
 
 func TestInternalizeRequiresTxHexOrTxID(t *testing.T) {
 	w := &fakeInternalizer{}
-	err := doInternalize(
-		context.Background(),
-		w,
-		defs.NetworkMainnet,
-		"",
-		funding.InternalizeRequest{},
-		"origin",
-		silentLogger(),
-	)
+	err := doInternalize(params(w, "", funding.InternalizeRequest{}))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "atomic_tx_hex or txid")
 	require.Equal(t, 0, w.calls)
 }
 
 func TestInternalizeNilWallet(t *testing.T) {
-	err := doInternalize(
-		context.Background(),
-		nil,
-		defs.NetworkMainnet,
-		"",
-		funding.InternalizeRequest{AtomicTxHex: "00"},
-		"origin",
-		silentLogger(),
-	)
+	err := doInternalize(params(nil, "", funding.InternalizeRequest{AtomicTxHex: "00"}))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "wallet")
 }
 
 func TestInternalizeBadAtomicHex(t *testing.T) {
 	w := &fakeInternalizer{}
-	err := doInternalize(
-		context.Background(),
-		w,
-		defs.NetworkMainnet,
-		"",
-		funding.InternalizeRequest{AtomicTxHex: "zz"},
-		"origin",
-		silentLogger(),
-	)
+	err := doInternalize(params(w, "", funding.InternalizeRequest{AtomicTxHex: "zz"}))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "decode atomic_tx_hex")
 	require.Equal(t, 0, w.calls)
@@ -169,15 +143,9 @@ func TestInternalizeAtomicPathSuccess(t *testing.T) {
 	rawHex := p2pkhRawTxHex(t, info.Address)
 	w := &fakeInternalizer{}
 
-	err = doInternalize(
-		context.Background(),
-		w,
-		defs.NetworkMainnet,
-		info.Address,
-		funding.InternalizeRequest{AtomicTxHex: rawHex, OutputIndex: 0},
-		"throughput-dashboard.local",
-		silentLogger(),
-	)
+	p := params(w, info.Address, funding.InternalizeRequest{AtomicTxHex: rawHex, OutputIndex: 0})
+	p.Originator = "throughput-dashboard.local"
+	err = doInternalize(p)
 	require.NoError(t, err)
 	require.Equal(t, 1, w.calls)
 	require.Equal(t, "throughput-dashboard.local", w.lastOriginator)
@@ -206,16 +174,10 @@ func TestInternalizePrefersAtomicOverTxID(t *testing.T) {
 	beef := &fakeBeefSource{atomic: []byte("should-not-be-used")}
 
 	err = doInternalize(
-		context.Background(),
-		w,
-		defs.NetworkMainnet,
-		info.Address,
-		funding.InternalizeRequest{
+		params(w, info.Address, funding.InternalizeRequest{
 			AtomicTxHex: rawHex,
 			TxID:        "aabbccdd", // ignored when atomic present
-		},
-		"origin",
-		silentLogger(),
+		}),
 		funding.WithAtomicBeefSource(beef),
 	)
 	require.NoError(t, err)
@@ -236,13 +198,7 @@ func TestInternalizeTxIDPathUsesBeefSource(t *testing.T) {
 	const txid = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 
 	err = doInternalize(
-		context.Background(),
-		w,
-		defs.NetworkMainnet,
-		info.Address,
-		funding.InternalizeRequest{TxID: txid, OutputIndex: 0},
-		"origin",
-		silentLogger(),
+		params(w, info.Address, funding.InternalizeRequest{TxID: txid, OutputIndex: 0}),
 		funding.WithAtomicBeefSource(beef),
 	)
 	require.NoError(t, err)
@@ -257,13 +213,7 @@ func TestInternalizeTxIDBeefSourceError(t *testing.T) {
 	beef := &fakeBeefSource{err: errors.New("network down")}
 
 	err := doInternalize(
-		context.Background(),
-		w,
-		defs.NetworkMainnet,
-		"",
-		funding.InternalizeRequest{TxID: "aa"},
-		"origin",
-		silentLogger(),
+		params(w, "", funding.InternalizeRequest{TxID: "aa"}),
 		funding.WithAtomicBeefSource(beef),
 	)
 	require.Error(t, err)
@@ -285,15 +235,7 @@ func TestInternalizeRejectsWrongAddress(t *testing.T) {
 	rawHex := p2pkhRawTxHex(t, otherInfo.Address)
 	w := &fakeInternalizer{}
 
-	err = doInternalize(
-		context.Background(),
-		w,
-		defs.NetworkMainnet,
-		info.Address,
-		funding.InternalizeRequest{AtomicTxHex: rawHex},
-		"origin",
-		silentLogger(),
-	)
+	err = doInternalize(params(w, info.Address, funding.InternalizeRequest{AtomicTxHex: rawHex}))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no output pays operator deposit address")
 	require.Equal(t, 0, w.calls)
@@ -314,15 +256,7 @@ func TestInternalizeAutoDetectsPaymentAfterChangeOutput(t *testing.T) {
 	rawHex := changeThenPaymentRawTxHex(t, changeInfo.Address, info.Address)
 	w := &fakeInternalizer{}
 
-	err = doInternalize(
-		context.Background(),
-		w,
-		defs.NetworkMainnet,
-		info.Address,
-		funding.InternalizeRequest{AtomicTxHex: rawHex, OutputIndex: 0}, // wrong preferred index
-		"origin",
-		silentLogger(),
-	)
+	err = doInternalize(params(w, info.Address, funding.InternalizeRequest{AtomicTxHex: rawHex, OutputIndex: 0})) // wrong preferred index
 	require.NoError(t, err)
 	require.Equal(t, 1, w.calls)
 	require.Equal(t, uint32(1), w.lastArgs.Outputs[0].OutputIndex)
@@ -337,15 +271,7 @@ func TestInternalizeResolvesWrongPreferredIndexWhenPaymentExists(t *testing.T) {
 	w := &fakeInternalizer{}
 
 	// Preferred index out of range, but deposit is on vout 0 — auto-resolve.
-	err = doInternalize(
-		context.Background(),
-		w,
-		defs.NetworkMainnet,
-		info.Address,
-		funding.InternalizeRequest{AtomicTxHex: rawHex, OutputIndex: 5},
-		"origin",
-		silentLogger(),
-	)
+	err = doInternalize(params(w, info.Address, funding.InternalizeRequest{AtomicTxHex: rawHex, OutputIndex: 5}))
 	require.NoError(t, err)
 	require.Equal(t, 1, w.calls)
 	require.Equal(t, uint32(0), w.lastArgs.Outputs[0].OutputIndex)
@@ -354,15 +280,7 @@ func TestInternalizeResolvesWrongPreferredIndexWhenPaymentExists(t *testing.T) {
 func TestInternalizeSkipsValidationWhenUnparseable(t *testing.T) {
 	// Unparseable atomic bytes: validation is skipped; wallet is still called.
 	w := &fakeInternalizer{}
-	err := doInternalize(
-		context.Background(),
-		w,
-		defs.NetworkMainnet,
-		"1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", // valid address form
-		funding.InternalizeRequest{AtomicTxHex: "00"},
-		"origin",
-		silentLogger(),
-	)
+	err := doInternalize(params(w, "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", funding.InternalizeRequest{AtomicTxHex: "00"})) // valid address form
 	require.NoError(t, err)
 	require.Equal(t, 1, w.calls)
 }
@@ -375,15 +293,7 @@ func TestInternalizePropagatesWalletError(t *testing.T) {
 	rawHex := p2pkhRawTxHex(t, info.Address)
 	w := &fakeInternalizer{err: errors.New("wallet reject")}
 
-	err = doInternalize(
-		context.Background(),
-		w,
-		defs.NetworkMainnet,
-		info.Address,
-		funding.InternalizeRequest{AtomicTxHex: rawHex},
-		"origin",
-		silentLogger(),
-	)
+	err = doInternalize(params(w, info.Address, funding.InternalizeRequest{AtomicTxHex: rawHex}))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "internalize")
 	require.Contains(t, err.Error(), "wallet reject")
@@ -391,15 +301,7 @@ func TestInternalizePropagatesWalletError(t *testing.T) {
 
 func TestInternalizeInvalidExpectedAddress(t *testing.T) {
 	w := &fakeInternalizer{}
-	err := doInternalize(
-		context.Background(),
-		w,
-		defs.NetworkMainnet,
-		"not-an-address",
-		funding.InternalizeRequest{AtomicTxHex: "00"},
-		"origin",
-		silentLogger(),
-	)
+	err := doInternalize(params(w, "not-an-address", funding.InternalizeRequest{AtomicTxHex: "00"}))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "parse expected address")
 	require.Equal(t, 0, w.calls)

--- a/cmd/throughput_dashboard/internal/funding/internalize_test.go
+++ b/cmd/throughput_dashboard/internal/funding/internalize_test.go
@@ -59,17 +59,37 @@ func silentLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-func p2pkhRawTxHex(t *testing.T, address string) string {
+func p2pkhLock(t *testing.T, address string) *script.Script {
 	t.Helper()
 	addr, err := script.NewAddressFromString(address)
 	require.NoError(t, err)
 	lock, err := p2pkh.Lock(addr)
 	require.NoError(t, err)
+	return lock
+}
 
+func p2pkhRawTxHex(t *testing.T, address string) string {
+	t.Helper()
 	tx := transaction.NewTransaction()
 	tx.AddOutput(&transaction.TransactionOutput{
 		Satoshis:      50_000,
-		LockingScript: lock,
+		LockingScript: p2pkhLock(t, address),
+	})
+	return hex.EncodeToString(tx.Bytes())
+}
+
+// changeThenPaymentRawTxHex models a typical local-wallet createAction layout:
+// vout 0 = change back to the payer, vout 1 = payment to the deposit address.
+func changeThenPaymentRawTxHex(t *testing.T, changeAddress, depositAddress string) string {
+	t.Helper()
+	tx := transaction.NewTransaction()
+	tx.AddOutput(&transaction.TransactionOutput{
+		Satoshis:      10_000,
+		LockingScript: p2pkhLock(t, changeAddress),
+	})
+	tx.AddOutput(&transaction.TransactionOutput{
+		Satoshis:      50_000,
+		LockingScript: p2pkhLock(t, depositAddress),
 	})
 	return hex.EncodeToString(tx.Bytes())
 }
@@ -254,11 +274,40 @@ func TestInternalizeRejectsWrongAddress(t *testing.T) {
 		silentLogger(),
 	)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "does not pay operator deposit address")
+	require.Contains(t, err.Error(), "no output pays operator deposit address")
 	require.Equal(t, 0, w.calls)
 }
 
-func TestInternalizeOutputIndexOutOfRange(t *testing.T) {
+func TestInternalizeAutoDetectsPaymentAfterChangeOutput(t *testing.T) {
+	// Local wallets typically put change at vout 0 and the payment later.
+	// Requesting vout 0 (default) must still resolve to the deposit output.
+	opPriv := testOperatorPriv(t)
+	info, err := funding.DeriveInfo(opPriv, defs.NetworkMainnet, 0)
+	require.NoError(t, err)
+
+	changePriv, err := ec.NewPrivateKey()
+	require.NoError(t, err)
+	changeInfo, err := funding.DeriveInfo(changePriv, defs.NetworkMainnet, 0)
+	require.NoError(t, err)
+
+	rawHex := changeThenPaymentRawTxHex(t, changeInfo.Address, info.Address)
+	w := &fakeInternalizer{}
+
+	err = funding.Internalize(
+		context.Background(),
+		w,
+		defs.NetworkMainnet,
+		info.Address,
+		funding.InternalizeRequest{AtomicTxHex: rawHex, OutputIndex: 0}, // wrong preferred index
+		"origin",
+		silentLogger(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, w.calls)
+	require.Equal(t, uint32(1), w.lastArgs.Outputs[0].OutputIndex)
+}
+
+func TestInternalizeResolvesWrongPreferredIndexWhenPaymentExists(t *testing.T) {
 	priv := testOperatorPriv(t)
 	info, err := funding.DeriveInfo(priv, defs.NetworkMainnet, 0)
 	require.NoError(t, err)
@@ -266,6 +315,7 @@ func TestInternalizeOutputIndexOutOfRange(t *testing.T) {
 	rawHex := p2pkhRawTxHex(t, info.Address)
 	w := &fakeInternalizer{}
 
+	// Preferred index out of range, but deposit is on vout 0 — auto-resolve.
 	err = funding.Internalize(
 		context.Background(),
 		w,
@@ -275,9 +325,9 @@ func TestInternalizeOutputIndexOutOfRange(t *testing.T) {
 		"origin",
 		silentLogger(),
 	)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "out of range")
-	require.Equal(t, 0, w.calls)
+	require.NoError(t, err)
+	require.Equal(t, 1, w.calls)
+	require.Equal(t, uint32(0), w.lastArgs.Outputs[0].OutputIndex)
 }
 
 func TestInternalizeSkipsValidationWhenUnparseable(t *testing.T) {

--- a/cmd/throughput_dashboard/internal/funding/internalize_test.go
+++ b/cmd/throughput_dashboard/internal/funding/internalize_test.go
@@ -306,4 +306,3 @@ func TestInternalizeInvalidExpectedAddress(t *testing.T) {
 	require.Contains(t, err.Error(), "parse expected address")
 	require.Equal(t, 0, w.calls)
 }
-

--- a/cmd/throughput_dashboard/internal/metrics/sampler.go
+++ b/cmd/throughput_dashboard/internal/metrics/sampler.go
@@ -1,0 +1,278 @@
+// Package metrics samples wallet baskets and stream stats for the dashboard.
+package metrics
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	sdk "github.com/bsv-blockchain/go-sdk/wallet"
+	"github.com/go-softwarelab/common/pkg/to"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/stream"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+)
+
+// Event is a dashboard SSE-friendly event.
+type Event struct {
+	Type      string         `json:"type"`
+	Timestamp string         `json:"timestamp"`
+	Payload   map[string]any `json:"payload"`
+}
+
+// Tick is a periodic sample of stream + fuel gauges.
+type Tick struct {
+	Timestamp      string       `json:"timestamp"`
+	Stream         stream.Stats `json:"stream"`
+	TPSSucceeded   uint64       `json:"tps_succeeded"`
+	TPSFailed      uint64       `json:"tps_failed"`
+	TPSAttempted   uint64       `json:"tps_attempted"`
+	DefaultSats    uint64       `json:"default_sats"`
+	FuelCount      uint64       `json:"fuel_count"`
+	ReserveCount   uint64       `json:"reserve_count"`
+	FuelRunwaySec  float64      `json:"fuel_runway_seconds"`
+	TargetTPS      uint64       `json:"target_tps"`
+	Denomination   uint64       `json:"denomination"`
+	LowWater       uint64       `json:"low_water"`
+	HighWater      uint64       `json:"high_water"`
+	TargetPoolSize uint64       `json:"target_pool_size"`
+}
+
+// WalletAPI is the wallet surface used by the sampler.
+type WalletAPI interface {
+	Balance(ctx context.Context) (uint64, error)
+	ListOutputs(ctx context.Context, args sdk.ListOutputsArgs, originator string) (*sdk.ListOutputsResult, error)
+}
+
+// Sampler polls balances and stream counters and records top-up inventory deltas.
+type Sampler struct {
+	wallet       WalletAPI
+	ctrl         *stream.Controller
+	originator   string
+	logger       *slog.Logger
+	interval     time.Duration
+	targetTPS    uint64
+	denomination uint64
+	targetPool   uint64
+	lowWater     uint64
+	highWater    uint64
+
+	mu            sync.RWMutex
+	lastTick      Tick
+	events        []Event
+	maxEvents     int
+	prevAttempted uint64
+	prevSucceeded uint64
+	prevFailed    uint64
+	prevFuel      uint64
+	prevReserve   uint64
+	havePrev      bool
+
+	subscribersMu sync.Mutex
+	subscribers   map[chan Event]struct{}
+}
+
+// NewSampler builds a metrics sampler.
+func NewSampler(
+	wallet WalletAPI,
+	ctrl *stream.Controller,
+	originator string,
+	interval time.Duration,
+	targetTPS, denomination, targetPool, lowWaterPercent, highWaterPercent uint64,
+	logger *slog.Logger,
+) *Sampler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if interval <= 0 {
+		interval = time.Second
+	}
+	low := targetPool * lowWaterPercent / 100
+	high := targetPool * highWaterPercent / 100
+	return &Sampler{
+		wallet:       wallet,
+		ctrl:         ctrl,
+		originator:   originator,
+		logger:       logger,
+		interval:     interval,
+		targetTPS:    targetTPS,
+		denomination: denomination,
+		targetPool:   targetPool,
+		lowWater:     low,
+		highWater:    high,
+		maxEvents:    200,
+		subscribers:  make(map[chan Event]struct{}),
+	}
+}
+
+// Run samples until ctx is cancelled.
+func (s *Sampler) Run(ctx context.Context) {
+	// Immediate sample then tick.
+	s.sample(ctx)
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.sample(ctx)
+		}
+	}
+}
+
+// LastTick returns the most recent sample.
+func (s *Sampler) LastTick() Tick {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.lastTick
+}
+
+// RecentEvents returns a copy of the event ring.
+func (s *Sampler) RecentEvents() []Event {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Event, len(s.events))
+	copy(out, s.events)
+	return out
+}
+
+// Subscribe receives live events. Caller must Unsubscribe.
+func (s *Sampler) Subscribe() chan Event {
+	ch := make(chan Event, 32)
+	s.subscribersMu.Lock()
+	s.subscribers[ch] = struct{}{}
+	s.subscribersMu.Unlock()
+	return ch
+}
+
+// Unsubscribe removes a subscriber and closes its channel.
+func (s *Sampler) Unsubscribe(ch chan Event) {
+	s.subscribersMu.Lock()
+	if _, ok := s.subscribers[ch]; ok {
+		delete(s.subscribers, ch)
+		close(ch)
+	}
+	s.subscribersMu.Unlock()
+}
+
+func (s *Sampler) sample(ctx context.Context) {
+	now := time.Now().UTC()
+	stats, dAtt, dSucc, dFail := s.ctrl.SnapshotAndDelta(s.prevAttempted, s.prevSucceeded, s.prevFailed)
+	s.prevAttempted = stats.Attempted
+	s.prevSucceeded = stats.Succeeded
+	s.prevFailed = stats.Failed
+
+	defaultSats, err := s.wallet.Balance(ctx)
+	if err != nil {
+		s.logger.Warn("balance sample failed", "error", err)
+	}
+	fuelCount, err := s.basketCount(ctx, wdk.BasketNameForFuel)
+	if err != nil {
+		s.logger.Warn("fuel count sample failed", "error", err)
+	}
+	reserveCount, err := s.basketCount(ctx, wdk.BasketNameForReserve)
+	if err != nil {
+		s.logger.Warn("reserve count sample failed", "error", err)
+	}
+
+	var runway float64
+	if s.targetTPS > 0 {
+		runway = float64(fuelCount) / float64(s.targetTPS)
+	}
+
+	tick := Tick{
+		Timestamp:      now.Format(time.RFC3339Nano),
+		Stream:         stats,
+		TPSSucceeded:   dSucc,
+		TPSFailed:      dFail,
+		TPSAttempted:   dAtt,
+		DefaultSats:    defaultSats,
+		FuelCount:      fuelCount,
+		ReserveCount:   reserveCount,
+		FuelRunwaySec:  runway,
+		TargetTPS:      s.targetTPS,
+		Denomination:   s.denomination,
+		LowWater:       s.lowWater,
+		HighWater:      s.highWater,
+		TargetPoolSize: s.targetPool,
+	}
+
+	// Detect top-up activity via inventory increases.
+	if s.havePrev {
+		if fuelCount > s.prevFuel {
+			s.emit(Event{
+				Type:      "topup",
+				Timestamp: tick.Timestamp,
+				Payload: map[string]any{
+					"basket":     wdk.BasketNameForFuel,
+					"before":     s.prevFuel,
+					"after":      fuelCount,
+					"delta":      fuelCount - s.prevFuel,
+					"kind":       "fuel_inventory_increase",
+					"message":    "fuel pool inventory increased (FuelKeeper mint activity)",
+				},
+			})
+		}
+		if reserveCount > s.prevReserve {
+			s.emit(Event{
+				Type:      "topup",
+				Timestamp: tick.Timestamp,
+				Payload: map[string]any{
+					"basket":  wdk.BasketNameForReserve,
+					"before":  s.prevReserve,
+					"after":   reserveCount,
+					"delta":   reserveCount - s.prevReserve,
+					"kind":    "reserve_inventory_increase",
+					"message": "reserve basket inventory increased (chunk fan-out)",
+				},
+			})
+		}
+	}
+	s.prevFuel = fuelCount
+	s.prevReserve = reserveCount
+	s.havePrev = true
+
+	s.mu.Lock()
+	s.lastTick = tick
+	s.mu.Unlock()
+
+	s.emit(Event{
+		Type:      "tick",
+		Timestamp: tick.Timestamp,
+		Payload: map[string]any{
+			"tick": tick,
+		},
+	})
+}
+
+func (s *Sampler) basketCount(ctx context.Context, basket string) (uint64, error) {
+	result, err := s.wallet.ListOutputs(ctx, sdk.ListOutputsArgs{
+		Basket: basket,
+		Limit:  to.Ptr(uint32(1)),
+	}, s.originator)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(result.TotalOutputs), nil
+}
+
+func (s *Sampler) emit(ev Event) {
+	s.mu.Lock()
+	s.events = append(s.events, ev)
+	if len(s.events) > s.maxEvents {
+		s.events = s.events[len(s.events)-s.maxEvents:]
+	}
+	s.mu.Unlock()
+
+	s.subscribersMu.Lock()
+	defer s.subscribersMu.Unlock()
+	for ch := range s.subscribers {
+		select {
+		case ch <- ev:
+		default:
+			// drop if slow subscriber
+		}
+	}
+}

--- a/cmd/throughput_dashboard/internal/metrics/sampler.go
+++ b/cmd/throughput_dashboard/internal/metrics/sampler.go
@@ -164,15 +164,24 @@ func (s *Sampler) sample(ctx context.Context) {
 	s.prevSucceeded = stats.Succeeded
 	s.prevFailed = stats.Failed
 
-	defaultSats, err := s.wallet.Balance(ctx)
+	// Bound each storage call so a hung RPC cannot freeze ticks forever.
+	const callTimeout = 15 * time.Second
+
+	defaultSats, err := s.withTimeout(ctx, callTimeout, func(cctx context.Context) (uint64, error) {
+		return s.wallet.Balance(cctx)
+	})
 	if err != nil {
 		s.logger.Warn("balance sample failed", "error", err)
 	}
-	fuelCount, err := s.basketCount(ctx, wdk.BasketNameForFuel)
+	fuelCount, err := s.withTimeout(ctx, callTimeout, func(cctx context.Context) (uint64, error) {
+		return s.basketCount(cctx, wdk.BasketNameForFuel)
+	})
 	if err != nil {
 		s.logger.Warn("fuel count sample failed", "error", err)
 	}
-	reserveCount, err := s.basketCount(ctx, wdk.BasketNameForReserve)
+	reserveCount, err := s.withTimeout(ctx, callTimeout, func(cctx context.Context) (uint64, error) {
+		return s.basketCount(cctx, wdk.BasketNameForReserve)
+	})
 	if err != nil {
 		s.logger.Warn("reserve count sample failed", "error", err)
 	}
@@ -256,6 +265,12 @@ func (s *Sampler) basketCount(ctx context.Context, basket string) (uint64, error
 		return 0, err
 	}
 	return uint64(result.TotalOutputs), nil
+}
+
+func (s *Sampler) withTimeout(ctx context.Context, d time.Duration, fn func(context.Context) (uint64, error)) (uint64, error) {
+	cctx, cancel := context.WithTimeout(ctx, d)
+	defer cancel()
+	return fn(cctx)
 }
 
 func (s *Sampler) emit(ev Event) {

--- a/cmd/throughput_dashboard/internal/metrics/sampler.go
+++ b/cmd/throughput_dashboard/internal/metrics/sampler.go
@@ -75,14 +75,14 @@ type Sampler struct {
 
 // Config configures a metrics Sampler.
 type Config struct {
-	Originator        string
-	Interval          time.Duration
-	TargetTPS         uint64
-	Denomination      uint64
-	TargetPool        uint64
-	LowWaterPercent   uint64
-	HighWaterPercent  uint64
-	Logger            *slog.Logger
+	Originator       string
+	Interval         time.Duration
+	TargetTPS        uint64
+	Denomination     uint64
+	TargetPool       uint64
+	LowWaterPercent  uint64
+	HighWaterPercent uint64
+	Logger           *slog.Logger
 }
 
 // NewSampler builds a metrics sampler.
@@ -222,12 +222,12 @@ func (s *Sampler) sample(ctx context.Context) {
 				Type:      "topup",
 				Timestamp: tick.Timestamp,
 				Payload: map[string]any{
-					"basket":     wdk.BasketNameForFuel,
-					"before":     s.prevFuel,
-					"after":      fuelCount,
-					"delta":      fuelCount - s.prevFuel,
-					"kind":       "fuel_inventory_increase",
-					"message":    "fuel pool inventory increased (FuelKeeper mint activity)",
+					"basket":  wdk.BasketNameForFuel,
+					"before":  s.prevFuel,
+					"after":   fuelCount,
+					"delta":   fuelCount - s.prevFuel,
+					"kind":    "fuel_inventory_increase",
+					"message": "fuel pool inventory increased (FuelKeeper mint activity)",
 				},
 			})
 		}

--- a/cmd/throughput_dashboard/internal/metrics/sampler.go
+++ b/cmd/throughput_dashboard/internal/metrics/sampler.go
@@ -73,32 +73,39 @@ type Sampler struct {
 	subscribers   map[chan Event]struct{}
 }
 
+// Config configures a metrics Sampler.
+type Config struct {
+	Originator        string
+	Interval          time.Duration
+	TargetTPS         uint64
+	Denomination      uint64
+	TargetPool        uint64
+	LowWaterPercent   uint64
+	HighWaterPercent  uint64
+	Logger            *slog.Logger
+}
+
 // NewSampler builds a metrics sampler.
-func NewSampler(
-	wallet WalletAPI,
-	ctrl *stream.Controller,
-	originator string,
-	interval time.Duration,
-	targetTPS, denomination, targetPool, lowWaterPercent, highWaterPercent uint64,
-	logger *slog.Logger,
-) *Sampler {
+func NewSampler(wallet WalletAPI, ctrl *stream.Controller, cfg Config) *Sampler {
+	logger := cfg.Logger
 	if logger == nil {
 		logger = slog.Default()
 	}
+	interval := cfg.Interval
 	if interval <= 0 {
 		interval = time.Second
 	}
-	low := targetPool * lowWaterPercent / 100
-	high := targetPool * highWaterPercent / 100
+	low := cfg.TargetPool * cfg.LowWaterPercent / 100
+	high := cfg.TargetPool * cfg.HighWaterPercent / 100
 	return &Sampler{
 		wallet:       wallet,
 		ctrl:         ctrl,
-		originator:   originator,
+		originator:   cfg.Originator,
 		logger:       logger,
 		interval:     interval,
-		targetTPS:    targetTPS,
-		denomination: denomination,
-		targetPool:   targetPool,
+		targetTPS:    cfg.TargetTPS,
+		denomination: cfg.Denomination,
+		targetPool:   cfg.TargetPool,
 		lowWater:     low,
 		highWater:    high,
 		maxEvents:    200,

--- a/cmd/throughput_dashboard/internal/metrics/sampler_test.go
+++ b/cmd/throughput_dashboard/internal/metrics/sampler_test.go
@@ -1,0 +1,497 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	sdk "github.com/bsv-blockchain/go-sdk/wallet"
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/stream"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeWallet implements WalletAPI with controllable balance and basket totals.
+type fakeWallet struct {
+	mu           sync.Mutex
+	balance      uint64
+	balanceErr   error
+	fuelTotal    uint32
+	reserveTotal uint32
+	listErr      error
+	listCalls    []sdk.ListOutputsArgs
+	originators  []string
+}
+
+func (f *fakeWallet) Balance(context.Context) (uint64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.balanceErr != nil {
+		return 0, f.balanceErr
+	}
+	return f.balance, nil
+}
+
+func (f *fakeWallet) ListOutputs(_ context.Context, args sdk.ListOutputsArgs, originator string) (*sdk.ListOutputsResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.listCalls = append(f.listCalls, args)
+	f.originators = append(f.originators, originator)
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	var total uint32
+	switch args.Basket {
+	case wdk.BasketNameForFuel:
+		total = f.fuelTotal
+	case wdk.BasketNameForReserve:
+		total = f.reserveTotal
+	}
+	return &sdk.ListOutputsResult{TotalOutputs: total}, nil
+}
+
+func (f *fakeWallet) setFuel(n uint32) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.fuelTotal = n
+}
+
+func (f *fakeWallet) setReserve(n uint32) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reserveTotal = n
+}
+
+// fakeActionCreator satisfies stream.ActionCreator for constructing a Controller.
+type fakeActionCreator struct {
+	calls atomic.Uint64
+	fail  bool
+}
+
+func (f *fakeActionCreator) CreateAction(ctx context.Context, _ sdk.CreateActionArgs, _ string) (*sdk.CreateActionResult, error) {
+	f.calls.Add(1)
+	if f.fail {
+		return nil, errors.New("createAction failed")
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	return &sdk.CreateActionResult{}, nil
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newTestSampler(t *testing.T, wallet WalletAPI, ctrl *stream.Controller, targetTPS uint64) *Sampler {
+	t.Helper()
+	if ctrl == nil {
+		ctrl = stream.NewController(&fakeActionCreator{}, stream.Options{TPS: 1, Workers: 1, Originator: "test"}, discardLogger())
+	}
+	return NewSampler(
+		wallet,
+		ctrl,
+		"test-originator",
+		time.Hour, // long interval; tests drive sample() directly
+		targetTPS,
+		240,  // denomination
+		1000, // target pool
+		60,   // low water %
+		100,  // high water %
+		discardLogger(),
+	)
+}
+
+func TestNewSampler_Defaults(t *testing.T) {
+	ctrl := stream.NewController(&fakeActionCreator{}, stream.Options{}, discardLogger())
+	s := NewSampler(&fakeWallet{}, ctrl, "orig", 0, 10, 240, 1000, 60, 100, nil)
+
+	assert.Equal(t, time.Second, s.interval, "non-positive interval defaults to 1s")
+	assert.Equal(t, uint64(600), s.lowWater)
+	assert.Equal(t, uint64(1000), s.highWater)
+	assert.Equal(t, 200, s.maxEvents)
+	assert.NotNil(t, s.logger)
+	assert.NotNil(t, s.subscribers)
+}
+
+func TestSample_TickFieldsAndRunway(t *testing.T) {
+	wallet := &fakeWallet{balance: 50_000, fuelTotal: 120, reserveTotal: 40}
+	s := newTestSampler(t, wallet, nil, 10)
+
+	s.sample(context.Background())
+
+	tick := s.LastTick()
+	assert.NotEmpty(t, tick.Timestamp)
+	assert.Equal(t, uint64(50_000), tick.DefaultSats)
+	assert.Equal(t, uint64(120), tick.FuelCount)
+	assert.Equal(t, uint64(40), tick.ReserveCount)
+	assert.InDelta(t, 12.0, tick.FuelRunwaySec, 1e-9) // 120 / 10
+	assert.Equal(t, uint64(10), tick.TargetTPS)
+	assert.Equal(t, uint64(240), tick.Denomination)
+	assert.Equal(t, uint64(600), tick.LowWater)
+	assert.Equal(t, uint64(1000), tick.HighWater)
+	assert.Equal(t, uint64(1000), tick.TargetPoolSize)
+	assert.Equal(t, uint64(0), tick.TPSAttempted)
+	assert.Equal(t, uint64(0), tick.TPSSucceeded)
+	assert.Equal(t, uint64(0), tick.TPSFailed)
+
+	// ListOutputs polled for fuel + reserve with limit 1 and originator.
+	require.Len(t, wallet.listCalls, 2)
+	assert.Equal(t, wdk.BasketNameForFuel, wallet.listCalls[0].Basket)
+	assert.Equal(t, wdk.BasketNameForReserve, wallet.listCalls[1].Basket)
+	require.NotNil(t, wallet.listCalls[0].Limit)
+	assert.Equal(t, uint32(1), *wallet.listCalls[0].Limit)
+	assert.Equal(t, []string{"test-originator", "test-originator"}, wallet.originators)
+}
+
+func TestSample_RunwayZeroWhenTargetTPSZero(t *testing.T) {
+	wallet := &fakeWallet{fuelTotal: 500}
+	s := newTestSampler(t, wallet, nil, 0)
+
+	s.sample(context.Background())
+	assert.Equal(t, float64(0), s.LastTick().FuelRunwaySec)
+}
+
+func TestSample_EmitsTickEvent(t *testing.T) {
+	s := newTestSampler(t, &fakeWallet{fuelTotal: 1}, nil, 5)
+	s.sample(context.Background())
+
+	events := s.RecentEvents()
+	require.Len(t, events, 1)
+	assert.Equal(t, "tick", events[0].Type)
+	assert.NotEmpty(t, events[0].Timestamp)
+	require.Contains(t, events[0].Payload, "tick")
+}
+
+func TestSample_NoTopupOnFirstSample(t *testing.T) {
+	wallet := &fakeWallet{fuelTotal: 100, reserveTotal: 50}
+	s := newTestSampler(t, wallet, nil, 10)
+
+	s.sample(context.Background())
+
+	for _, ev := range s.RecentEvents() {
+		assert.NotEqual(t, "topup", ev.Type, "first sample must not emit topup")
+	}
+}
+
+func TestSample_TopupOnFuelIncrease(t *testing.T) {
+	wallet := &fakeWallet{fuelTotal: 10, reserveTotal: 5}
+	s := newTestSampler(t, wallet, nil, 10)
+
+	s.sample(context.Background())
+	wallet.setFuel(25)
+	s.sample(context.Background())
+
+	var topups []Event
+	for _, ev := range s.RecentEvents() {
+		if ev.Type == "topup" {
+			topups = append(topups, ev)
+		}
+	}
+	require.Len(t, topups, 1)
+	assert.Equal(t, wdk.BasketNameForFuel, topups[0].Payload["basket"])
+	assert.Equal(t, uint64(10), topups[0].Payload["before"])
+	assert.Equal(t, uint64(25), topups[0].Payload["after"])
+	assert.Equal(t, uint64(15), topups[0].Payload["delta"])
+	assert.Equal(t, "fuel_inventory_increase", topups[0].Payload["kind"])
+}
+
+func TestSample_TopupOnReserveIncrease(t *testing.T) {
+	wallet := &fakeWallet{fuelTotal: 10, reserveTotal: 5}
+	s := newTestSampler(t, wallet, nil, 10)
+
+	s.sample(context.Background())
+	wallet.setReserve(12)
+	s.sample(context.Background())
+
+	var topups []Event
+	for _, ev := range s.RecentEvents() {
+		if ev.Type == "topup" {
+			topups = append(topups, ev)
+		}
+	}
+	require.Len(t, topups, 1)
+	assert.Equal(t, wdk.BasketNameForReserve, topups[0].Payload["basket"])
+	assert.Equal(t, uint64(5), topups[0].Payload["before"])
+	assert.Equal(t, uint64(12), topups[0].Payload["after"])
+	assert.Equal(t, uint64(7), topups[0].Payload["delta"])
+	assert.Equal(t, "reserve_inventory_increase", topups[0].Payload["kind"])
+}
+
+func TestSample_TopupBothBaskets(t *testing.T) {
+	wallet := &fakeWallet{fuelTotal: 1, reserveTotal: 1}
+	s := newTestSampler(t, wallet, nil, 10)
+
+	s.sample(context.Background())
+	wallet.setFuel(2)
+	wallet.setReserve(3)
+	s.sample(context.Background())
+
+	var kinds []string
+	for _, ev := range s.RecentEvents() {
+		if ev.Type == "topup" {
+			kinds = append(kinds, ev.Payload["kind"].(string))
+		}
+	}
+	assert.ElementsMatch(t, []string{"fuel_inventory_increase", "reserve_inventory_increase"}, kinds)
+}
+
+func TestSample_NoTopupOnDecreaseOrUnchanged(t *testing.T) {
+	wallet := &fakeWallet{fuelTotal: 20, reserveTotal: 20}
+	s := newTestSampler(t, wallet, nil, 10)
+
+	s.sample(context.Background())
+	wallet.setFuel(15)    // decrease
+	wallet.setReserve(20) // unchanged
+	s.sample(context.Background())
+
+	for _, ev := range s.RecentEvents() {
+		assert.NotEqual(t, "topup", ev.Type)
+	}
+	// two ticks only
+	assert.Len(t, s.RecentEvents(), 2)
+}
+
+func TestSample_StreamDeltasAfterActivity(t *testing.T) {
+	actions := &fakeActionCreator{}
+	ctrl := stream.NewController(actions, stream.Options{TPS: 200, Workers: 4, Originator: "test"}, discardLogger())
+	wallet := &fakeWallet{}
+	s := newTestSampler(t, wallet, ctrl, 10)
+
+	// Baseline sample with idle stream.
+	s.sample(context.Background())
+	require.Equal(t, uint64(0), s.LastTick().TPSAttempted)
+
+	require.NoError(t, ctrl.Start(context.Background(), stream.Options{}))
+	time.Sleep(80 * time.Millisecond)
+	ctrl.Stop()
+
+	s.sample(context.Background())
+	tick := s.LastTick()
+	require.Positive(t, tick.TPSAttempted, "expected stream activity deltas after run")
+	assert.Equal(t, tick.TPSAttempted, tick.TPSSucceeded+tick.TPSFailed)
+	assert.Equal(t, tick.Stream.Attempted, tick.TPSAttempted) // prev was 0
+
+	// Idle again: deltas should be zero while cumulative stats remain.
+	prevAttempted := tick.Stream.Attempted
+	s.sample(context.Background())
+	tick2 := s.LastTick()
+	assert.Equal(t, uint64(0), tick2.TPSAttempted)
+	assert.Equal(t, prevAttempted, tick2.Stream.Attempted)
+}
+
+func TestSubscribe_ReceivesEvents(t *testing.T) {
+	s := newTestSampler(t, &fakeWallet{fuelTotal: 1}, nil, 5)
+	ch := s.Subscribe()
+	defer s.Unsubscribe(ch)
+
+	s.sample(context.Background())
+
+	select {
+	case ev := <-ch:
+		assert.Equal(t, "tick", ev.Type)
+	case <-time.After(time.Second):
+		t.Fatal("expected tick event on subscriber channel")
+	}
+}
+
+func TestSubscribe_ReceivesTopup(t *testing.T) {
+	wallet := &fakeWallet{fuelTotal: 1}
+	s := newTestSampler(t, wallet, nil, 5)
+	ch := s.Subscribe()
+	defer s.Unsubscribe(ch)
+
+	s.sample(context.Background())
+	// drain first tick
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("missing first tick")
+	}
+
+	wallet.setFuel(10)
+	s.sample(context.Background())
+
+	var gotTopup, gotTick bool
+	deadline := time.After(time.Second)
+	for !gotTopup || !gotTick {
+		select {
+		case ev := <-ch:
+			switch ev.Type {
+			case "topup":
+				gotTopup = true
+			case "tick":
+				gotTick = true
+			}
+		case <-deadline:
+			t.Fatalf("timeout waiting for topup+tick (topup=%v tick=%v)", gotTopup, gotTick)
+		}
+	}
+}
+
+func TestUnsubscribe_ClosesChannelAndStopsDelivery(t *testing.T) {
+	s := newTestSampler(t, &fakeWallet{}, nil, 5)
+	ch := s.Subscribe()
+	s.Unsubscribe(ch)
+
+	// Channel should be closed.
+	_, ok := <-ch
+	assert.False(t, ok, "unsubscribed channel should be closed")
+
+	// Further samples must not panic or re-open delivery.
+	s.sample(context.Background())
+	assert.Len(t, s.RecentEvents(), 1)
+
+	// Double unsubscribe is safe.
+	s.Unsubscribe(ch)
+}
+
+func TestEmit_NonBlockingWhenSubscriberFull(t *testing.T) {
+	s := newTestSampler(t, &fakeWallet{}, nil, 5)
+	ch := s.Subscribe() // buffer 32
+	defer s.Unsubscribe(ch)
+
+	// Flood past buffer capacity; sample/emit must not block.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 64; i++ {
+			s.sample(context.Background())
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// ok
+	case <-time.After(3 * time.Second):
+		t.Fatal("emit blocked on slow/full subscriber")
+	}
+
+	// Channel has at most buffer capacity of events.
+	n := 0
+drain:
+	for {
+		select {
+		case <-ch:
+			n++
+		default:
+			break drain
+		}
+	}
+	assert.LessOrEqual(t, n, 32)
+	assert.Positive(t, n)
+}
+
+func TestRecentEvents_RingCap(t *testing.T) {
+	s := newTestSampler(t, &fakeWallet{}, nil, 5)
+	s.maxEvents = 5
+
+	for i := 0; i < 12; i++ {
+		s.sample(context.Background())
+	}
+
+	events := s.RecentEvents()
+	require.Len(t, events, 5)
+	// All remaining should be ticks from the latest samples.
+	for _, ev := range events {
+		assert.Equal(t, "tick", ev.Type)
+	}
+
+	// Copy independence: mutating returned slice does not affect ring.
+	events[0].Type = "mutated"
+	assert.Equal(t, "tick", s.RecentEvents()[0].Type)
+}
+
+func TestRun_SamplesThenStopsOnCancel(t *testing.T) {
+	wallet := &fakeWallet{balance: 1, fuelTotal: 2}
+	s := NewSampler(
+		wallet,
+		stream.NewController(&fakeActionCreator{}, stream.Options{TPS: 1, Workers: 1}, discardLogger()),
+		"orig",
+		50*time.Millisecond,
+		10, 240, 100, 60, 100,
+		discardLogger(),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.Run(ctx)
+		close(done)
+	}()
+
+	// Wait for at least the immediate sample + one ticker fire.
+	require.Eventually(t, func() bool {
+		return len(s.RecentEvents()) >= 2
+	}, time.Second, 10*time.Millisecond)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not exit after cancel")
+	}
+
+	tick := s.LastTick()
+	assert.Equal(t, uint64(1), tick.DefaultSats)
+	assert.Equal(t, uint64(2), tick.FuelCount)
+}
+
+func TestSample_WalletErrorsDoNotPanic(t *testing.T) {
+	wallet := &fakeWallet{
+		balanceErr: errors.New("balance down"),
+		listErr:    errors.New("list down"),
+	}
+	s := newTestSampler(t, wallet, nil, 10)
+
+	require.NotPanics(t, func() {
+		s.sample(context.Background())
+	})
+	tick := s.LastTick()
+	assert.Equal(t, uint64(0), tick.DefaultSats)
+	assert.Equal(t, uint64(0), tick.FuelCount)
+	assert.Equal(t, uint64(0), tick.ReserveCount)
+	// still emits tick
+	require.Len(t, s.RecentEvents(), 1)
+}
+
+func TestConcurrentLastTickAndSubscribe(t *testing.T) {
+	wallet := &fakeWallet{fuelTotal: 5}
+	s := newTestSampler(t, wallet, nil, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.Run(ctx)
+	}()
+
+	// Concurrent readers + short-lived subscribers while Run samples.
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				_ = s.LastTick()
+				_ = s.RecentEvents()
+				ch := s.Subscribe()
+				s.Unsubscribe(ch)
+			}
+		}()
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	wg.Wait()
+}

--- a/cmd/throughput_dashboard/internal/metrics/sampler_test.go
+++ b/cmd/throughput_dashboard/internal/metrics/sampler_test.go
@@ -417,7 +417,7 @@ func TestRecentEvents_RingCap(t *testing.T) {
 func TestRun_SamplesThenStopsOnCancel(t *testing.T) {
 	wallet := &fakeWallet{balance: 1, fuelTotal: 2}
 	s := NewSampler(wallet, stream.NewController(&fakeActionCreator{}, stream.Options{TPS: 1, Workers: 1}, discardLogger()), Config{
-		Originator: "orig", Interval: 50*time.Millisecond,
+		Originator: "orig", Interval: 50 * time.Millisecond,
 		TargetTPS: 10, Denomination: 240, TargetPool: 100,
 		LowWaterPercent: 60, HighWaterPercent: 100,
 		Logger: discardLogger(),

--- a/cmd/throughput_dashboard/internal/metrics/sampler_test.go
+++ b/cmd/throughput_dashboard/internal/metrics/sampler_test.go
@@ -96,23 +96,27 @@ func newTestSampler(t *testing.T, wallet WalletAPI, ctrl *stream.Controller, tar
 	if ctrl == nil {
 		ctrl = stream.NewController(&fakeActionCreator{}, stream.Options{TPS: 1, Workers: 1, Originator: "test"}, discardLogger())
 	}
-	return NewSampler(
-		wallet,
-		ctrl,
-		"test-originator",
-		time.Hour, // long interval; tests drive sample() directly
-		targetTPS,
-		240,  // denomination
-		1000, // target pool
-		60,   // low water %
-		100,  // high water %
-		discardLogger(),
-	)
+	// long interval; tests drive sample() directly
+	return NewSampler(wallet, ctrl, Config{
+		Originator:       "test-originator",
+		Interval:         time.Hour,
+		TargetTPS:        targetTPS,
+		Denomination:     240,
+		TargetPool:       1000,
+		LowWaterPercent:  60,
+		HighWaterPercent: 100,
+		Logger:           discardLogger(),
+	})
 }
 
 func TestNewSampler_Defaults(t *testing.T) {
 	ctrl := stream.NewController(&fakeActionCreator{}, stream.Options{}, discardLogger())
-	s := NewSampler(&fakeWallet{}, ctrl, "orig", 0, 10, 240, 1000, 60, 100, nil)
+	s := NewSampler(&fakeWallet{}, ctrl, Config{
+		Originator: "orig", Interval: 0,
+		TargetTPS: 10, Denomination: 240, TargetPool: 1000,
+		LowWaterPercent: 60, HighWaterPercent: 100,
+		Logger: nil,
+	})
 
 	assert.Equal(t, time.Second, s.interval, "non-positive interval defaults to 1s")
 	assert.Equal(t, uint64(600), s.lowWater)
@@ -412,14 +416,12 @@ func TestRecentEvents_RingCap(t *testing.T) {
 
 func TestRun_SamplesThenStopsOnCancel(t *testing.T) {
 	wallet := &fakeWallet{balance: 1, fuelTotal: 2}
-	s := NewSampler(
-		wallet,
-		stream.NewController(&fakeActionCreator{}, stream.Options{TPS: 1, Workers: 1}, discardLogger()),
-		"orig",
-		50*time.Millisecond,
-		10, 240, 100, 60, 100,
-		discardLogger(),
-	)
+	s := NewSampler(wallet, stream.NewController(&fakeActionCreator{}, stream.Options{TPS: 1, Workers: 1}, discardLogger()), Config{
+		Originator: "orig", Interval: 50*time.Millisecond,
+		TargetTPS: 10, Denomination: 240, TargetPool: 100,
+		LowWaterPercent: 60, HighWaterPercent: 100,
+		Logger: discardLogger(),
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})

--- a/cmd/throughput_dashboard/internal/metrics/sampler_test.go
+++ b/cmd/throughput_dashboard/internal/metrics/sampler_test.go
@@ -161,7 +161,7 @@ func TestSample_RunwayZeroWhenTargetTPSZero(t *testing.T) {
 	s := newTestSampler(t, wallet, nil, 0)
 
 	s.sample(context.Background())
-	assert.Equal(t, float64(0), s.LastTick().FuelRunwaySec)
+	assert.InDelta(t, 0, s.LastTick().FuelRunwaySec, 0.001)
 }
 
 func TestSample_EmitsTickEvent(t *testing.T) {

--- a/cmd/throughput_dashboard/internal/stream/controller.go
+++ b/cmd/throughput_dashboard/internal/stream/controller.go
@@ -37,6 +37,13 @@ type Options struct {
 	Originator string
 }
 
+// Hard caps for stream knobs. Workers sizes a channel buffer and a goroutine
+// pool; unbounded user input would allow a denial-of-service allocation.
+const (
+	MaxTPS     = 100_000
+	MaxWorkers = 512
+)
+
 // Controller is a start/stop controllable rate-limited createAction stream.
 type Controller struct {
 	wallet ActionCreator
@@ -98,6 +105,12 @@ func (c *Controller) Start(parent context.Context, opts Options) error {
 	}
 	if c.tps <= 0 || c.workers <= 0 {
 		return fmt.Errorf("invalid stream options: tps=%d workers=%d", c.tps, c.workers)
+	}
+	if c.tps > MaxTPS {
+		return fmt.Errorf("tps %d exceeds max %d", c.tps, MaxTPS)
+	}
+	if c.workers > MaxWorkers {
+		return fmt.Errorf("workers %d exceeds max %d", c.workers, MaxWorkers)
 	}
 
 	ctx, cancel := context.WithCancel(parent)

--- a/cmd/throughput_dashboard/internal/stream/controller.go
+++ b/cmd/throughput_dashboard/internal/stream/controller.go
@@ -1,0 +1,247 @@
+package stream
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	sdk "github.com/bsv-blockchain/go-sdk/wallet"
+	"github.com/go-softwarelab/common/pkg/to"
+	"golang.org/x/time/rate"
+)
+
+// ActionCreator is the wallet surface used by the stream.
+type ActionCreator interface {
+	CreateAction(ctx context.Context, args sdk.CreateActionArgs, originator string) (*sdk.CreateActionResult, error)
+}
+
+// Stats holds aggregate createAction outcomes.
+type Stats struct {
+	Attempted  uint64 `json:"attempted"`
+	Succeeded  uint64 `json:"succeeded"`
+	Failed     uint64 `json:"failed"`
+	Iteration  uint64 `json:"iteration"`
+	Running    bool   `json:"running"`
+	TPS        int    `json:"tps"`
+	Workers    int    `json:"workers"`
+	StartedAt  string `json:"started_at,omitempty"`
+}
+
+// Options configure a stream run.
+type Options struct {
+	TPS        int
+	Workers    int
+	Originator string
+}
+
+// Controller is a start/stop controllable rate-limited createAction stream.
+type Controller struct {
+	wallet ActionCreator
+	logger *slog.Logger
+
+	mu        sync.Mutex
+	running   bool
+	cancel    context.CancelFunc
+	done      chan struct{}
+	tps       int
+	workers   int
+	originator string
+	startedAt time.Time
+
+	attempted atomic.Uint64
+	succeeded atomic.Uint64
+	failed    atomic.Uint64
+	iteration atomic.Uint64
+}
+
+// NewController creates a stream controller. Default options apply until Start overrides them.
+func NewController(wallet ActionCreator, defaults Options, logger *slog.Logger) *Controller {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if defaults.TPS <= 0 {
+		defaults.TPS = 10
+	}
+	if defaults.Workers <= 0 {
+		defaults.Workers = 8
+	}
+	if defaults.Originator == "" {
+		defaults.Originator = "throughput-dashboard.local"
+	}
+	return &Controller{
+		wallet:     wallet,
+		logger:     logger,
+		tps:        defaults.TPS,
+		workers:    defaults.Workers,
+		originator: defaults.Originator,
+	}
+}
+
+// Start begins the event stream. Idempotent if already running with same process.
+func (c *Controller) Start(parent context.Context, opts Options) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.running {
+		return fmt.Errorf("stream already running")
+	}
+	if opts.TPS > 0 {
+		c.tps = opts.TPS
+	}
+	if opts.Workers > 0 {
+		c.workers = opts.Workers
+	}
+	if opts.Originator != "" {
+		c.originator = opts.Originator
+	}
+	if c.tps <= 0 || c.workers <= 0 {
+		return fmt.Errorf("invalid stream options: tps=%d workers=%d", c.tps, c.workers)
+	}
+
+	ctx, cancel := context.WithCancel(parent)
+	c.cancel = cancel
+	c.done = make(chan struct{})
+	c.running = true
+	c.startedAt = time.Now().UTC()
+
+	go c.run(ctx, c.done)
+	c.logger.Info("event stream started", "tps", c.tps, "workers", c.workers)
+	return nil
+}
+
+// Stop requests stream shutdown and waits for workers to drain.
+func (c *Controller) Stop() {
+	c.mu.Lock()
+	if !c.running {
+		c.mu.Unlock()
+		return
+	}
+	cancel := c.cancel
+	done := c.done
+	c.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done
+	}
+
+	c.mu.Lock()
+	c.running = false
+	c.cancel = nil
+	c.done = nil
+	c.mu.Unlock()
+	c.logger.Info("event stream stopped", "stats", c.Stats())
+}
+
+// Running reports whether the stream is active.
+func (c *Controller) Running() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.running
+}
+
+// Stats returns a snapshot of counters and run state.
+func (c *Controller) Stats() Stats {
+	c.mu.Lock()
+	running := c.running
+	tps := c.tps
+	workers := c.workers
+	started := c.startedAt
+	c.mu.Unlock()
+
+	s := Stats{
+		Attempted: c.attempted.Load(),
+		Succeeded: c.succeeded.Load(),
+		Failed:    c.failed.Load(),
+		Iteration: c.iteration.Load(),
+		Running:   running,
+		TPS:       tps,
+		Workers:   workers,
+	}
+	if !started.IsZero() {
+		s.StartedAt = started.Format(time.RFC3339Nano)
+	}
+	return s
+}
+
+// SnapshotAndDelta returns current stats and deltas since prev counters.
+func (c *Controller) SnapshotAndDelta(prevAttempted, prevSucceeded, prevFailed uint64) (Stats, uint64, uint64, uint64) {
+	s := c.Stats()
+	return s, s.Attempted - prevAttempted, s.Succeeded - prevSucceeded, s.Failed - prevFailed
+}
+
+func (c *Controller) run(ctx context.Context, done chan struct{}) {
+	defer close(done)
+
+	jobs := make(chan struct{}, c.workers)
+	var wg sync.WaitGroup
+	for i := 0; i < c.workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range jobs {
+				c.runOne(ctx)
+			}
+		}()
+	}
+
+	limiter := rate.NewLimiter(rate.Limit(c.tps), 1)
+	for {
+		if err := limiter.Wait(ctx); err != nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			// drain producer
+			goto drain
+		case jobs <- struct{}{}:
+		}
+	}
+drain:
+	close(jobs)
+	wg.Wait()
+
+	c.mu.Lock()
+	c.running = false
+	c.cancel = nil
+	c.mu.Unlock()
+}
+
+func (c *Controller) runOne(ctx context.Context) {
+	iter := c.iteration.Add(1)
+	c.attempted.Add(1)
+
+	locking, err := OpReturnLockingScriptForIteration(iter, time.Now().UTC())
+	if err != nil {
+		c.failed.Add(1)
+		c.logger.Warn("opreturn build failed", "error", err, "iteration", iter)
+		return
+	}
+
+	args := sdk.CreateActionArgs{
+		Description: fmt.Sprintf("throughput dashboard stream #%d", iter),
+		Outputs: []sdk.CreateActionOutput{
+			{
+				LockingScript:     locking,
+				Satoshis:          0,
+				OutputDescription: "sha256(iteration||timestamp)",
+			},
+		},
+		Options: &sdk.CreateActionOptions{
+			AcceptDelayedBroadcast: to.Ptr(true),
+		},
+	}
+
+	if _, err := c.wallet.CreateAction(ctx, args, c.originator); err != nil {
+		n := c.failed.Add(1)
+		if n <= 5 || n%100 == 0 {
+			c.logger.Warn("createAction failed", "error", err, "failed_count", n, "iteration", iter)
+		}
+		return
+	}
+	c.succeeded.Add(1)
+}

--- a/cmd/throughput_dashboard/internal/stream/controller.go
+++ b/cmd/throughput_dashboard/internal/stream/controller.go
@@ -119,10 +119,9 @@ func (c *Controller) Start(parent context.Context, opts Options) error {
 		parent = context.Background()
 	}
 
-	// prodCtx is canceled only to halt the rate-limited job producer.
-	// workCtx is never canceled by Stop (or parent cancel) so in-flight
-	// CreateAction calls always run to completion.
-	prodCtx, stopProd := context.WithCancel(context.Background())
+	// prodCtx is canceled by Stop() or when parent ends — only the job producer
+	// uses it. workCtx is never canceled so in-flight CreateAction calls finish.
+	prodCtx, stopProd := context.WithCancel(parent)
 	workCtx := context.WithoutCancel(parent)
 	c.stopProd = stopProd
 	c.done = make(chan struct{})
@@ -135,15 +134,6 @@ func (c *Controller) Start(parent context.Context, opts Options) error {
 	workers := c.workers
 	originator := c.originator
 	done := c.done
-
-	// Parent cancel (e.g. process shutdown signal path) also stops production.
-	go func() {
-		select {
-		case <-parent.Done():
-			stopProd()
-		case <-prodCtx.Done():
-		}
-	}()
 
 	go c.run(prodCtx, workCtx, done, tps, workers, originator)
 	c.logger.Info("event stream started", "tps", tps, "workers", workers)

--- a/cmd/throughput_dashboard/internal/stream/controller.go
+++ b/cmd/throughput_dashboard/internal/stream/controller.go
@@ -51,7 +51,7 @@ type Controller struct {
 
 	mu         sync.Mutex
 	running    bool
-	cancel     context.CancelFunc
+	stopProd   context.CancelFunc // stops new job production only
 	done       chan struct{}
 	tps        int
 	workers    int
@@ -88,6 +88,9 @@ func NewController(wallet ActionCreator, defaults Options, logger *slog.Logger) 
 }
 
 // Start begins the event stream. Returns an error if a stream is already running.
+//
+// parent, when canceled, stops scheduling new events (same as Stop) but does not
+// abort createActions already in flight. Stop always waits for those to finish.
 func (c *Controller) Start(parent context.Context, opts Options) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -112,9 +115,16 @@ func (c *Controller) Start(parent context.Context, opts Options) error {
 	if c.workers > MaxWorkers {
 		return fmt.Errorf("workers %d exceeds max %d", c.workers, MaxWorkers)
 	}
+	if parent == nil {
+		parent = context.Background()
+	}
 
-	ctx, cancel := context.WithCancel(parent)
-	c.cancel = cancel
+	// prodCtx is canceled only to halt the rate-limited job producer.
+	// workCtx is never canceled by Stop (or parent cancel) so in-flight
+	// CreateAction calls always run to completion.
+	prodCtx, stopProd := context.WithCancel(context.Background())
+	workCtx := context.WithoutCancel(parent)
+	c.stopProd = stopProd
 	c.done = make(chan struct{})
 	c.running = true
 	c.startedAt = time.Now().UTC()
@@ -126,12 +136,22 @@ func (c *Controller) Start(parent context.Context, opts Options) error {
 	originator := c.originator
 	done := c.done
 
-	go c.run(ctx, done, tps, workers, originator)
+	// Parent cancel (e.g. process shutdown signal path) also stops production.
+	go func() {
+		select {
+		case <-parent.Done():
+			stopProd()
+		case <-prodCtx.Done():
+		}
+	}()
+
+	go c.run(prodCtx, workCtx, done, tps, workers, originator)
 	c.logger.Info("event stream started", "tps", tps, "workers", workers)
 	return nil
 }
 
-// Stop requests stream shutdown and waits for workers to drain.
+// Stop stops scheduling new createAction events and waits for in-flight ones to finish.
+// It does not cancel wallet RPCs that have already started.
 // Concurrent Stop calls are safe; a Stop that loses a race with a subsequent Start
 // will not tear down the newer run.
 func (c *Controller) Stop() {
@@ -140,23 +160,23 @@ func (c *Controller) Stop() {
 		c.mu.Unlock()
 		return
 	}
-	cancel := c.cancel
+	stopProd := c.stopProd
 	done := c.done
 	c.mu.Unlock()
 
-	if cancel != nil {
-		cancel()
+	if stopProd != nil {
+		stopProd()
 	}
 	if done != nil {
 		<-done
 	}
 
 	c.mu.Lock()
-	// Only clear state if this Stop still owns the generation it cancelled.
+	// Only clear state if this Stop still owns the generation it stopped.
 	// run() may already have cleared running; a newer Start may have replaced done.
 	if c.done == done {
 		c.running = false
-		c.cancel = nil
+		c.stopProd = nil
 		c.done = nil
 	}
 	c.mu.Unlock()
@@ -200,7 +220,7 @@ func (c *Controller) SnapshotAndDelta(prevAttempted, prevSucceeded, prevFailed u
 	return s, s.Attempted - prevAttempted, s.Succeeded - prevSucceeded, s.Failed - prevFailed
 }
 
-func (c *Controller) run(ctx context.Context, done chan struct{}, tps, workers int, originator string) {
+func (c *Controller) run(prodCtx, workCtx context.Context, done chan struct{}, tps, workers int, originator string) {
 	defer close(done)
 
 	jobs := make(chan struct{}, workers)
@@ -210,18 +230,19 @@ func (c *Controller) run(ctx context.Context, done chan struct{}, tps, workers i
 		go func() {
 			defer wg.Done()
 			for range jobs {
-				c.runOne(ctx, originator)
+				// workCtx is never canceled by Stop — only production is halted.
+				c.runOne(workCtx, originator)
 			}
 		}()
 	}
 
 	limiter := rate.NewLimiter(rate.Limit(tps), 1)
 	for {
-		if err := limiter.Wait(ctx); err != nil {
+		if err := limiter.Wait(prodCtx); err != nil {
 			break
 		}
 		select {
-		case <-ctx.Done():
+		case <-prodCtx.Done():
 			goto drain
 		case jobs <- struct{}{}:
 		}
@@ -234,7 +255,7 @@ drain:
 	// Mark stopped if this generation is still current. Stop() may also clear.
 	if c.done == done {
 		c.running = false
-		c.cancel = nil
+		c.stopProd = nil
 	}
 	c.mu.Unlock()
 }

--- a/cmd/throughput_dashboard/internal/stream/controller.go
+++ b/cmd/throughput_dashboard/internal/stream/controller.go
@@ -20,14 +20,14 @@ type ActionCreator interface {
 
 // Stats holds aggregate createAction outcomes.
 type Stats struct {
-	Attempted  uint64 `json:"attempted"`
-	Succeeded  uint64 `json:"succeeded"`
-	Failed     uint64 `json:"failed"`
-	Iteration  uint64 `json:"iteration"`
-	Running    bool   `json:"running"`
-	TPS        int    `json:"tps"`
-	Workers    int    `json:"workers"`
-	StartedAt  string `json:"started_at,omitempty"`
+	Attempted uint64 `json:"attempted"`
+	Succeeded uint64 `json:"succeeded"`
+	Failed    uint64 `json:"failed"`
+	Iteration uint64 `json:"iteration"`
+	Running   bool   `json:"running"`
+	TPS       int    `json:"tps"`
+	Workers   int    `json:"workers"`
+	StartedAt string `json:"started_at,omitempty"`
 }
 
 // Options configure a stream run.
@@ -42,14 +42,14 @@ type Controller struct {
 	wallet ActionCreator
 	logger *slog.Logger
 
-	mu        sync.Mutex
-	running   bool
-	cancel    context.CancelFunc
-	done      chan struct{}
-	tps       int
-	workers   int
+	mu         sync.Mutex
+	running    bool
+	cancel     context.CancelFunc
+	done       chan struct{}
+	tps        int
+	workers    int
 	originator string
-	startedAt time.Time
+	startedAt  time.Time
 
 	attempted atomic.Uint64
 	succeeded atomic.Uint64
@@ -80,7 +80,7 @@ func NewController(wallet ActionCreator, defaults Options, logger *slog.Logger) 
 	}
 }
 
-// Start begins the event stream. Idempotent if already running with same process.
+// Start begins the event stream. Returns an error if a stream is already running.
 func (c *Controller) Start(parent context.Context, opts Options) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -106,12 +106,21 @@ func (c *Controller) Start(parent context.Context, opts Options) error {
 	c.running = true
 	c.startedAt = time.Now().UTC()
 
-	go c.run(ctx, c.done)
-	c.logger.Info("event stream started", "tps", c.tps, "workers", c.workers)
+	// Snapshot knobs for this run so concurrent Stats/Start readers cannot observe
+	// mid-run mutation (Start rejects when running, but we still avoid racing reads).
+	tps := c.tps
+	workers := c.workers
+	originator := c.originator
+	done := c.done
+
+	go c.run(ctx, done, tps, workers, originator)
+	c.logger.Info("event stream started", "tps", tps, "workers", workers)
 	return nil
 }
 
 // Stop requests stream shutdown and waits for workers to drain.
+// Concurrent Stop calls are safe; a Stop that loses a race with a subsequent Start
+// will not tear down the newer run.
 func (c *Controller) Stop() {
 	c.mu.Lock()
 	if !c.running {
@@ -130,9 +139,13 @@ func (c *Controller) Stop() {
 	}
 
 	c.mu.Lock()
-	c.running = false
-	c.cancel = nil
-	c.done = nil
+	// Only clear state if this Stop still owns the generation it cancelled.
+	// run() may already have cleared running; a newer Start may have replaced done.
+	if c.done == done {
+		c.running = false
+		c.cancel = nil
+		c.done = nil
+	}
 	c.mu.Unlock()
 	c.logger.Info("event stream stopped", "stats", c.Stats())
 }
@@ -174,29 +187,28 @@ func (c *Controller) SnapshotAndDelta(prevAttempted, prevSucceeded, prevFailed u
 	return s, s.Attempted - prevAttempted, s.Succeeded - prevSucceeded, s.Failed - prevFailed
 }
 
-func (c *Controller) run(ctx context.Context, done chan struct{}) {
+func (c *Controller) run(ctx context.Context, done chan struct{}, tps, workers int, originator string) {
 	defer close(done)
 
-	jobs := make(chan struct{}, c.workers)
+	jobs := make(chan struct{}, workers)
 	var wg sync.WaitGroup
-	for i := 0; i < c.workers; i++ {
+	for i := 0; i < workers; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			for range jobs {
-				c.runOne(ctx)
+				c.runOne(ctx, originator)
 			}
 		}()
 	}
 
-	limiter := rate.NewLimiter(rate.Limit(c.tps), 1)
+	limiter := rate.NewLimiter(rate.Limit(tps), 1)
 	for {
 		if err := limiter.Wait(ctx); err != nil {
 			break
 		}
 		select {
 		case <-ctx.Done():
-			// drain producer
 			goto drain
 		case jobs <- struct{}{}:
 		}
@@ -206,12 +218,15 @@ drain:
 	wg.Wait()
 
 	c.mu.Lock()
-	c.running = false
-	c.cancel = nil
+	// Mark stopped if this generation is still current. Stop() may also clear.
+	if c.done == done {
+		c.running = false
+		c.cancel = nil
+	}
 	c.mu.Unlock()
 }
 
-func (c *Controller) runOne(ctx context.Context) {
+func (c *Controller) runOne(ctx context.Context, originator string) {
 	iter := c.iteration.Add(1)
 	c.attempted.Add(1)
 
@@ -236,7 +251,7 @@ func (c *Controller) runOne(ctx context.Context) {
 		},
 	}
 
-	if _, err := c.wallet.CreateAction(ctx, args, c.originator); err != nil {
+	if _, err := c.wallet.CreateAction(ctx, args, originator); err != nil {
 		n := c.failed.Add(1)
 		if n <= 5 || n%100 == 0 {
 			c.logger.Warn("createAction failed", "error", err, "failed_count", n, "iteration", iter)

--- a/cmd/throughput_dashboard/internal/stream/controller_test.go
+++ b/cmd/throughput_dashboard/internal/stream/controller_test.go
@@ -3,10 +3,12 @@ package stream_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/go-sdk/script"
 	sdk "github.com/bsv-blockchain/go-sdk/wallet"
 	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/stream"
 	"github.com/stretchr/testify/require"
@@ -15,19 +17,50 @@ import (
 type fakeWallet struct {
 	calls atomic.Uint64
 	fail  bool
+
+	mu        sync.Mutex
+	args      []sdk.CreateActionArgs
+	origins   []string
+	seenHash  map[string]struct{}
+	delay     time.Duration
 }
 
-func (f *fakeWallet) CreateAction(ctx context.Context, _ sdk.CreateActionArgs, _ string) (*sdk.CreateActionResult, error) {
+func (f *fakeWallet) CreateAction(ctx context.Context, args sdk.CreateActionArgs, originator string) (*sdk.CreateActionResult, error) {
 	f.calls.Add(1)
+
+	f.mu.Lock()
+	f.args = append(f.args, args)
+	f.origins = append(f.origins, originator)
+	if f.seenHash == nil {
+		f.seenHash = make(map[string]struct{})
+	}
+	if len(args.Outputs) == 1 {
+		// Record locking script bytes for uniqueness checks.
+		f.seenHash[string(args.Outputs[0].LockingScript)] = struct{}{}
+	}
+	delay := f.delay
+	f.mu.Unlock()
+
 	if f.fail {
 		return nil, errors.New("boom")
+	}
+	if delay <= 0 {
+		delay = time.Millisecond
 	}
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
-	case <-time.After(time.Millisecond):
+	case <-time.After(delay):
 	}
 	return &sdk.CreateActionResult{}, nil
+}
+
+func (f *fakeWallet) snapshot() (args []sdk.CreateActionArgs, origins []string, uniqueScripts int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	args = append([]sdk.CreateActionArgs(nil), f.args...)
+	origins = append([]string(nil), f.origins...)
+	return args, origins, len(f.seenHash)
 }
 
 func TestControllerStartStop(t *testing.T) {
@@ -47,8 +80,10 @@ func TestControllerStartStop(t *testing.T) {
 	require.Positive(t, stats.Attempted)
 	require.Positive(t, stats.Succeeded)
 	// Stop cancels in-flight CreateAction; those count as failed, not crashes.
+	// Do not require Succeeded == Attempted after Stop.
 	require.Equal(t, stats.Attempted, stats.Succeeded+stats.Failed)
 	require.Equal(t, stats.Attempted, fake.calls.Load())
+	require.Equal(t, stats.Iteration, stats.Attempted)
 }
 
 func TestControllerCountsFailures(t *testing.T) {
@@ -67,6 +102,119 @@ func TestControllerCountsFailures(t *testing.T) {
 
 func TestControllerStopWhenNotRunningIsNoop(t *testing.T) {
 	ctrl := stream.NewController(&fakeWallet{}, stream.Options{TPS: 1, Workers: 1}, nil)
+	ctrl.Stop()
+	require.False(t, ctrl.Running())
+}
+
+func TestControllerCreateActionArgs(t *testing.T) {
+	fake := &fakeWallet{}
+	ctrl := stream.NewController(fake, stream.Options{TPS: 40, Workers: 2, Originator: "demo-origin"}, nil)
+
+	require.NoError(t, ctrl.Start(context.Background(), stream.Options{}))
+	time.Sleep(120 * time.Millisecond)
+	ctrl.Stop()
+
+	args, origins, uniqueScripts := fake.snapshot()
+	require.NotEmpty(t, args)
+
+	for i, a := range args {
+		require.Lenf(t, a.Outputs, 1, "call %d: single OP_RETURN output", i)
+		out := a.Outputs[0]
+		require.EqualValuesf(t, 0, out.Satoshis, "call %d: satoshis must be 0", i)
+		require.NotEmptyf(t, out.LockingScript, "call %d: locking script", i)
+
+		asm := script.NewFromBytes(out.LockingScript).ToASM()
+		require.Containsf(t, asm, "OP_RETURN", "call %d", i)
+
+		require.NotNilf(t, a.Options, "call %d: options required", i)
+		require.NotNilf(t, a.Options.AcceptDelayedBroadcast, "call %d", i)
+		require.Truef(t, *a.Options.AcceptDelayedBroadcast, "call %d: AcceptDelayedBroadcast", i)
+
+		require.Equalf(t, "demo-origin", origins[i], "call %d: originator", i)
+	}
+
+	// Each action should get a distinct locking script (unique hash/iteration).
+	require.Equal(t, len(args), uniqueScripts)
+	require.Equal(t, uint64(len(args)), ctrl.Stats().Iteration)
+}
+
+func TestControllerRestartAfterStop(t *testing.T) {
+	fake := &fakeWallet{}
+	ctrl := stream.NewController(fake, stream.Options{TPS: 60, Workers: 2, Originator: "test"}, nil)
+
+	require.NoError(t, ctrl.Start(context.Background(), stream.Options{}))
+	time.Sleep(80 * time.Millisecond)
+	ctrl.Stop()
+	require.False(t, ctrl.Running())
+	first := ctrl.Stats().Attempted
+	require.Positive(t, first)
+
+	require.NoError(t, ctrl.Start(context.Background(), stream.Options{TPS: 40, Workers: 3}))
+	require.True(t, ctrl.Running())
+	time.Sleep(80 * time.Millisecond)
+	ctrl.Stop()
+	require.False(t, ctrl.Running())
+
+	stats := ctrl.Stats()
+	require.Greater(t, stats.Attempted, first)
+	require.Equal(t, stats.Attempted, stats.Succeeded+stats.Failed)
+	require.Equal(t, 40, stats.TPS)
+	require.Equal(t, 3, stats.Workers)
+}
+
+func TestControllerStartOverridesOptions(t *testing.T) {
+	ctrl := stream.NewController(&fakeWallet{}, stream.Options{TPS: 10, Workers: 8, Originator: "default"}, nil)
+	require.NoError(t, ctrl.Start(context.Background(), stream.Options{TPS: 25, Workers: 5, Originator: "override"}))
+	stats := ctrl.Stats()
+	require.Equal(t, 25, stats.TPS)
+	require.Equal(t, 5, stats.Workers)
+	require.True(t, stats.Running)
+	ctrl.Stop()
+}
+
+func TestControllerDefaults(t *testing.T) {
+	ctrl := stream.NewController(&fakeWallet{}, stream.Options{}, nil)
+	stats := ctrl.Stats()
+	require.Equal(t, 10, stats.TPS)
+	require.Equal(t, 8, stats.Workers)
+	require.False(t, stats.Running)
+}
+
+func TestControllerSnapshotAndDelta(t *testing.T) {
+	fake := &fakeWallet{}
+	ctrl := stream.NewController(fake, stream.Options{TPS: 50, Workers: 2, Originator: "test"}, nil)
+
+	require.NoError(t, ctrl.Start(context.Background(), stream.Options{}))
+	time.Sleep(100 * time.Millisecond)
+	ctrl.Stop()
+
+	s, dA, dS, dF := ctrl.SnapshotAndDelta(0, 0, 0)
+	require.Equal(t, s.Attempted, dA)
+	require.Equal(t, s.Succeeded, dS)
+	require.Equal(t, s.Failed, dF)
+
+	s2, dA2, dS2, dF2 := ctrl.SnapshotAndDelta(s.Attempted, s.Succeeded, s.Failed)
+	require.Equal(t, s.Attempted, s2.Attempted)
+	require.Zero(t, dA2)
+	require.Zero(t, dS2)
+	require.Zero(t, dF2)
+}
+
+func TestControllerParentCancelStopsStream(t *testing.T) {
+	fake := &fakeWallet{}
+	ctrl := stream.NewController(fake, stream.Options{TPS: 50, Workers: 2, Originator: "test"}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, ctrl.Start(ctx, stream.Options{}))
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	// Wait until run marks itself not running.
+	require.Eventually(t, func() bool { return !ctrl.Running() }, time.Second, 10*time.Millisecond)
+
+	stats := ctrl.Stats()
+	require.Equal(t, stats.Attempted, stats.Succeeded+stats.Failed)
+	// Stop after parent cancel is still a safe no-op / drain.
 	ctrl.Stop()
 	require.False(t, ctrl.Running())
 }

--- a/cmd/throughput_dashboard/internal/stream/controller_test.go
+++ b/cmd/throughput_dashboard/internal/stream/controller_test.go
@@ -180,6 +180,22 @@ func TestControllerDefaults(t *testing.T) {
 	require.False(t, stats.Running)
 }
 
+func TestControllerRejectsExcessiveWorkers(t *testing.T) {
+	ctrl := stream.NewController(&fakeWallet{}, stream.Options{TPS: 10, Workers: 8}, nil)
+	err := ctrl.Start(context.Background(), stream.Options{Workers: stream.MaxWorkers + 1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds max")
+	require.False(t, ctrl.Running())
+}
+
+func TestControllerRejectsExcessiveTPS(t *testing.T) {
+	ctrl := stream.NewController(&fakeWallet{}, stream.Options{TPS: 10, Workers: 8}, nil)
+	err := ctrl.Start(context.Background(), stream.Options{TPS: stream.MaxTPS + 1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds max")
+	require.False(t, ctrl.Running())
+}
+
 func TestControllerSnapshotAndDelta(t *testing.T) {
 	fake := &fakeWallet{}
 	ctrl := stream.NewController(fake, stream.Options{TPS: 50, Workers: 2, Originator: "test"}, nil)

--- a/cmd/throughput_dashboard/internal/stream/controller_test.go
+++ b/cmd/throughput_dashboard/internal/stream/controller_test.go
@@ -1,0 +1,72 @@
+package stream_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	sdk "github.com/bsv-blockchain/go-sdk/wallet"
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/stream"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeWallet struct {
+	calls atomic.Uint64
+	fail  bool
+}
+
+func (f *fakeWallet) CreateAction(ctx context.Context, _ sdk.CreateActionArgs, _ string) (*sdk.CreateActionResult, error) {
+	f.calls.Add(1)
+	if f.fail {
+		return nil, errors.New("boom")
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(time.Millisecond):
+	}
+	return &sdk.CreateActionResult{}, nil
+}
+
+func TestControllerStartStop(t *testing.T) {
+	fake := &fakeWallet{}
+	ctrl := stream.NewController(fake, stream.Options{TPS: 50, Workers: 4, Originator: "test"}, nil)
+
+	ctx := context.Background()
+	require.NoError(t, ctrl.Start(ctx, stream.Options{}))
+	require.True(t, ctrl.Running())
+	require.Error(t, ctrl.Start(ctx, stream.Options{}), "second start should fail")
+
+	time.Sleep(200 * time.Millisecond)
+	ctrl.Stop()
+	require.False(t, ctrl.Running())
+
+	stats := ctrl.Stats()
+	require.Positive(t, stats.Attempted)
+	require.Positive(t, stats.Succeeded)
+	// Stop cancels in-flight CreateAction; those count as failed, not crashes.
+	require.Equal(t, stats.Attempted, stats.Succeeded+stats.Failed)
+	require.Equal(t, stats.Attempted, fake.calls.Load())
+}
+
+func TestControllerCountsFailures(t *testing.T) {
+	fake := &fakeWallet{fail: true}
+	ctrl := stream.NewController(fake, stream.Options{TPS: 80, Workers: 4, Originator: "test"}, nil)
+
+	require.NoError(t, ctrl.Start(context.Background(), stream.Options{}))
+	time.Sleep(150 * time.Millisecond)
+	ctrl.Stop()
+
+	stats := ctrl.Stats()
+	require.Positive(t, stats.Attempted)
+	require.Equal(t, stats.Attempted, stats.Failed)
+	require.Equal(t, uint64(0), stats.Succeeded)
+}
+
+func TestControllerStopWhenNotRunningIsNoop(t *testing.T) {
+	ctrl := stream.NewController(&fakeWallet{}, stream.Options{TPS: 1, Workers: 1}, nil)
+	ctrl.Stop()
+	require.False(t, ctrl.Running())
+}

--- a/cmd/throughput_dashboard/internal/stream/controller_test.go
+++ b/cmd/throughput_dashboard/internal/stream/controller_test.go
@@ -18,11 +18,11 @@ type fakeWallet struct {
 	calls atomic.Uint64
 	fail  bool
 
-	mu        sync.Mutex
-	args      []sdk.CreateActionArgs
-	origins   []string
-	seenHash  map[string]struct{}
-	delay     time.Duration
+	mu       sync.Mutex
+	args     []sdk.CreateActionArgs
+	origins  []string
+	seenHash map[string]struct{}
+	delay    time.Duration
 }
 
 func (f *fakeWallet) CreateAction(ctx context.Context, args sdk.CreateActionArgs, originator string) (*sdk.CreateActionResult, error) {

--- a/cmd/throughput_dashboard/internal/stream/controller_test.go
+++ b/cmd/throughput_dashboard/internal/stream/controller_test.go
@@ -79,11 +79,34 @@ func TestControllerStartStop(t *testing.T) {
 	stats := ctrl.Stats()
 	require.Positive(t, stats.Attempted)
 	require.Positive(t, stats.Succeeded)
-	// Stop cancels in-flight CreateAction; those count as failed, not crashes.
-	// Do not require Succeeded == Attempted after Stop.
-	require.Equal(t, stats.Attempted, stats.Succeeded+stats.Failed)
+	// Stop does not cancel in-flight createActions; all started calls finish successfully.
+	require.Equal(t, stats.Attempted, stats.Succeeded)
+	require.Zero(t, stats.Failed)
 	require.Equal(t, stats.Attempted, fake.calls.Load())
 	require.Equal(t, stats.Iteration, stats.Attempted)
+}
+
+func TestControllerStopDoesNotCancelInFlightCreateAction(t *testing.T) {
+	// Slow createAction so Stop races with in-flight work.
+	started := make(chan struct{})
+	slow := &signalingWallet{delay: 300 * time.Millisecond, started: started}
+	ctrl := stream.NewController(slow, stream.Options{TPS: 100, Workers: 1, Originator: "test"}, nil)
+
+	require.NoError(t, ctrl.Start(context.Background(), stream.Options{}))
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for createAction to start")
+	}
+	// Stop while at least one createAction is mid-flight; none may be aborted.
+	ctrl.Stop()
+	require.False(t, ctrl.Running())
+
+	stats := ctrl.Stats()
+	require.Positive(t, stats.Attempted)
+	require.Equal(t, stats.Attempted, stats.Succeeded)
+	require.Zero(t, stats.Failed)
+	require.Equal(t, stats.Attempted, slow.calls.Load())
 }
 
 func TestControllerCountsFailures(t *testing.T) {
@@ -225,12 +248,41 @@ func TestControllerParentCancelStopsStream(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	cancel()
 
-	// Wait until run marks itself not running.
-	require.Eventually(t, func() bool { return !ctrl.Running() }, time.Second, 10*time.Millisecond)
+	// Parent cancel stops production; in-flight createActions still finish.
+	// Wait until run drains and marks itself not running.
+	require.Eventually(t, func() bool { return !ctrl.Running() }, 2*time.Second, 10*time.Millisecond)
 
 	stats := ctrl.Stats()
-	require.Equal(t, stats.Attempted, stats.Succeeded+stats.Failed)
+	require.Equal(t, stats.Attempted, stats.Succeeded)
+	require.Zero(t, stats.Failed)
 	// Stop after parent cancel is still a safe no-op / drain.
 	ctrl.Stop()
 	require.False(t, ctrl.Running())
+}
+
+// signalingWallet is like fakeWallet but signals when CreateAction starts.
+type signalingWallet struct {
+	calls   atomic.Uint64
+	delay   time.Duration
+	started chan struct{}
+	once    sync.Once
+}
+
+func (f *signalingWallet) CreateAction(ctx context.Context, _ sdk.CreateActionArgs, _ string) (*sdk.CreateActionResult, error) {
+	f.calls.Add(1)
+	f.once.Do(func() {
+		if f.started != nil {
+			close(f.started)
+		}
+	})
+	delay := f.delay
+	if delay <= 0 {
+		delay = time.Millisecond
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(delay):
+	}
+	return &sdk.CreateActionResult{}, nil
 }

--- a/cmd/throughput_dashboard/internal/stream/opreturn.go
+++ b/cmd/throughput_dashboard/internal/stream/opreturn.go
@@ -1,0 +1,36 @@
+// Package stream implements the controllable createAction event stream.
+package stream
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/bsv-blockchain/go-sdk/transaction"
+)
+
+// HashPayload returns sha256(iteration string concatenated with RFC3339Nano timestamp).
+func HashPayload(iteration uint64, ts time.Time) []byte {
+	// Concatenate as decimal iteration + timestamp string (no separator required by the demo).
+	msg := strconv.FormatUint(iteration, 10) + ts.UTC().Format(time.RFC3339Nano)
+	sum := sha256.Sum256([]byte(msg))
+	return sum[:]
+}
+
+// OpReturnLockingScriptForHash builds an OP_RETURN locking script that pushes the 32-byte hash.
+func OpReturnLockingScriptForHash(hash []byte) ([]byte, error) {
+	if len(hash) == 0 {
+		return nil, fmt.Errorf("opreturn hash must be non-empty")
+	}
+	out, err := transaction.CreateOpReturnOutput([][]byte{hash})
+	if err != nil {
+		return nil, fmt.Errorf("create opreturn output: %w", err)
+	}
+	return out.LockingScript.Bytes(), nil
+}
+
+// OpReturnLockingScriptForIteration builds the OP_RETURN locking script for one stream iteration.
+func OpReturnLockingScriptForIteration(iteration uint64, ts time.Time) ([]byte, error) {
+	return OpReturnLockingScriptForHash(HashPayload(iteration, ts))
+}

--- a/cmd/throughput_dashboard/internal/stream/opreturn.go
+++ b/cmd/throughput_dashboard/internal/stream/opreturn.go
@@ -11,6 +11,7 @@ import (
 )
 
 // HashPayload returns sha256(iteration string concatenated with RFC3339Nano timestamp).
+// The timestamp is always formatted in UTC. Result is always 32 bytes.
 func HashPayload(iteration uint64, ts time.Time) []byte {
 	// Concatenate as decimal iteration + timestamp string (no separator required by the demo).
 	msg := strconv.FormatUint(iteration, 10) + ts.UTC().Format(time.RFC3339Nano)
@@ -22,6 +23,9 @@ func HashPayload(iteration uint64, ts time.Time) []byte {
 func OpReturnLockingScriptForHash(hash []byte) ([]byte, error) {
 	if len(hash) == 0 {
 		return nil, fmt.Errorf("opreturn hash must be non-empty")
+	}
+	if len(hash) != sha256.Size {
+		return nil, fmt.Errorf("opreturn hash must be %d bytes, got %d", sha256.Size, len(hash))
 	}
 	out, err := transaction.CreateOpReturnOutput([][]byte{hash})
 	if err != nil {

--- a/cmd/throughput_dashboard/internal/stream/opreturn_test.go
+++ b/cmd/throughput_dashboard/internal/stream/opreturn_test.go
@@ -3,6 +3,7 @@ package stream_test
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"strconv"
 	"testing"
 	"time"
 
@@ -15,10 +16,30 @@ func TestHashPayloadIsSHA256OfIterationConcatTimestamp(t *testing.T) {
 	ts := time.Date(2026, 7, 21, 12, 0, 0, 123456789, time.UTC)
 	got := stream.HashPayload(42, ts)
 
-	msg := "42" + ts.Format(time.RFC3339Nano)
+	msg := strconv.FormatUint(42, 10) + ts.UTC().Format(time.RFC3339Nano)
 	want := sha256.Sum256([]byte(msg))
 	require.Equal(t, want[:], got)
-	require.Len(t, got, 32)
+	require.Len(t, got, sha256.Size)
+}
+
+func TestHashPayloadIsDeterministic(t *testing.T) {
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 6, time.UTC)
+	a := stream.HashPayload(99, ts)
+	b := stream.HashPayload(99, ts)
+	require.Equal(t, a, b)
+}
+
+func TestHashPayloadUsesUTC(t *testing.T) {
+	// Same instant in different zones must hash identically (UTC format).
+	utc := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	offset := time.FixedZone("UTC-5", -5*60*60)
+	local := utc.In(offset)
+	require.Equal(t, stream.HashPayload(1, utc), stream.HashPayload(1, local))
+
+	// Explicit expected message uses UTC layout.
+	msg := "1" + utc.Format(time.RFC3339Nano)
+	want := sha256.Sum256([]byte(msg))
+	require.Equal(t, want[:], stream.HashPayload(1, local))
 }
 
 func TestHashPayloadChangesWithIterationAndTime(t *testing.T) {
@@ -44,4 +65,26 @@ func TestOpReturnLockingScriptForHashContainsHash(t *testing.T) {
 func TestOpReturnLockingScriptForHashRejectsEmpty(t *testing.T) {
 	_, err := stream.OpReturnLockingScriptForHash(nil)
 	require.Error(t, err)
+
+	_, err = stream.OpReturnLockingScriptForHash([]byte{})
+	require.Error(t, err)
+}
+
+func TestOpReturnLockingScriptForHashRejectsWrongLength(t *testing.T) {
+	_, err := stream.OpReturnLockingScriptForHash([]byte("too-short"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "32")
+
+	_, err = stream.OpReturnLockingScriptForHash(make([]byte, 64))
+	require.Error(t, err)
+}
+
+func TestOpReturnLockingScriptForIteration(t *testing.T) {
+	ts := time.Date(2026, 7, 21, 15, 30, 0, 1, time.UTC)
+	locking, err := stream.OpReturnLockingScriptForIteration(123, ts)
+	require.NoError(t, err)
+
+	hash := stream.HashPayload(123, ts)
+	require.Contains(t, string(locking), string(hash))
+	require.Contains(t, script.NewFromBytes(locking).ToASM(), "OP_RETURN")
 }

--- a/cmd/throughput_dashboard/internal/stream/opreturn_test.go
+++ b/cmd/throughput_dashboard/internal/stream/opreturn_test.go
@@ -1,0 +1,47 @@
+package stream_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-sdk/script"
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/stream"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashPayloadIsSHA256OfIterationConcatTimestamp(t *testing.T) {
+	ts := time.Date(2026, 7, 21, 12, 0, 0, 123456789, time.UTC)
+	got := stream.HashPayload(42, ts)
+
+	msg := "42" + ts.Format(time.RFC3339Nano)
+	want := sha256.Sum256([]byte(msg))
+	require.Equal(t, want[:], got)
+	require.Len(t, got, 32)
+}
+
+func TestHashPayloadChangesWithIterationAndTime(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	a := stream.HashPayload(1, ts)
+	b := stream.HashPayload(2, ts)
+	c := stream.HashPayload(1, ts.Add(time.Second))
+	require.NotEqual(t, hex.EncodeToString(a), hex.EncodeToString(b))
+	require.NotEqual(t, hex.EncodeToString(a), hex.EncodeToString(c))
+}
+
+func TestOpReturnLockingScriptForHashContainsHash(t *testing.T) {
+	hash := stream.HashPayload(7, time.Unix(0, 0).UTC())
+	locking, err := stream.OpReturnLockingScriptForHash(hash)
+	require.NoError(t, err)
+	require.NotEmpty(t, locking)
+
+	asm := script.NewFromBytes(locking).ToASM()
+	require.Contains(t, asm, "OP_RETURN")
+	require.Contains(t, string(locking), string(hash))
+}
+
+func TestOpReturnLockingScriptForHashRejectsEmpty(t *testing.T) {
+	_, err := stream.OpReturnLockingScriptForHash(nil)
+	require.Error(t, err)
+}

--- a/cmd/throughput_dashboard/internal/syncwallet/serial.go
+++ b/cmd/throughput_dashboard/internal/syncwallet/serial.go
@@ -1,0 +1,76 @@
+// Package syncwallet serializes wallet RPC through a single mutex.
+//
+// The storage HTTP client uses BRC-104 AuthFetch, which is not safe for concurrent
+// session handshakes on one peer. FuelKeeper + metrics sampler both call ListOutputs
+// at startup and can deadlock for minutes, leaving the dashboard UI at empty ticks
+// even when funds are already internalized.
+package syncwallet
+
+import (
+	"context"
+	"sync"
+
+	sdk "github.com/bsv-blockchain/go-sdk/wallet"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+)
+
+// Wallet is the operator surface used by the dashboard (stream, sampler, keeper, funding).
+type Wallet interface {
+	Balance(ctx context.Context) (uint64, error)
+	ListOutputs(ctx context.Context, args sdk.ListOutputsArgs, originator string) (*sdk.ListOutputsResult, error)
+	CreateAction(ctx context.Context, args sdk.CreateActionArgs, originator string) (*sdk.CreateActionResult, error)
+	FanOutFuel(ctx context.Context, shape wdk.ShapedChange, originator string) (*sdk.CreateActionResult, error)
+	InternalizeAction(ctx context.Context, args sdk.InternalizeActionArgs, originator string) (*sdk.InternalizeActionResult, error)
+	Close()
+}
+
+// Serial wraps Wallet with a mutex so only one storage RPC runs at a time.
+type Serial struct {
+	mu sync.Mutex
+	w  Wallet
+}
+
+// New returns a serializing wrapper around w.
+func New(w Wallet) *Serial {
+	return &Serial{w: w}
+}
+
+// Unwrap returns the underlying wallet (for Close).
+func (s *Serial) Unwrap() Wallet { return s.w }
+
+func (s *Serial) Balance(ctx context.Context) (uint64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.Balance(ctx)
+}
+
+func (s *Serial) ListOutputs(ctx context.Context, args sdk.ListOutputsArgs, originator string) (*sdk.ListOutputsResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.ListOutputs(ctx, args, originator)
+}
+
+func (s *Serial) CreateAction(ctx context.Context, args sdk.CreateActionArgs, originator string) (*sdk.CreateActionResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.CreateAction(ctx, args, originator)
+}
+
+func (s *Serial) FanOutFuel(ctx context.Context, shape wdk.ShapedChange, originator string) (*sdk.CreateActionResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.FanOutFuel(ctx, shape, originator)
+}
+
+func (s *Serial) InternalizeAction(ctx context.Context, args sdk.InternalizeActionArgs, originator string) (*sdk.InternalizeActionResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.InternalizeAction(ctx, args, originator)
+}
+
+func (s *Serial) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.w.Close()
+}

--- a/cmd/throughput_dashboard/main.go
+++ b/cmd/throughput_dashboard/main.go
@@ -98,24 +98,29 @@ func run(logger *slog.Logger) error {
 		Originator: cfg.Originator,
 	}, logger)
 
-	sampler := metrics.NewSampler(
-		wallet,
-		ctrl,
-		cfg.Originator,
-		time.Duration(cfg.SampleSeconds)*time.Second,
-		throughput.TargetTPS,
-		denom,
-		targetPool,
-		throughput.LowWaterPercent,
-		throughput.HighWaterPercent,
-		logger,
-	)
+	sampler := metrics.NewSampler(wallet, ctrl, metrics.Config{
+		Originator:       cfg.Originator,
+		Interval:         time.Duration(cfg.SampleSeconds) * time.Second,
+		TargetTPS:        throughput.TargetTPS,
+		Denomination:     denom,
+		TargetPool:       targetPool,
+		LowWaterPercent:  throughput.LowWaterPercent,
+		HighWaterPercent: throughput.HighWaterPercent,
+		Logger:           logger,
+	})
 	go sampler.Run(ctx)
 
 	webFS, err := fs.Sub(webRoot, "web")
 	if err != nil {
 		return fmt.Errorf("embed web fs: %w", err)
 	}
+
+	// Done closes when the process context is canceled (no context stored on Server).
+	done := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		close(done)
+	}()
 
 	srv := api.New(api.Deps{
 		Ctrl:       ctrl,
@@ -127,7 +132,7 @@ func run(logger *slog.Logger) error {
 		ServerURL:  cfg.ServerURL,
 		Logger:     logger,
 		WebFS:      webFS,
-		ParentCtx:  ctx,
+		Done:       done,
 	})
 
 	httpServer := &http.Server{

--- a/cmd/throughput_dashboard/main.go
+++ b/cmd/throughput_dashboard/main.go
@@ -57,7 +57,8 @@ func run(logger *slog.Logger) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	logger.Info("connecting to storage",
+	logger.Info(
+		"connecting to storage",
 		"server_url", cfg.ServerURL,
 		"network", network,
 		"http_addr", cfg.HTTPAddr,
@@ -78,7 +79,8 @@ func run(logger *slog.Logger) error {
 		return fmt.Errorf("resolve denomination: %w", err)
 	}
 	targetPool := throughput.TargetPool()
-	logger.Info("throughput profile",
+	logger.Info(
+		"throughput profile",
 		"denomination_satoshis", denom,
 		"target_tps", throughput.TargetTPS,
 		"target_pool", targetPool,

--- a/cmd/throughput_dashboard/main.go
+++ b/cmd/throughput_dashboard/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/connect"
 	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/metrics"
 	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/stream"
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/syncwallet"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/fuelkeeper"
 )
@@ -66,7 +67,10 @@ func run(logger *slog.Logger) error {
 	if err != nil {
 		return fmt.Errorf("create wallet: %w", err)
 	}
-	defer operatorWallet.Close()
+	// Serialize all storage RPCs: concurrent AuthFetch handshakes deadlock and
+	// leave FuelKeeper + sampler stuck so the UI never shows internalized funds.
+	wallet := syncwallet.New(operatorWallet)
+	defer wallet.Close()
 
 	throughput := config.DemoThroughput()
 	denom, err := throughput.Denomination(defs.DefaultFeeModel(), defs.DefaultCommission())
@@ -82,20 +86,20 @@ func run(logger *slog.Logger) error {
 		"high_water_percent", throughput.HighWaterPercent,
 	)
 
-	keeper, err := fuelkeeper.New(operatorWallet, fuelkeeper.FromThroughput(throughput, denom), logger)
+	keeper, err := fuelkeeper.New(wallet, fuelkeeper.FromThroughput(throughput, denom), logger)
 	if err != nil {
 		return fmt.Errorf("create fuel keeper: %w", err)
 	}
 	go keeper.Run(ctx)
 
-	ctrl := stream.NewController(operatorWallet, stream.Options{
+	ctrl := stream.NewController(wallet, stream.Options{
 		TPS:        cfg.TPS,
 		Workers:    cfg.Workers,
 		Originator: cfg.Originator,
 	}, logger)
 
 	sampler := metrics.NewSampler(
-		operatorWallet,
+		wallet,
 		ctrl,
 		cfg.Originator,
 		time.Duration(cfg.SampleSeconds)*time.Second,
@@ -116,7 +120,7 @@ func run(logger *slog.Logger) error {
 	srv := api.New(api.Deps{
 		Ctrl:       ctrl,
 		Sampler:    sampler,
-		Wallet:     operatorWallet,
+		Wallet:     wallet,
 		Priv:       priv,
 		Network:    network,
 		Originator: cfg.Originator,

--- a/cmd/throughput_dashboard/main.go
+++ b/cmd/throughput_dashboard/main.go
@@ -1,0 +1,158 @@
+// Command throughput_dashboard runs a mainnet-oriented demo control plane for
+// wallet-infra throughput mode: FuelKeeper, start/stop OP_RETURN createAction
+// stream, and a localhost web UI (TPS, fuel balances, top-ups, WalletClient funding).
+package main
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	ec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/api"
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/config"
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/connect"
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/metrics"
+	"github.com/bsv-blockchain/go-wallet-toolbox/cmd/throughput_dashboard/internal/stream"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/fuelkeeper"
+)
+
+//go:embed web/*
+var webRoot embed.FS
+
+func main() {
+	logger := slog.Default()
+	if err := run(logger); err != nil {
+		logger.Error("throughput dashboard failed", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run(logger *slog.Logger) error {
+	cfg, err := config.ConfigFromEnv()
+	if err != nil {
+		return fmt.Errorf("config: %w", err)
+	}
+
+	priv, err := ec.PrivateKeyFromHex(cfg.PrivateKeyHex)
+	if err != nil {
+		return fmt.Errorf("parse PRIVATE_KEY: %w", err)
+	}
+
+	network, err := defs.ParseBSVNetworkStr(cfg.Network)
+	if err != nil {
+		return fmt.Errorf("parse BSV_NETWORK: %w", err)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	logger.Info("connecting to storage",
+		"server_url", cfg.ServerURL,
+		"network", network,
+		"http_addr", cfg.HTTPAddr,
+	)
+
+	operatorWallet, err := connect.Wallet(ctx, network, priv, cfg.ServerURL, logger)
+	if err != nil {
+		return fmt.Errorf("create wallet: %w", err)
+	}
+	defer operatorWallet.Close()
+
+	throughput := config.DemoThroughput()
+	denom, err := throughput.Denomination(defs.DefaultFeeModel(), defs.DefaultCommission())
+	if err != nil {
+		return fmt.Errorf("resolve denomination: %w", err)
+	}
+	targetPool := throughput.TargetPool()
+	logger.Info("throughput profile",
+		"denomination_satoshis", denom,
+		"target_tps", throughput.TargetTPS,
+		"target_pool", targetPool,
+		"low_water_percent", throughput.LowWaterPercent,
+		"high_water_percent", throughput.HighWaterPercent,
+	)
+
+	keeper, err := fuelkeeper.New(operatorWallet, fuelkeeper.FromThroughput(throughput, denom), logger)
+	if err != nil {
+		return fmt.Errorf("create fuel keeper: %w", err)
+	}
+	go keeper.Run(ctx)
+
+	ctrl := stream.NewController(operatorWallet, stream.Options{
+		TPS:        cfg.TPS,
+		Workers:    cfg.Workers,
+		Originator: cfg.Originator,
+	}, logger)
+
+	sampler := metrics.NewSampler(
+		operatorWallet,
+		ctrl,
+		cfg.Originator,
+		time.Duration(cfg.SampleSeconds)*time.Second,
+		throughput.TargetTPS,
+		denom,
+		targetPool,
+		throughput.LowWaterPercent,
+		throughput.HighWaterPercent,
+		logger,
+	)
+	go sampler.Run(ctx)
+
+	webFS, err := fs.Sub(webRoot, "web")
+	if err != nil {
+		return fmt.Errorf("embed web fs: %w", err)
+	}
+
+	srv := api.New(api.Deps{
+		Ctrl:       ctrl,
+		Sampler:    sampler,
+		Wallet:     operatorWallet,
+		Priv:       priv,
+		Network:    network,
+		Originator: cfg.Originator,
+		ServerURL:  cfg.ServerURL,
+		Logger:     logger,
+		WebFS:      webFS,
+		ParentCtx:  ctx,
+	})
+
+	httpServer := &http.Server{
+		Addr:              cfg.HTTPAddr,
+		Handler:           srv.Handler(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		logger.Info("dashboard listening", "addr", cfg.HTTPAddr, "network", network)
+		if listenErr := httpServer.ListenAndServe(); listenErr != nil && listenErr != http.ErrServerClosed {
+			errCh <- listenErr
+		}
+		close(errCh)
+	}()
+
+	select {
+	case <-ctx.Done():
+		logger.Info("shutdown requested")
+	case listenErr := <-errCh:
+		if listenErr != nil {
+			return listenErr
+		}
+	}
+
+	ctrl.Stop()
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_ = httpServer.Shutdown(shutdownCtx)
+	return nil
+}

--- a/cmd/throughput_dashboard/web/app.js
+++ b/cmd/throughput_dashboard/web/app.js
@@ -488,24 +488,39 @@ function extractAtomicHex(result) {
 }
 
 function extractOutputIndex(result, lockingScriptHex) {
-  // Prefer explicit single-output payment (vout 0) unless wallet reports outputs.
-  const outs =
-    result?.outputs ||
-    result?.Outputs ||
-    result?.tx?.outputs ||
-    null;
-  if (Array.isArray(outs) && lockingScriptHex) {
-    const want = normalizeHex(lockingScriptHex);
+  // Prefer the vout that matches the deposit locking script. Local wallets
+  // usually put *change* at vout 0 and the payment later — defaulting to 0 is
+  // wrong. The server also auto-scans if this is still 0 / wrong.
+  const want = normalizeHex(lockingScriptHex || "");
+  const lists = [
+    result?.outputs,
+    result?.Outputs,
+    result?.tx?.outputs,
+    result?.tx?.Outputs,
+    result?.rawTx?.outputs,
+  ].filter((x) => Array.isArray(x));
+
+  for (const outs of lists) {
     for (let i = 0; i < outs.length; i++) {
       const ls =
         outs[i]?.lockingScript ||
         outs[i]?.locking_script ||
         outs[i]?.script ||
+        outs[i]?.lockingScriptHex ||
         "";
       const hex = coerceToHex(ls);
-      if (hex && want && hex === want) return i;
+      if (hex && want && normalizeHex(hex) === want) return i;
+      // Some wallets report a basket/payment target address string.
+      if (
+        fundingInfo?.address &&
+        (outs[i]?.address === fundingInfo.address ||
+          outs[i]?.to === fundingInfo.address)
+      ) {
+        return i;
+      }
     }
   }
+  // Leave 0 as a hint only — server resolvePaymentOutputIndex will scan.
   return 0;
 }
 

--- a/cmd/throughput_dashboard/web/app.js
+++ b/cmd/throughput_dashboard/web/app.js
@@ -1,11 +1,20 @@
 // Throughput demo dashboard — control plane client + WalletClient funding.
 
 const MAX_POINTS = 60;
+const MAX_TOPUPS = 50;
+const POLL_MS = 5000;
+const SDK_URLS = [
+  "https://esm.sh/@bsv/sdk@1.4.20",
+  "https://esm.sh/@bsv/sdk",
+];
 
 const els = {
   networkBadge: document.getElementById("network-badge"),
   mainnetBanner: document.getElementById("mainnet-banner"),
+  connStatus: document.getElementById("conn-status"),
+  connLabel: document.getElementById("conn-label"),
   streamState: document.getElementById("stream-state"),
+  streamStatus: document.getElementById("stream-status"),
   succeeded: document.getElementById("stat-succeeded"),
   failed: document.getElementById("stat-failed"),
   iteration: document.getElementById("stat-iteration"),
@@ -21,56 +30,142 @@ const els = {
   metaWater: document.getElementById("meta-water"),
   metaServer: document.getElementById("meta-server"),
   topupLog: document.getElementById("topup-log"),
+  topupEmpty: document.getElementById("topup-empty"),
   fundAddress: document.getElementById("fund-address"),
   fundAmount: document.getElementById("fund-amount"),
   btnFund: document.getElementById("btn-fund"),
   btnRefreshFunding: document.getElementById("btn-refresh-funding"),
+  btnCopyAddress: document.getElementById("btn-copy-address"),
   fundStatus: document.getElementById("fund-status"),
+  manualTxid: document.getElementById("manual-txid"),
+  manualHex: document.getElementById("manual-hex"),
+  manualVout: document.getElementById("manual-vout"),
+  btnManualInternalize: document.getElementById("btn-manual-internalize"),
+  tpsChartFallback: document.getElementById("tps-chart-fallback"),
+  fuelChartFallback: document.getElementById("fuel-chart-fallback"),
 };
 
 let fundingInfo = null;
+let lastTickKey = "";
+let chartsEnabled = typeof window.Chart === "function";
+const seenTopups = new Set();
+let streamBusy = false;
 
-const tpsChart = new Chart(document.getElementById("tps-chart"), {
-  type: "line",
-  data: {
-    labels: [],
-    datasets: [
-      { label: "succeeded/s", data: [], borderColor: "#3dd6c6", tension: 0.25, pointRadius: 0 },
-      { label: "failed/s", data: [], borderColor: "#ff5c7a", tension: 0.25, pointRadius: 0 },
-    ],
-  },
-  options: {
-    responsive: true,
-    animation: false,
-    scales: {
-      x: { ticks: { color: "#93a0bf", maxTicksLimit: 8 }, grid: { color: "rgba(36,48,80,0.6)" } },
-      y: { beginAtZero: true, ticks: { color: "#93a0bf" }, grid: { color: "rgba(36,48,80,0.6)" } },
-    },
-    plugins: { legend: { labels: { color: "#c9d6f5" } } },
-  },
-});
+// ---------------------------------------------------------------------------
+// Charts (optional — page remains usable if Chart.js CDN is blocked)
+// ---------------------------------------------------------------------------
 
-const fuelChart = new Chart(document.getElementById("fuel-chart"), {
-  type: "line",
-  data: {
-    labels: [],
-    datasets: [
-      { label: "fuel UTXOs", data: [], borderColor: "#ffb020", tension: 0.25, pointRadius: 0 },
-      { label: "reserve UTXOs", data: [], borderColor: "#8b9cff", tension: 0.25, pointRadius: 0 },
-    ],
-  },
-  options: {
-    responsive: true,
-    animation: false,
-    scales: {
-      x: { ticks: { color: "#93a0bf", maxTicksLimit: 8 }, grid: { color: "rgba(36,48,80,0.6)" } },
-      y: { beginAtZero: true, ticks: { color: "#93a0bf" }, grid: { color: "rgba(36,48,80,0.6)" } },
+const chartDefaults = {
+  responsive: true,
+  maintainAspectRatio: true,
+  animation: false,
+  interaction: { mode: "index", intersect: false },
+  scales: {
+    x: {
+      ticks: { color: "#93a0bf", maxTicksLimit: 8 },
+      grid: { color: "rgba(36,48,80,0.6)" },
     },
-    plugins: { legend: { labels: { color: "#c9d6f5" } } },
+    y: {
+      beginAtZero: true,
+      ticks: { color: "#93a0bf", precision: 0 },
+      grid: { color: "rgba(36,48,80,0.6)" },
+    },
   },
-});
+  plugins: {
+    legend: {
+      labels: { color: "#c9d6f5", boxWidth: 12, boxHeight: 12, usePointStyle: true },
+    },
+    tooltip: {
+      backgroundColor: "rgba(12, 18, 36, 0.95)",
+      titleColor: "#e8eefc",
+      bodyColor: "#c9d6f5",
+      borderColor: "#243050",
+      borderWidth: 1,
+    },
+  },
+};
+
+let tpsChart = null;
+let fuelChart = null;
+
+if (chartsEnabled) {
+  try {
+    tpsChart = new Chart(document.getElementById("tps-chart"), {
+      type: "line",
+      data: {
+        labels: [],
+        datasets: [
+          {
+            label: "succeeded/s",
+            data: [],
+            borderColor: "#3dd6c6",
+            backgroundColor: "rgba(61, 214, 198, 0.12)",
+            fill: true,
+            tension: 0.3,
+            pointRadius: 0,
+            borderWidth: 2,
+          },
+          {
+            label: "failed/s",
+            data: [],
+            borderColor: "#ff5c7a",
+            backgroundColor: "rgba(255, 92, 122, 0.08)",
+            fill: true,
+            tension: 0.3,
+            pointRadius: 0,
+            borderWidth: 2,
+          },
+        ],
+      },
+      options: chartDefaults,
+    });
+
+    fuelChart = new Chart(document.getElementById("fuel-chart"), {
+      type: "line",
+      data: {
+        labels: [],
+        datasets: [
+          {
+            label: "fuel UTXOs",
+            data: [],
+            borderColor: "#ffb020",
+            backgroundColor: "rgba(255, 176, 32, 0.1)",
+            fill: true,
+            tension: 0.3,
+            pointRadius: 0,
+            borderWidth: 2,
+          },
+          {
+            label: "reserve UTXOs",
+            data: [],
+            borderColor: "#8b9cff",
+            backgroundColor: "rgba(139, 156, 255, 0.08)",
+            fill: true,
+            tension: 0.3,
+            pointRadius: 0,
+            borderWidth: 2,
+          },
+        ],
+      },
+      options: chartDefaults,
+    });
+  } catch (err) {
+    console.warn("Chart.js init failed", err);
+    chartsEnabled = false;
+    tpsChart = null;
+    fuelChart = null;
+  }
+}
+
+if (!chartsEnabled) {
+  els.tpsChartFallback.hidden = false;
+  els.fuelChartFallback.hidden = false;
+  document.getElementById("tps-chart")?.setAttribute("hidden", "");
+  document.getElementById("fuel-chart")?.setAttribute("hidden", "");
+}
 
 function pushPoint(chart, label, values) {
+  if (!chart) return;
   chart.data.labels.push(label);
   values.forEach((v, i) => chart.data.datasets[i].data.push(v));
   while (chart.data.labels.length > MAX_POINTS) {
@@ -80,56 +175,163 @@ function pushPoint(chart, label, values) {
   chart.update("none");
 }
 
-function applyTick(tick) {
-  if (!tick) return;
-  const stream = tick.stream || {};
-  els.streamState.textContent = stream.running ? "running" : "stopped";
-  els.streamState.style.color = stream.running ? "#4ade80" : "#93a0bf";
-  els.succeeded.textContent = stream.succeeded ?? 0;
-  els.failed.textContent = stream.failed ?? 0;
-  els.iteration.textContent = stream.iteration ?? 0;
-  els.btnStart.disabled = !!stream.running;
-  els.btnStop.disabled = !stream.running;
-  if (stream.tps) els.tps.value = stream.tps;
-  if (stream.workers) els.workers.value = stream.workers;
-
-  els.balDefault.textContent = fmt(tick.default_sats);
-  els.balFuel.textContent = fmt(tick.fuel_count);
-  els.balReserve.textContent = fmt(tick.reserve_count);
-  els.balRunway.textContent = tick.fuel_runway_seconds != null
-    ? Number(tick.fuel_runway_seconds).toFixed(1)
-    : "—";
-  els.metaDenom.textContent = tick.denomination ?? "—";
-  els.metaWater.textContent = `${tick.low_water ?? "—"} / ${tick.high_water ?? "—"} (target ${tick.target_pool_size ?? "—"})`;
-
-  const label = (tick.timestamp || "").slice(11, 19) || new Date().toISOString().slice(11, 19);
-  pushPoint(tpsChart, label, [tick.tps_succeeded || 0, tick.tps_failed || 0]);
-  pushPoint(fuelChart, label, [tick.fuel_count || 0, tick.reserve_count || 0]);
-}
+// ---------------------------------------------------------------------------
+// Formatting & status helpers
+// ---------------------------------------------------------------------------
 
 function fmt(n) {
   if (n == null || n === "—") return "—";
   return Number(n).toLocaleString();
 }
 
-function prependTopup(ev) {
-  const li = document.createElement("li");
-  const p = ev.payload || {};
-  const time = document.createElement("time");
-  time.textContent = (ev.timestamp || "").slice(11, 19);
-  li.appendChild(time);
-  li.appendChild(document.createTextNode(
-    p.message || `${p.kind || "topup"} ${p.basket || ""} +${p.delta ?? "?"} (now ${p.after ?? "?"})`
-  ));
-  els.topupLog.prepend(li);
-  while (els.topupLog.children.length > 50) {
-    els.topupLog.removeChild(els.topupLog.lastChild);
+function setStatus(el, kind, message) {
+  el.className = kind ? `status ${kind}` : "status";
+  el.textContent = message || "";
+}
+
+function setConn(state, label) {
+  els.connStatus.className = `conn conn-${state}`;
+  els.connLabel.textContent = label;
+}
+
+function setBusy(btn, busy, idleLabel, busyLabel) {
+  btn.disabled = busy || btn.dataset.forceDisabled === "1";
+  btn.classList.toggle("busy", busy);
+  if (busyLabel || idleLabel) {
+    btn.textContent = busy ? (busyLabel || idleLabel) : idleLabel;
   }
 }
 
-async function refreshStatus() {
+function tickKey(tick) {
+  if (!tick) return "";
+  return [
+    tick.timestamp,
+    tick.tps_succeeded,
+    tick.tps_failed,
+    tick.fuel_count,
+    tick.reserve_count,
+    tick.stream?.succeeded,
+    tick.stream?.failed,
+    tick.stream?.iteration,
+    tick.stream?.running,
+  ].join("|");
+}
+
+// ---------------------------------------------------------------------------
+// Tick / top-up application
+// ---------------------------------------------------------------------------
+
+function applyTick(tick, { chart = true } = {}) {
+  if (!tick) return;
+
+  const key = tickKey(tick);
+  const isDup = key && key === lastTickKey;
+  lastTickKey = key || lastTickKey;
+
+  const stream = tick.stream || {};
+  const running = !!stream.running;
+
+  els.streamState.textContent = running ? "running" : "stopped";
+  els.streamState.className = `value state-pill ${running ? "state-running" : "state-stopped"}`;
+  els.succeeded.textContent = fmt(stream.succeeded ?? 0);
+  els.failed.textContent = fmt(stream.failed ?? 0);
+  els.iteration.textContent = fmt(stream.iteration ?? 0);
+
+  if (!streamBusy) {
+    els.btnStart.disabled = running;
+    els.btnStart.dataset.forceDisabled = running ? "1" : "0";
+    els.btnStop.disabled = !running;
+    els.btnStop.dataset.forceDisabled = !running ? "1" : "0";
+    els.tps.disabled = running;
+    els.workers.disabled = running;
+  }
+
+  // Reflect live configured rate only when stream reports values.
+  if (stream.tps) els.tps.value = stream.tps;
+  if (stream.workers) els.workers.value = stream.workers;
+
+  els.balDefault.textContent = fmt(tick.default_sats);
+  els.balFuel.textContent = fmt(tick.fuel_count);
+  els.balReserve.textContent = fmt(tick.reserve_count);
+  els.balRunway.textContent =
+    tick.fuel_runway_seconds != null ? Number(tick.fuel_runway_seconds).toFixed(1) : "—";
+  els.metaDenom.textContent = tick.denomination ?? "—";
+  els.metaWater.textContent = `${tick.low_water ?? "—"} / ${tick.high_water ?? "—"} (target ${tick.target_pool_size ?? "—"})`;
+
+  if (chart && !isDup) {
+    const label =
+      (tick.timestamp || "").slice(11, 19) || new Date().toISOString().slice(11, 19);
+    pushPoint(tpsChart, label, [tick.tps_succeeded || 0, tick.tps_failed || 0]);
+    pushPoint(fuelChart, label, [tick.fuel_count || 0, tick.reserve_count || 0]);
+  }
+}
+
+function topupKey(ev) {
+  const p = ev?.payload || {};
+  return `${ev?.timestamp || ""}|${p.basket || ""}|${p.before ?? ""}|${p.after ?? ""}|${p.kind || ""}`;
+}
+
+function prependTopup(ev) {
+  if (!ev) return;
+  const key = topupKey(ev);
+  if (key && seenTopups.has(key)) return;
+  if (key) {
+    seenTopups.add(key);
+    // Bound memory for long-running demos.
+    if (seenTopups.size > MAX_TOPUPS * 4) {
+      const drop = [...seenTopups].slice(0, seenTopups.size - MAX_TOPUPS * 2);
+      drop.forEach((k) => seenTopups.delete(k));
+    }
+  }
+
+  const p = ev.payload || {};
+  const li = document.createElement("li");
+
+  const time = document.createElement("time");
+  time.dateTime = ev.timestamp || "";
+  time.textContent = (ev.timestamp || "").slice(11, 19) || "—";
+  li.appendChild(time);
+
+  const basket = String(p.basket || "").toLowerCase();
+  if (basket) {
+    const tag = document.createElement("span");
+    tag.className = `tag${basket === "reserve" ? " reserve" : ""}`;
+    tag.textContent = basket;
+    li.appendChild(tag);
+  }
+
+  const text = document.createElement("span");
+  text.textContent =
+    p.message ||
+    `${p.kind || "topup"} ${p.basket || ""} +${p.delta ?? "?"} (now ${p.after ?? "?"})`;
+  li.appendChild(text);
+
+  els.topupLog.prepend(li);
+  while (els.topupLog.children.length > MAX_TOPUPS) {
+    els.topupLog.removeChild(els.topupLog.lastChild);
+  }
+  els.topupEmpty.classList.add("hidden");
+}
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+async function readJSON(res) {
+  const text = await res.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`Non-JSON response (${res.status}): ${text.slice(0, 120)}`);
+  }
+}
+
+async function refreshStatus({ chart = false } = {}) {
   const res = await fetch("/api/status");
-  const data = await res.json();
+  const data = await readJSON(res);
+  if (!res.ok) throw new Error(data.error || `status ${res.status}`);
+
   els.metaServer.textContent = data.server_url || "—";
   if (data.mainnet) {
     els.networkBadge.textContent = "MAINNET";
@@ -140,63 +342,307 @@ async function refreshStatus() {
     els.networkBadge.className = "badge badge-ok";
     els.mainnetBanner.style.display = "none";
   }
-  if (data.tick) applyTick(data.tick);
-  (data.events || []).filter((e) => e.type === "topup").slice(-20).forEach(prependTopup);
+
+  if (data.tick) applyTick(data.tick, { chart });
+
+  // Seed top-up log once from status history (deduped).
+  const topups = (data.events || []).filter((e) => e.type === "topup");
+  topups.slice(-20).forEach(prependTopup);
+  return data;
 }
 
 async function refreshFunding() {
-  const res = await fetch("/api/funding");
-  fundingInfo = await res.json();
-  if (fundingInfo.error) {
-    els.fundAddress.textContent = fundingInfo.error;
-    return;
-  }
-  els.fundAddress.textContent = fundingInfo.address;
-  if (fundingInfo.suggested_satoshis) {
-    els.fundAmount.value = fundingInfo.suggested_satoshis;
+  els.btnRefreshFunding.disabled = true;
+  try {
+    const res = await fetch("/api/funding");
+    fundingInfo = await readJSON(res);
+    if (!res.ok || fundingInfo.error) {
+      els.fundAddress.textContent = fundingInfo.error || `funding ${res.status}`;
+      els.btnCopyAddress.disabled = true;
+      setStatus(els.fundStatus, "err", fundingInfo.error || "Failed to load deposit address");
+      return;
+    }
+    els.fundAddress.textContent = fundingInfo.address || "—";
+    els.btnCopyAddress.disabled = !fundingInfo.address;
+    if (fundingInfo.suggested_satoshis) {
+      els.fundAmount.value = fundingInfo.suggested_satoshis;
+    }
+    setStatus(els.fundStatus, "", "");
+  } catch (err) {
+    els.fundAddress.textContent = "unavailable";
+    els.btnCopyAddress.disabled = true;
+    setStatus(els.fundStatus, "err", err?.message || String(err));
+  } finally {
+    els.btnRefreshFunding.disabled = false;
   }
 }
 
-els.btnStart.addEventListener("click", async () => {
-  const body = {
-    tps: Number(els.tps.value) || 10,
-    workers: Number(els.workers.value) || 8,
-  };
-  const res = await fetch("/api/stream/start", {
+// ---------------------------------------------------------------------------
+// Funding result parsing — WalletClient shapes vary across sdk / wallet hosts
+// ---------------------------------------------------------------------------
+
+function bytesToHex(bytes) {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function looksLikeHex(s) {
+  return typeof s === "string" && s.length >= 2 && /^[0-9a-fA-F]+$/.test(s.replace(/^0x/i, ""));
+}
+
+function normalizeHex(s) {
+  if (typeof s !== "string") return "";
+  const t = s.trim().replace(/^0x/i, "");
+  return looksLikeHex(t) ? t.toLowerCase() : "";
+}
+
+function tryBase64ToHex(s) {
+  if (typeof s !== "string" || !s.length) return "";
+  // Avoid treating pure hex as base64.
+  if (looksLikeHex(s)) return "";
+  try {
+    const bin = atob(s);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    return bytesToHex(bytes);
+  } catch {
+    return "";
+  }
+}
+
+function coerceToHex(value) {
+  if (value == null || value === "") return "";
+  if (typeof value === "string") {
+    const asHex = normalizeHex(value);
+    if (asHex) return asHex;
+    return tryBase64ToHex(value);
+  }
+  if (value instanceof Uint8Array || ArrayBuffer.isView(value)) {
+    return bytesToHex(new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
+  }
+  if (value instanceof ArrayBuffer) {
+    return bytesToHex(new Uint8Array(value));
+  }
+  if (Array.isArray(value) && value.every((n) => Number.isInteger(n) && n >= 0 && n <= 255)) {
+    return bytesToHex(value);
+  }
+  if (typeof value === "object") {
+    if (typeof value.toHex === "function") {
+      try {
+        return normalizeHex(value.toHex()) || coerceToHex(value.toHex());
+      } catch { /* ignore */ }
+    }
+    if (typeof value.toString === "function" && value.toString !== Object.prototype.toString) {
+      const s = value.toString();
+      if (looksLikeHex(s)) return normalizeHex(s);
+    }
+    // Nested common fields.
+    for (const k of ["hex", "atomicBEEF", "atomicBeef", "beef", "rawTx", "tx", "bytes"]) {
+      if (k in value) {
+        const nested = coerceToHex(value[k]);
+        if (nested) return nested;
+      }
+    }
+  }
+  return "";
+}
+
+function extractTxid(result) {
+  if (!result || typeof result !== "object") return "";
+  const candidates = [
+    result.txid,
+    result.txId,
+    result.txID,
+    result.TxID,
+    Array.isArray(result.txids) ? result.txids[0] : null,
+    Array.isArray(result.Txids) ? result.Txids[0] : null,
+  ];
+  for (const c of candidates) {
+    if (typeof c === "string") {
+      const h = normalizeHex(c);
+      if (h.length === 64) return h;
+    }
+  }
+  return "";
+}
+
+function extractAtomicHex(result) {
+  if (!result || typeof result !== "object") return "";
+  const candidates = [
+    result.tx,
+    result.Tx,
+    result.rawTx,
+    result.rawtx,
+    result.atomicBeef,
+    result.atomicBEEF,
+    result.AtomicBEEF,
+    result.beef,
+    result.BEEF,
+    result.signableTransaction?.tx,
+    result.signableTransaction?.Tx,
+  ];
+  for (const c of candidates) {
+    const hex = coerceToHex(c);
+    if (hex) return hex;
+  }
+  return "";
+}
+
+function extractOutputIndex(result, lockingScriptHex) {
+  // Prefer explicit single-output payment (vout 0) unless wallet reports outputs.
+  const outs =
+    result?.outputs ||
+    result?.Outputs ||
+    result?.tx?.outputs ||
+    null;
+  if (Array.isArray(outs) && lockingScriptHex) {
+    const want = normalizeHex(lockingScriptHex);
+    for (let i = 0; i < outs.length; i++) {
+      const ls =
+        outs[i]?.lockingScript ||
+        outs[i]?.locking_script ||
+        outs[i]?.script ||
+        "";
+      const hex = coerceToHex(ls);
+      if (hex && want && hex === want) return i;
+    }
+  }
+  return 0;
+}
+
+async function loadWalletClient() {
+  let lastErr;
+  for (const url of SDK_URLS) {
+    try {
+      const mod = await import(/* @vite-ignore */ url);
+      if (mod?.WalletClient) return mod.WalletClient;
+      if (mod?.default?.WalletClient) return mod.default.WalletClient;
+      lastErr = new Error(`WalletClient export missing from ${url}`);
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw new Error(
+    `Could not load @bsv/sdk WalletClient (CDN blocked or offline). ${lastErr?.message || lastErr || ""}`.trim()
+  );
+}
+
+async function postInternalize(body) {
+  const res = await fetch("/api/funding/internalize", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  const data = await res.json();
-  if (!res.ok) {
-    alert(data.error || "failed to start");
-    return;
+  const data = await readJSON(res);
+  if (!res.ok) throw new Error(data.error || "internalize failed");
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Stream controls
+// ---------------------------------------------------------------------------
+
+function parsePositiveInt(input, fallback, { min = 1, max = 1e9 } = {}) {
+  const n = Number(input);
+  if (!Number.isFinite(n) || n < min) return fallback;
+  return Math.min(max, Math.floor(n));
+}
+
+els.btnStart.addEventListener("click", async () => {
+  const tps = parsePositiveInt(els.tps.value, 10, { min: 1, max: 10000 });
+  const workers = parsePositiveInt(els.workers.value, 8, { min: 1, max: 256 });
+  els.tps.value = tps;
+  els.workers.value = workers;
+
+  streamBusy = true;
+  setBusy(els.btnStart, true, "Start stream", "Starting…");
+  els.btnStop.disabled = true;
+  setStatus(els.streamStatus, "info", `Starting stream at ${tps} TPS · ${workers} workers…`);
+
+  try {
+    const res = await fetch("/api/stream/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tps, workers }),
+    });
+    const data = await readJSON(res);
+    if (!res.ok) throw new Error(data.error || "failed to start");
+    setStatus(els.streamStatus, "ok", "Stream running.");
+    await refreshStatus({ chart: false });
+  } catch (err) {
+    setStatus(els.streamStatus, "err", err?.message || String(err));
+  } finally {
+    streamBusy = false;
+    setBusy(els.btnStart, false, "Start stream");
+    // applyTick from refreshStatus re-enables buttons from stream state.
+    await refreshStatus({ chart: false }).catch(() => {});
   }
-  await refreshStatus();
 });
 
 els.btnStop.addEventListener("click", async () => {
-  await fetch("/api/stream/stop", { method: "POST" });
-  await refreshStatus();
+  streamBusy = true;
+  setBusy(els.btnStop, true, "Stop stream", "Stopping…");
+  els.btnStart.disabled = true;
+  setStatus(els.streamStatus, "info", "Stopping stream…");
+  try {
+    const res = await fetch("/api/stream/stop", { method: "POST" });
+    const data = await readJSON(res);
+    if (!res.ok) throw new Error(data.error || "failed to stop");
+    setStatus(els.streamStatus, "ok", "Stream stopped. FuelKeeper continues running.");
+  } catch (err) {
+    setStatus(els.streamStatus, "err", err?.message || String(err));
+  } finally {
+    streamBusy = false;
+    setBusy(els.btnStop, false, "Stop stream");
+    await refreshStatus({ chart: false }).catch(() => {});
+  }
 });
 
-els.btnRefreshFunding.addEventListener("click", () => refreshFunding());
+// ---------------------------------------------------------------------------
+// Funding controls
+// ---------------------------------------------------------------------------
+
+els.btnRefreshFunding.addEventListener("click", () => {
+  refreshFunding();
+});
+
+els.btnCopyAddress.addEventListener("click", async () => {
+  const addr = fundingInfo?.address || els.fundAddress.textContent;
+  if (!addr || addr === "loading…" || addr === "unavailable") return;
+  try {
+    await navigator.clipboard.writeText(addr);
+    setStatus(els.fundStatus, "ok", "Address copied to clipboard.");
+  } catch {
+    // Fallback for restricted clipboard.
+    const range = document.createRange();
+    range.selectNodeContents(els.fundAddress);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    setStatus(els.fundStatus, "info", "Select the address and copy manually (clipboard blocked).");
+  }
+});
 
 els.btnFund.addEventListener("click", async () => {
-  els.fundStatus.className = "status";
-  els.fundStatus.textContent = "Connecting WalletClient…";
+  setStatus(els.fundStatus, "info", "Connecting WalletClient…");
+  setBusy(els.btnFund, true, "Pay with WalletClient", "Paying…");
+  els.btnManualInternalize.disabled = true;
+
   try {
     if (!fundingInfo?.locking_script_hex) {
       await refreshFunding();
     }
-    const amount = Number(els.fundAmount.value);
-    if (!amount || amount <= 0) throw new Error("Enter a positive satoshi amount");
+    if (!fundingInfo?.locking_script_hex) {
+      throw new Error("Deposit locking script unavailable — check /api/funding");
+    }
 
-    // Dynamic import so the page still works if CDN is blocked (status UI remains usable).
-    const { WalletClient } = await import("https://esm.sh/@bsv/sdk@1.9.25");
+    const amount = parsePositiveInt(els.fundAmount.value, 0, { min: 1 });
+    if (!amount) throw new Error("Enter a positive satoshi amount");
+    els.fundAmount.value = amount;
+
+    const WalletClient = await loadWalletClient();
     const client = new WalletClient();
 
-    els.fundStatus.textContent = "Creating payment action…";
+    setStatus(els.fundStatus, "info", "Creating payment action in browser wallet…");
     const result = await client.createAction({
       description: "throughput dashboard operator top-up",
       outputs: [
@@ -208,60 +654,107 @@ els.btnFund.addEventListener("click", async () => {
       ],
     });
 
-    const atomic =
-      result?.tx ||
-      result?.rawTx ||
-      result?.atomicBeef ||
-      result?.beef ||
-      "";
-    const txid = result?.txid || result?.txids?.[0] || "";
+    const atomicHex = extractAtomicHex(result);
+    const txid = extractTxid(result);
+    const outputIndex = extractOutputIndex(result, fundingInfo.locking_script_hex);
 
-    const body = {
-      output_index: 0,
-      txid: typeof txid === "string" ? txid : String(txid || ""),
-    };
-    if (typeof atomic === "string" && atomic.length > 0) {
-      // WalletClient may return hex already; strip 0x if present.
-      body.atomic_tx_hex = atomic.startsWith("0x") ? atomic.slice(2) : atomic;
-    } else if (atomic && typeof atomic === "object" && atomic.toHex) {
-      body.atomic_tx_hex = atomic.toHex();
-    } else if (atomic instanceof Uint8Array) {
-      body.atomic_tx_hex = [...atomic].map((b) => b.toString(16).padStart(2, "0")).join("");
-    }
+    const body = { output_index: outputIndex };
+    if (atomicHex) body.atomic_tx_hex = atomicHex;
+    if (txid) body.txid = txid;
 
     if (!body.atomic_tx_hex && !body.txid) {
-      throw new Error("WalletClient returned neither tx bytes nor txid");
+      console.error("WalletClient createAction result:", result);
+      throw new Error(
+        "WalletClient returned neither tx bytes nor txid. Use Manual internalize with a known txid, or check the browser wallet."
+      );
     }
 
-    els.fundStatus.textContent = "Internalizing into operator wallet…";
-    const res = await fetch("/api/funding/internalize", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
-    const data = await res.json();
-    if (!res.ok) throw new Error(data.error || "internalize failed");
+    setStatus(els.fundStatus, "info", "Internalizing into operator wallet…");
+    await postInternalize(body);
 
-    els.fundStatus.className = "status ok";
-    els.fundStatus.textContent = `Funded OK${body.txid ? ` · ${body.txid}` : ""}. FuelKeeper will fan out into reserve/fuel.`;
-    await refreshStatus();
+    const ref = body.txid || (body.atomic_tx_hex ? `${body.atomic_tx_hex.slice(0, 16)}…` : "");
+    setStatus(
+      els.fundStatus,
+      "ok",
+      `Funded OK${ref ? ` · ${ref}` : ""}. FuelKeeper will fan out into reserve/fuel.`
+    );
+    await refreshStatus({ chart: false });
   } catch (err) {
     console.error(err);
-    els.fundStatus.className = "status err";
-    els.fundStatus.textContent = err?.message || String(err);
+    const msg = err?.message || String(err);
+    // Friendlier guidance when CDN / extension is missing.
+    if (/Failed to fetch|import|CDN|WalletClient|network/i.test(msg)) {
+      setStatus(
+        els.fundStatus,
+        "err",
+        `${msg} — open Manual internalize below if you paid the address externally.`
+      );
+    } else {
+      setStatus(els.fundStatus, "err", msg);
+    }
+  } finally {
+    setBusy(els.btnFund, false, "Pay with WalletClient");
+    els.btnManualInternalize.disabled = false;
   }
 });
 
+els.btnManualInternalize.addEventListener("click", async () => {
+  setBusy(els.btnManualInternalize, true, "Internalize", "Internalizing…");
+  setStatus(els.fundStatus, "info", "Internalizing…");
+  try {
+    const txid = normalizeHex(els.manualTxid.value.trim());
+    const atomic = normalizeHex(els.manualHex.value.trim()) || tryBase64ToHex(els.manualHex.value.trim());
+    const outputIndex = parsePositiveInt(els.manualVout.value, 0, { min: 0, max: 1e6 });
+
+    if (!txid && !atomic) {
+      throw new Error("Provide a txid and/or atomic tx hex");
+    }
+    if (txid && txid.length !== 64) {
+      throw new Error("txid must be 64 hex characters");
+    }
+
+    const body = { output_index: outputIndex };
+    if (atomic) body.atomic_tx_hex = atomic;
+    if (txid) body.txid = txid;
+
+    await postInternalize(body);
+    setStatus(els.fundStatus, "ok", `Internalized OK${txid ? ` · ${txid}` : ""}.`);
+    els.manualTxid.value = "";
+    els.manualHex.value = "";
+    await refreshStatus({ chart: false });
+  } catch (err) {
+    setStatus(els.fundStatus, "err", err?.message || String(err));
+  } finally {
+    setBusy(els.btnManualInternalize, false, "Internalize");
+  }
+});
+
+// ---------------------------------------------------------------------------
+// SSE + poll backup
+// ---------------------------------------------------------------------------
+
 function connectSSE() {
+  setConn("pending", "Connecting…");
   const es = new EventSource("/api/events");
+
+  es.addEventListener("open", () => {
+    setConn("live", "Live");
+  });
+
+  // Some browsers only fire open via onopen.
+  es.onopen = () => setConn("live", "Live");
+
   es.addEventListener("tick", (msg) => {
     try {
       const ev = JSON.parse(msg.data);
-      applyTick(ev.payload?.tick);
+      const tick = ev.payload?.tick ?? ev.tick ?? null;
+      applyTick(tick, { chart: true });
+      setConn("live", "Live");
     } catch (e) {
       console.warn("tick parse", e);
     }
   });
+
   es.addEventListener("topup", (msg) => {
     try {
       const ev = JSON.parse(msg.data);
@@ -270,15 +763,29 @@ function connectSSE() {
       console.warn("topup parse", e);
     }
   });
+
   es.onerror = () => {
-    // Browser will reconnect; also poll as backup.
+    setConn("offline", "Reconnecting…");
+    // Browser auto-reconnects EventSource; poll backup keeps gauges fresh.
   };
 }
 
-await refreshStatus();
+// ---------------------------------------------------------------------------
+// Boot
+// ---------------------------------------------------------------------------
+
+try {
+  await refreshStatus({ chart: true });
+} catch (err) {
+  setStatus(els.streamStatus, "err", `Status unavailable: ${err?.message || err}`);
+  setConn("offline", "API offline");
+}
+
 await refreshFunding();
 connectSSE();
-// Backup poll in case SSE is flaky.
+
 setInterval(() => {
-  refreshStatus().catch(() => {});
-}, 5000);
+  refreshStatus({ chart: false }).catch(() => {
+    setConn("offline", "Poll failed");
+  });
+}, POLL_MS);

--- a/cmd/throughput_dashboard/web/app.js
+++ b/cmd/throughput_dashboard/web/app.js
@@ -1,0 +1,284 @@
+// Throughput demo dashboard — control plane client + WalletClient funding.
+
+const MAX_POINTS = 60;
+
+const els = {
+  networkBadge: document.getElementById("network-badge"),
+  mainnetBanner: document.getElementById("mainnet-banner"),
+  streamState: document.getElementById("stream-state"),
+  succeeded: document.getElementById("stat-succeeded"),
+  failed: document.getElementById("stat-failed"),
+  iteration: document.getElementById("stat-iteration"),
+  tps: document.getElementById("tps"),
+  workers: document.getElementById("workers"),
+  btnStart: document.getElementById("btn-start"),
+  btnStop: document.getElementById("btn-stop"),
+  balDefault: document.getElementById("bal-default"),
+  balFuel: document.getElementById("bal-fuel"),
+  balReserve: document.getElementById("bal-reserve"),
+  balRunway: document.getElementById("bal-runway"),
+  metaDenom: document.getElementById("meta-denom"),
+  metaWater: document.getElementById("meta-water"),
+  metaServer: document.getElementById("meta-server"),
+  topupLog: document.getElementById("topup-log"),
+  fundAddress: document.getElementById("fund-address"),
+  fundAmount: document.getElementById("fund-amount"),
+  btnFund: document.getElementById("btn-fund"),
+  btnRefreshFunding: document.getElementById("btn-refresh-funding"),
+  fundStatus: document.getElementById("fund-status"),
+};
+
+let fundingInfo = null;
+
+const tpsChart = new Chart(document.getElementById("tps-chart"), {
+  type: "line",
+  data: {
+    labels: [],
+    datasets: [
+      { label: "succeeded/s", data: [], borderColor: "#3dd6c6", tension: 0.25, pointRadius: 0 },
+      { label: "failed/s", data: [], borderColor: "#ff5c7a", tension: 0.25, pointRadius: 0 },
+    ],
+  },
+  options: {
+    responsive: true,
+    animation: false,
+    scales: {
+      x: { ticks: { color: "#93a0bf", maxTicksLimit: 8 }, grid: { color: "rgba(36,48,80,0.6)" } },
+      y: { beginAtZero: true, ticks: { color: "#93a0bf" }, grid: { color: "rgba(36,48,80,0.6)" } },
+    },
+    plugins: { legend: { labels: { color: "#c9d6f5" } } },
+  },
+});
+
+const fuelChart = new Chart(document.getElementById("fuel-chart"), {
+  type: "line",
+  data: {
+    labels: [],
+    datasets: [
+      { label: "fuel UTXOs", data: [], borderColor: "#ffb020", tension: 0.25, pointRadius: 0 },
+      { label: "reserve UTXOs", data: [], borderColor: "#8b9cff", tension: 0.25, pointRadius: 0 },
+    ],
+  },
+  options: {
+    responsive: true,
+    animation: false,
+    scales: {
+      x: { ticks: { color: "#93a0bf", maxTicksLimit: 8 }, grid: { color: "rgba(36,48,80,0.6)" } },
+      y: { beginAtZero: true, ticks: { color: "#93a0bf" }, grid: { color: "rgba(36,48,80,0.6)" } },
+    },
+    plugins: { legend: { labels: { color: "#c9d6f5" } } },
+  },
+});
+
+function pushPoint(chart, label, values) {
+  chart.data.labels.push(label);
+  values.forEach((v, i) => chart.data.datasets[i].data.push(v));
+  while (chart.data.labels.length > MAX_POINTS) {
+    chart.data.labels.shift();
+    chart.data.datasets.forEach((d) => d.data.shift());
+  }
+  chart.update("none");
+}
+
+function applyTick(tick) {
+  if (!tick) return;
+  const stream = tick.stream || {};
+  els.streamState.textContent = stream.running ? "running" : "stopped";
+  els.streamState.style.color = stream.running ? "#4ade80" : "#93a0bf";
+  els.succeeded.textContent = stream.succeeded ?? 0;
+  els.failed.textContent = stream.failed ?? 0;
+  els.iteration.textContent = stream.iteration ?? 0;
+  els.btnStart.disabled = !!stream.running;
+  els.btnStop.disabled = !stream.running;
+  if (stream.tps) els.tps.value = stream.tps;
+  if (stream.workers) els.workers.value = stream.workers;
+
+  els.balDefault.textContent = fmt(tick.default_sats);
+  els.balFuel.textContent = fmt(tick.fuel_count);
+  els.balReserve.textContent = fmt(tick.reserve_count);
+  els.balRunway.textContent = tick.fuel_runway_seconds != null
+    ? Number(tick.fuel_runway_seconds).toFixed(1)
+    : "—";
+  els.metaDenom.textContent = tick.denomination ?? "—";
+  els.metaWater.textContent = `${tick.low_water ?? "—"} / ${tick.high_water ?? "—"} (target ${tick.target_pool_size ?? "—"})`;
+
+  const label = (tick.timestamp || "").slice(11, 19) || new Date().toISOString().slice(11, 19);
+  pushPoint(tpsChart, label, [tick.tps_succeeded || 0, tick.tps_failed || 0]);
+  pushPoint(fuelChart, label, [tick.fuel_count || 0, tick.reserve_count || 0]);
+}
+
+function fmt(n) {
+  if (n == null || n === "—") return "—";
+  return Number(n).toLocaleString();
+}
+
+function prependTopup(ev) {
+  const li = document.createElement("li");
+  const p = ev.payload || {};
+  const time = document.createElement("time");
+  time.textContent = (ev.timestamp || "").slice(11, 19);
+  li.appendChild(time);
+  li.appendChild(document.createTextNode(
+    p.message || `${p.kind || "topup"} ${p.basket || ""} +${p.delta ?? "?"} (now ${p.after ?? "?"})`
+  ));
+  els.topupLog.prepend(li);
+  while (els.topupLog.children.length > 50) {
+    els.topupLog.removeChild(els.topupLog.lastChild);
+  }
+}
+
+async function refreshStatus() {
+  const res = await fetch("/api/status");
+  const data = await res.json();
+  els.metaServer.textContent = data.server_url || "—";
+  if (data.mainnet) {
+    els.networkBadge.textContent = "MAINNET";
+    els.networkBadge.className = "badge badge-warn";
+    els.mainnetBanner.style.display = "";
+  } else {
+    els.networkBadge.textContent = String(data.network || "test").toUpperCase();
+    els.networkBadge.className = "badge badge-ok";
+    els.mainnetBanner.style.display = "none";
+  }
+  if (data.tick) applyTick(data.tick);
+  (data.events || []).filter((e) => e.type === "topup").slice(-20).forEach(prependTopup);
+}
+
+async function refreshFunding() {
+  const res = await fetch("/api/funding");
+  fundingInfo = await res.json();
+  if (fundingInfo.error) {
+    els.fundAddress.textContent = fundingInfo.error;
+    return;
+  }
+  els.fundAddress.textContent = fundingInfo.address;
+  if (fundingInfo.suggested_satoshis) {
+    els.fundAmount.value = fundingInfo.suggested_satoshis;
+  }
+}
+
+els.btnStart.addEventListener("click", async () => {
+  const body = {
+    tps: Number(els.tps.value) || 10,
+    workers: Number(els.workers.value) || 8,
+  };
+  const res = await fetch("/api/stream/start", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    alert(data.error || "failed to start");
+    return;
+  }
+  await refreshStatus();
+});
+
+els.btnStop.addEventListener("click", async () => {
+  await fetch("/api/stream/stop", { method: "POST" });
+  await refreshStatus();
+});
+
+els.btnRefreshFunding.addEventListener("click", () => refreshFunding());
+
+els.btnFund.addEventListener("click", async () => {
+  els.fundStatus.className = "status";
+  els.fundStatus.textContent = "Connecting WalletClient…";
+  try {
+    if (!fundingInfo?.locking_script_hex) {
+      await refreshFunding();
+    }
+    const amount = Number(els.fundAmount.value);
+    if (!amount || amount <= 0) throw new Error("Enter a positive satoshi amount");
+
+    // Dynamic import so the page still works if CDN is blocked (status UI remains usable).
+    const { WalletClient } = await import("https://esm.sh/@bsv/sdk@1.9.25");
+    const client = new WalletClient();
+
+    els.fundStatus.textContent = "Creating payment action…";
+    const result = await client.createAction({
+      description: "throughput dashboard operator top-up",
+      outputs: [
+        {
+          lockingScript: fundingInfo.locking_script_hex,
+          satoshis: amount,
+          outputDescription: "operator fuel deposit",
+        },
+      ],
+    });
+
+    const atomic =
+      result?.tx ||
+      result?.rawTx ||
+      result?.atomicBeef ||
+      result?.beef ||
+      "";
+    const txid = result?.txid || result?.txids?.[0] || "";
+
+    const body = {
+      output_index: 0,
+      txid: typeof txid === "string" ? txid : String(txid || ""),
+    };
+    if (typeof atomic === "string" && atomic.length > 0) {
+      // WalletClient may return hex already; strip 0x if present.
+      body.atomic_tx_hex = atomic.startsWith("0x") ? atomic.slice(2) : atomic;
+    } else if (atomic && typeof atomic === "object" && atomic.toHex) {
+      body.atomic_tx_hex = atomic.toHex();
+    } else if (atomic instanceof Uint8Array) {
+      body.atomic_tx_hex = [...atomic].map((b) => b.toString(16).padStart(2, "0")).join("");
+    }
+
+    if (!body.atomic_tx_hex && !body.txid) {
+      throw new Error("WalletClient returned neither tx bytes nor txid");
+    }
+
+    els.fundStatus.textContent = "Internalizing into operator wallet…";
+    const res = await fetch("/api/funding/internalize", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || "internalize failed");
+
+    els.fundStatus.className = "status ok";
+    els.fundStatus.textContent = `Funded OK${body.txid ? ` · ${body.txid}` : ""}. FuelKeeper will fan out into reserve/fuel.`;
+    await refreshStatus();
+  } catch (err) {
+    console.error(err);
+    els.fundStatus.className = "status err";
+    els.fundStatus.textContent = err?.message || String(err);
+  }
+});
+
+function connectSSE() {
+  const es = new EventSource("/api/events");
+  es.addEventListener("tick", (msg) => {
+    try {
+      const ev = JSON.parse(msg.data);
+      applyTick(ev.payload?.tick);
+    } catch (e) {
+      console.warn("tick parse", e);
+    }
+  });
+  es.addEventListener("topup", (msg) => {
+    try {
+      const ev = JSON.parse(msg.data);
+      prependTopup(ev);
+    } catch (e) {
+      console.warn("topup parse", e);
+    }
+  });
+  es.onerror = () => {
+    // Browser will reconnect; also poll as backup.
+  };
+}
+
+await refreshStatus();
+await refreshFunding();
+connectSSE();
+// Backup poll in case SSE is flaky.
+setInterval(() => {
+  refreshStatus().catch(() => {});
+}, 5000);

--- a/cmd/throughput_dashboard/web/app.js
+++ b/cmd/throughput_dashboard/web/app.js
@@ -308,7 +308,7 @@ function prependTopup(ev) {
 
   els.topupLog.prepend(li);
   while (els.topupLog.children.length > MAX_TOPUPS) {
-    els.topupLog.removeChild(els.topupLog.lastChild);
+    els.topupLog.lastChild?.remove();
   }
   els.topupEmpty.classList.add("hidden");
 }
@@ -402,20 +402,19 @@ function tryBase64ToHex(s) {
   try {
     const bin = atob(s);
     const bytes = new Uint8Array(bin.length);
-    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.codePointAt(i);
     return bytesToHex(bytes);
   } catch {
     return "";
   }
 }
 
-function coerceToHex(value) {
-  if (value == null || value === "") return "";
-  if (typeof value === "string") {
-    const asHex = normalizeHex(value);
-    if (asHex) return asHex;
-    return tryBase64ToHex(value);
-  }
+function coerceStringToHex(value) {
+  const asHex = normalizeHex(value);
+  return asHex || tryBase64ToHex(value);
+}
+
+function coerceBytesToHex(value) {
   if (value instanceof Uint8Array || ArrayBuffer.isView(value)) {
     return bytesToHex(new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
   }
@@ -425,24 +424,37 @@ function coerceToHex(value) {
   if (Array.isArray(value) && value.every((n) => Number.isInteger(n) && n >= 0 && n <= 255)) {
     return bytesToHex(value);
   }
-  if (typeof value === "object") {
-    if (typeof value.toHex === "function") {
-      try {
-        return normalizeHex(value.toHex()) || coerceToHex(value.toHex());
-      } catch { /* ignore */ }
-    }
-    if (typeof value.toString === "function" && value.toString !== Object.prototype.toString) {
-      const s = value.toString();
-      if (looksLikeHex(s)) return normalizeHex(s);
-    }
-    // Nested common fields.
-    for (const k of ["hex", "atomicBEEF", "atomicBeef", "beef", "rawTx", "tx", "bytes"]) {
-      if (k in value) {
-        const nested = coerceToHex(value[k]);
-        if (nested) return nested;
-      }
+  return "";
+}
+
+function coerceObjectToHex(value) {
+  if (typeof value.toHex === "function") {
+    try {
+      const fromToHex = normalizeHex(value.toHex()) || coerceToHex(value.toHex());
+      if (fromToHex) return fromToHex;
+    } catch {
+      /* ignore */
     }
   }
+  if (typeof value.toString === "function" && value.toString !== Object.prototype.toString) {
+    const s = value.toString();
+    if (looksLikeHex(s)) return normalizeHex(s);
+  }
+  for (const k of ["hex", "atomicBEEF", "atomicBeef", "beef", "rawTx", "tx", "bytes"]) {
+    if (k in value) {
+      const nested = coerceToHex(value[k]);
+      if (nested) return nested;
+    }
+  }
+  return "";
+}
+
+function coerceToHex(value) {
+  if (value == null || value === "") return "";
+  if (typeof value === "string") return coerceStringToHex(value);
+  const asBytes = coerceBytesToHex(value);
+  if (asBytes) return asBytes;
+  if (typeof value === "object") return coerceObjectToHex(value);
   return "";
 }
 
@@ -687,11 +699,12 @@ els.btnFund.addEventListener("click", async () => {
     setStatus(els.fundStatus, "info", "Internalizing into operator wallet…");
     await postInternalize(body);
 
-    const ref = body.txid || (body.atomic_tx_hex ? `${body.atomic_tx_hex.slice(0, 16)}…` : "");
+    const ref = body.txid || (body.atomic_tx_hex ? body.atomic_tx_hex.slice(0, 16) + "…" : "");
+    const refSuffix = ref ? " · " + ref : "";
     setStatus(
       els.fundStatus,
       "ok",
-      `Funded OK${ref ? ` · ${ref}` : ""}. FuelKeeper will fan out into reserve/fuel.`
+      "Funded OK" + refSuffix + ". FuelKeeper will fan out into reserve/fuel."
     );
     await refreshStatus({ chart: false });
   } catch (err) {
@@ -733,7 +746,8 @@ els.btnManualInternalize.addEventListener("click", async () => {
     if (txid) body.txid = txid;
 
     await postInternalize(body);
-    setStatus(els.fundStatus, "ok", `Internalized OK${txid ? ` · ${txid}` : ""}.`);
+    const okSuffix = txid ? " · " + txid : "";
+    setStatus(els.fundStatus, "ok", "Internalized OK" + okSuffix + ".");
     els.manualTxid.value = "";
     els.manualHex.value = "";
     await refreshStatus({ chart: false });

--- a/cmd/throughput_dashboard/web/index.html
+++ b/cmd/throughput_dashboard/web/index.html
@@ -3,87 +3,161 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark" />
   <title>Throughput Demo Dashboard</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="/style.css" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
 </head>
 <body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
   <header class="top">
-    <div>
+    <div class="brand">
       <h1>Wallet Throughput Demo</h1>
       <p class="sub">Local infra · createAction OP_RETURN stream · FuelKeeper</p>
     </div>
-    <div id="network-badge" class="badge badge-warn">MAINNET</div>
+    <div class="top-meta" role="status" aria-live="polite">
+      <span id="conn-status" class="conn conn-pending" title="Event stream connection">
+        <span class="conn-dot" aria-hidden="true"></span>
+        <span id="conn-label">Connecting…</span>
+      </span>
+      <div id="network-badge" class="badge badge-warn" aria-label="Network">MAINNET</div>
+    </div>
   </header>
 
-  <section class="banner" id="mainnet-banner">
+  <section class="banner" id="mainnet-banner" role="alert">
     <strong>Mainnet live demo.</strong>
-    Real BSV and fees. Bind is localhost-only. Fund deliberately; start the stream only after fuel inventory is healthy.
+    Real BSV and fees. UI is localhost-only. Fund deliberately; start the stream only after fuel inventory is healthy.
   </section>
 
-  <main class="grid">
-    <section class="card">
-      <h2>Event stream</h2>
+  <main id="main" class="grid">
+    <section class="card" aria-labelledby="stream-heading">
+      <h2 id="stream-heading">Event stream</h2>
       <div class="row stats-row">
-        <div class="stat"><span class="label">State</span><span id="stream-state" class="value">stopped</span></div>
-        <div class="stat"><span class="label">Succeeded</span><span id="stat-succeeded" class="value">0</span></div>
-        <div class="stat"><span class="label">Failed</span><span id="stat-failed" class="value">0</span></div>
-        <div class="stat"><span class="label">Iteration</span><span id="stat-iteration" class="value">0</span></div>
+        <div class="stat">
+          <span class="label" id="lbl-state">State</span>
+          <span id="stream-state" class="value state-pill state-stopped" aria-labelledby="lbl-state">stopped</span>
+        </div>
+        <div class="stat">
+          <span class="label" id="lbl-succeeded">Succeeded</span>
+          <span id="stat-succeeded" class="value value-good" aria-labelledby="lbl-succeeded">0</span>
+        </div>
+        <div class="stat">
+          <span class="label" id="lbl-failed">Failed</span>
+          <span id="stat-failed" class="value value-bad" aria-labelledby="lbl-failed">0</span>
+        </div>
+        <div class="stat">
+          <span class="label" id="lbl-iteration">Iteration</span>
+          <span id="stat-iteration" class="value" aria-labelledby="lbl-iteration">0</span>
+        </div>
       </div>
-      <div class="controls">
-        <label>TPS <input type="number" id="tps" min="1" value="10" /></label>
-        <label>Workers <input type="number" id="workers" min="1" value="8" /></label>
-        <button id="btn-start" class="primary">Start stream</button>
-        <button id="btn-stop" class="danger" disabled>Stop stream</button>
+      <div class="controls" role="group" aria-label="Stream controls">
+        <label for="tps">TPS
+          <input type="number" id="tps" min="1" max="10000" step="1" value="10" inputmode="numeric" aria-describedby="stream-hint" />
+        </label>
+        <label for="workers">Workers
+          <input type="number" id="workers" min="1" max="256" step="1" value="8" inputmode="numeric" />
+        </label>
+        <button type="button" id="btn-start" class="primary">Start stream</button>
+        <button type="button" id="btn-stop" class="danger" disabled>Stop stream</button>
       </div>
-      <p class="hint">Each action embeds OP_RETURN <code>sha256(iteration ‖ RFC3339Nano timestamp)</code>.</p>
+      <p id="stream-status" class="status" role="status" aria-live="polite"></p>
+      <p id="stream-hint" class="hint">Each action embeds OP_RETURN <code>sha256(iteration ‖ RFC3339Nano timestamp)</code>.</p>
     </section>
 
-    <section class="card">
-      <h2>Fuel &amp; balances</h2>
+    <section class="card" aria-labelledby="balances-heading">
+      <h2 id="balances-heading">Fuel &amp; balances</h2>
       <div class="row stats-row">
-        <div class="stat"><span class="label">Default (sats)</span><span id="bal-default" class="value">—</span></div>
-        <div class="stat"><span class="label">Fuel UTXOs</span><span id="bal-fuel" class="value">—</span></div>
-        <div class="stat"><span class="label">Reserve UTXOs</span><span id="bal-reserve" class="value">—</span></div>
-        <div class="stat"><span class="label">Fuel runway (s)</span><span id="bal-runway" class="value">—</span></div>
+        <div class="stat">
+          <span class="label" id="lbl-default">Default (sats)</span>
+          <span id="bal-default" class="value" aria-labelledby="lbl-default">—</span>
+        </div>
+        <div class="stat">
+          <span class="label" id="lbl-fuel">Fuel UTXOs</span>
+          <span id="bal-fuel" class="value value-warn" aria-labelledby="lbl-fuel">—</span>
+        </div>
+        <div class="stat">
+          <span class="label" id="lbl-reserve">Reserve UTXOs</span>
+          <span id="bal-reserve" class="value" aria-labelledby="lbl-reserve">—</span>
+        </div>
+        <div class="stat">
+          <span class="label" id="lbl-runway">Fuel runway (s)</span>
+          <span id="bal-runway" class="value" aria-labelledby="lbl-runway">—</span>
+        </div>
       </div>
-      <div class="row meta">
+      <div class="row meta" aria-label="Pool configuration">
         <span>Denomination: <strong id="meta-denom">—</strong> sats</span>
         <span>Low / high water: <strong id="meta-water">—</strong></span>
         <span>Storage: <strong id="meta-server">—</strong></span>
       </div>
     </section>
 
-    <section class="card chart-card">
-      <h2>Transactions per second</h2>
-      <canvas id="tps-chart" height="120"></canvas>
+    <section class="card chart-card" aria-labelledby="tps-chart-heading">
+      <h2 id="tps-chart-heading">Transactions per second</h2>
+      <div class="chart-wrap">
+        <canvas id="tps-chart" height="140" role="img" aria-label="Line chart of succeeded and failed transactions per second"></canvas>
+        <p id="tps-chart-fallback" class="chart-fallback" hidden>Chart.js unavailable — numeric gauges above still update.</p>
+      </div>
     </section>
 
-    <section class="card chart-card">
-      <h2>Fuel inventory</h2>
-      <canvas id="fuel-chart" height="120"></canvas>
+    <section class="card chart-card" aria-labelledby="fuel-chart-heading">
+      <h2 id="fuel-chart-heading">Fuel inventory</h2>
+      <div class="chart-wrap">
+        <canvas id="fuel-chart" height="140" role="img" aria-label="Line chart of fuel and reserve UTXO counts"></canvas>
+        <p id="fuel-chart-fallback" class="chart-fallback" hidden>Chart.js unavailable — balance cards still update.</p>
+      </div>
     </section>
 
-    <section class="card">
-      <h2>Fuel top-ups</h2>
-      <p class="hint">Detected when FuelKeeper increases fuel or reserve inventory (client-side fan-out).</p>
-      <ul id="topup-log" class="log"></ul>
+    <section class="card" aria-labelledby="topup-heading">
+      <h2 id="topup-heading">Fuel top-ups</h2>
+      <p class="hint">Logged when FuelKeeper increases fuel or reserve inventory (client-side fan-out).</p>
+      <ul id="topup-log" class="log" aria-live="polite" aria-relevant="additions"></ul>
+      <p id="topup-empty" class="empty-state">No top-ups yet. Fund the operator and wait for FuelKeeper rounds.</p>
     </section>
 
-    <section class="card">
-      <h2>Fund operator (WalletClient)</h2>
+    <section class="card" aria-labelledby="fund-heading">
+      <h2 id="fund-heading">Fund operator (WalletClient)</h2>
       <p class="hint">
         Uses browser <code>@bsv/sdk</code> <code>WalletClient</code> (MetaNet-compatible) to pay the operator BRC-29 deposit address.
         After payment, the dashboard internalizes into the default basket; FuelKeeper fans funds into reserve → fuel.
       </p>
       <div class="funding-box">
-        <div><span class="label">Deposit address</span><code id="fund-address">loading…</code></div>
-        <div class="controls">
-          <label>Satoshis <input type="number" id="fund-amount" min="1" value="100000" /></label>
-          <button id="btn-fund" class="primary">Pay with WalletClient</button>
-          <button id="btn-refresh-funding" class="ghost">Refresh address</button>
+        <div class="fund-address-row">
+          <span class="label" id="lbl-address">Deposit address</span>
+          <div class="address-actions">
+            <code id="fund-address" aria-labelledby="lbl-address">loading…</code>
+            <button type="button" id="btn-copy-address" class="ghost compact" disabled title="Copy deposit address" aria-label="Copy deposit address">Copy</button>
+          </div>
         </div>
-        <p id="fund-status" class="status"></p>
+        <div class="controls" role="group" aria-label="Funding controls">
+          <label for="fund-amount">Satoshis
+            <input type="number" id="fund-amount" min="1" step="1" value="100000" inputmode="numeric" />
+          </label>
+          <button type="button" id="btn-fund" class="primary">Pay with WalletClient</button>
+          <button type="button" id="btn-refresh-funding" class="ghost">Refresh address</button>
+        </div>
+        <details class="advanced">
+          <summary>Manual internalize (txid / hex)</summary>
+          <p class="hint">If WalletClient is unavailable, paste a txid (or atomic BEEF / raw tx hex) that pays the deposit address.</p>
+          <div class="controls">
+            <label class="grow" for="manual-txid">Txid
+              <input type="text" id="manual-txid" spellcheck="false" autocomplete="off" placeholder="64-char hex txid" />
+            </label>
+          </div>
+          <div class="controls">
+            <label class="grow" for="manual-hex">Atomic tx hex
+              <input type="text" id="manual-hex" spellcheck="false" autocomplete="off" placeholder="optional atomic BEEF or raw tx hex" />
+            </label>
+            <label for="manual-vout">vout
+              <input type="number" id="manual-vout" min="0" step="1" value="0" inputmode="numeric" />
+            </label>
+            <button type="button" id="btn-manual-internalize" class="ghost">Internalize</button>
+          </div>
+        </details>
+        <p id="fund-status" class="status" role="status" aria-live="polite"></p>
       </div>
     </section>
   </main>

--- a/cmd/throughput_dashboard/web/index.html
+++ b/cmd/throughput_dashboard/web/index.html
@@ -9,7 +9,11 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="/style.css" />
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+  <script
+    src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"
+    integrity="sha384-vsrfeLOOY6KuIYKDlmVH5UiBmgIdB1oEf7p01YgWHuqmOHfZr374+odEv96n9tNC"
+    crossorigin="anonymous"
+  ></script>
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
@@ -19,11 +23,11 @@
       <h1>Wallet Throughput Demo</h1>
       <p class="sub">Local infra · createAction OP_RETURN stream · FuelKeeper</p>
     </div>
-    <div class="top-meta" role="status" aria-live="polite">
-      <span id="conn-status" class="conn conn-pending" title="Event stream connection">
+    <div class="top-meta">
+      <output id="conn-status" class="conn conn-pending" title="Event stream connection" aria-live="polite">
         <span class="conn-dot" aria-hidden="true"></span>
         <span id="conn-label">Connecting…</span>
-      </span>
+      </output>
       <div id="network-badge" class="badge badge-warn" aria-label="Network">MAINNET</div>
     </div>
   </header>
@@ -54,7 +58,8 @@
           <span id="stat-iteration" class="value" aria-labelledby="lbl-iteration">0</span>
         </div>
       </div>
-      <div class="controls" role="group" aria-label="Stream controls">
+      <fieldset class="controls" aria-label="Stream controls">
+        <legend class="sr-only">Stream controls</legend>
         <label for="tps">TPS
           <input type="number" id="tps" min="1" max="10000" step="1" value="10" inputmode="numeric" aria-describedby="stream-hint" />
         </label>
@@ -63,8 +68,8 @@
         </label>
         <button type="button" id="btn-start" class="primary">Start stream</button>
         <button type="button" id="btn-stop" class="danger" disabled>Stop stream</button>
-      </div>
-      <p id="stream-status" class="status" role="status" aria-live="polite"></p>
+      </fieldset>
+      <output id="stream-status" class="status" aria-live="polite"></output>
       <p id="stream-hint" class="hint">Each action embeds OP_RETURN <code>sha256(iteration ‖ RFC3339Nano timestamp)</code>.</p>
     </section>
 
@@ -98,7 +103,7 @@
     <section class="card chart-card" aria-labelledby="tps-chart-heading">
       <h2 id="tps-chart-heading">Transactions per second</h2>
       <div class="chart-wrap">
-        <canvas id="tps-chart" height="140" role="img" aria-label="Line chart of succeeded and failed transactions per second"></canvas>
+        <canvas id="tps-chart" height="140" aria-label="Line chart of succeeded and failed transactions per second"></canvas>
         <p id="tps-chart-fallback" class="chart-fallback" hidden>Chart.js unavailable — numeric gauges above still update.</p>
       </div>
     </section>
@@ -106,7 +111,7 @@
     <section class="card chart-card" aria-labelledby="fuel-chart-heading">
       <h2 id="fuel-chart-heading">Fuel inventory</h2>
       <div class="chart-wrap">
-        <canvas id="fuel-chart" height="140" role="img" aria-label="Line chart of fuel and reserve UTXO counts"></canvas>
+        <canvas id="fuel-chart" height="140" aria-label="Line chart of fuel and reserve UTXO counts"></canvas>
         <p id="fuel-chart-fallback" class="chart-fallback" hidden>Chart.js unavailable — balance cards still update.</p>
       </div>
     </section>
@@ -132,13 +137,14 @@
             <button type="button" id="btn-copy-address" class="ghost compact" disabled title="Copy deposit address" aria-label="Copy deposit address">Copy</button>
           </div>
         </div>
-        <div class="controls" role="group" aria-label="Funding controls">
+        <fieldset class="controls" aria-label="Funding controls">
+          <legend class="sr-only">Funding controls</legend>
           <label for="fund-amount">Satoshis
             <input type="number" id="fund-amount" min="1" step="1" value="100000" inputmode="numeric" />
           </label>
           <button type="button" id="btn-fund" class="primary">Pay with WalletClient</button>
           <button type="button" id="btn-refresh-funding" class="ghost">Refresh address</button>
-        </div>
+        </fieldset>
         <details class="advanced">
           <summary>Manual internalize (txid / hex)</summary>
           <p class="hint">If WalletClient is unavailable, paste a txid (or atomic BEEF / raw tx hex) that pays the deposit address.</p>
@@ -157,7 +163,7 @@
             <button type="button" id="btn-manual-internalize" class="ghost">Internalize</button>
           </div>
         </details>
-        <p id="fund-status" class="status" role="status" aria-live="polite"></p>
+        <output id="fund-status" class="status" aria-live="polite"></output>
       </div>
     </section>
   </main>

--- a/cmd/throughput_dashboard/web/index.html
+++ b/cmd/throughput_dashboard/web/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Throughput Demo Dashboard</title>
+  <link rel="stylesheet" href="/style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+</head>
+<body>
+  <header class="top">
+    <div>
+      <h1>Wallet Throughput Demo</h1>
+      <p class="sub">Local infra · createAction OP_RETURN stream · FuelKeeper</p>
+    </div>
+    <div id="network-badge" class="badge badge-warn">MAINNET</div>
+  </header>
+
+  <section class="banner" id="mainnet-banner">
+    <strong>Mainnet live demo.</strong>
+    Real BSV and fees. Bind is localhost-only. Fund deliberately; start the stream only after fuel inventory is healthy.
+  </section>
+
+  <main class="grid">
+    <section class="card">
+      <h2>Event stream</h2>
+      <div class="row stats-row">
+        <div class="stat"><span class="label">State</span><span id="stream-state" class="value">stopped</span></div>
+        <div class="stat"><span class="label">Succeeded</span><span id="stat-succeeded" class="value">0</span></div>
+        <div class="stat"><span class="label">Failed</span><span id="stat-failed" class="value">0</span></div>
+        <div class="stat"><span class="label">Iteration</span><span id="stat-iteration" class="value">0</span></div>
+      </div>
+      <div class="controls">
+        <label>TPS <input type="number" id="tps" min="1" value="10" /></label>
+        <label>Workers <input type="number" id="workers" min="1" value="8" /></label>
+        <button id="btn-start" class="primary">Start stream</button>
+        <button id="btn-stop" class="danger" disabled>Stop stream</button>
+      </div>
+      <p class="hint">Each action embeds OP_RETURN <code>sha256(iteration ‖ RFC3339Nano timestamp)</code>.</p>
+    </section>
+
+    <section class="card">
+      <h2>Fuel &amp; balances</h2>
+      <div class="row stats-row">
+        <div class="stat"><span class="label">Default (sats)</span><span id="bal-default" class="value">—</span></div>
+        <div class="stat"><span class="label">Fuel UTXOs</span><span id="bal-fuel" class="value">—</span></div>
+        <div class="stat"><span class="label">Reserve UTXOs</span><span id="bal-reserve" class="value">—</span></div>
+        <div class="stat"><span class="label">Fuel runway (s)</span><span id="bal-runway" class="value">—</span></div>
+      </div>
+      <div class="row meta">
+        <span>Denomination: <strong id="meta-denom">—</strong> sats</span>
+        <span>Low / high water: <strong id="meta-water">—</strong></span>
+        <span>Storage: <strong id="meta-server">—</strong></span>
+      </div>
+    </section>
+
+    <section class="card chart-card">
+      <h2>Transactions per second</h2>
+      <canvas id="tps-chart" height="120"></canvas>
+    </section>
+
+    <section class="card chart-card">
+      <h2>Fuel inventory</h2>
+      <canvas id="fuel-chart" height="120"></canvas>
+    </section>
+
+    <section class="card">
+      <h2>Fuel top-ups</h2>
+      <p class="hint">Detected when FuelKeeper increases fuel or reserve inventory (client-side fan-out).</p>
+      <ul id="topup-log" class="log"></ul>
+    </section>
+
+    <section class="card">
+      <h2>Fund operator (WalletClient)</h2>
+      <p class="hint">
+        Uses browser <code>@bsv/sdk</code> <code>WalletClient</code> (MetaNet-compatible) to pay the operator BRC-29 deposit address.
+        After payment, the dashboard internalizes into the default basket; FuelKeeper fans funds into reserve → fuel.
+      </p>
+      <div class="funding-box">
+        <div><span class="label">Deposit address</span><code id="fund-address">loading…</code></div>
+        <div class="controls">
+          <label>Satoshis <input type="number" id="fund-amount" min="1" value="100000" /></label>
+          <button id="btn-fund" class="primary">Pay with WalletClient</button>
+          <button id="btn-refresh-funding" class="ghost">Refresh address</button>
+        </div>
+        <p id="fund-status" class="status"></p>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    go-wallet-toolbox · throughput strategy · demo dashboard
+  </footer>
+
+  <script type="module" src="/app.js"></script>
+</body>
+</html>

--- a/cmd/throughput_dashboard/web/style.css
+++ b/cmd/throughput_dashboard/web/style.css
@@ -140,9 +140,9 @@ body {
   margin: 0.75rem 2rem 1rem;
   padding: 0.85rem 1rem;
   border-radius: 10px;
-  background: rgba(255, 92, 122, 0.18);
-  border: 1px solid rgba(255, 92, 122, 0.45);
-  color: #ffe8ec;
+  background: #4a1522;
+  border: 1px solid rgba(255, 92, 122, 0.55);
+  color: #ffffff;
   font-size: 0.92rem;
 }
 
@@ -415,14 +415,14 @@ button.busy {
   text-transform: uppercase;
   padding: 0.12rem 0.4rem;
   border-radius: 4px;
-  background: rgba(255, 176, 32, 0.22);
-  color: #ffd28a;
-  border: 1px solid rgba(255, 176, 32, 0.45);
+  background: #5c3a08;
+  color: #fff6df;
+  border: 1px solid rgba(255, 176, 32, 0.55);
 }
 .log .tag.reserve {
-  background: rgba(139, 156, 255, 0.22);
-  color: #c8d2ff;
-  border-color: rgba(139, 156, 255, 0.45);
+  background: #1c2558;
+  color: #eef2ff;
+  border-color: rgba(139, 156, 255, 0.55);
 }
 .empty-state {
   margin: 0.5rem 0 0;

--- a/cmd/throughput_dashboard/web/style.css
+++ b/cmd/throughput_dashboard/web/style.css
@@ -140,10 +140,35 @@ body {
   margin: 0.75rem 2rem 1rem;
   padding: 0.85rem 1rem;
   border-radius: 10px;
-  background: rgba(255, 92, 122, 0.1);
-  border: 1px solid rgba(255, 92, 122, 0.35);
-  color: #ffd0d8;
+  background: rgba(255, 92, 122, 0.18);
+  border: 1px solid rgba(255, 92, 122, 0.45);
+  color: #ffe8ec;
   font-size: 0.92rem;
+}
+
+/* Visually hidden but available to assistive tech */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+fieldset.controls {
+  border: 0;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+}
+
+output.status,
+output.conn {
+  display: block;
 }
 
 .grid {
@@ -390,14 +415,14 @@ button.busy {
   text-transform: uppercase;
   padding: 0.12rem 0.4rem;
   border-radius: 4px;
-  background: rgba(255, 176, 32, 0.12);
-  color: var(--warn);
-  border: 1px solid rgba(255, 176, 32, 0.3);
+  background: rgba(255, 176, 32, 0.22);
+  color: #ffd28a;
+  border: 1px solid rgba(255, 176, 32, 0.45);
 }
 .log .tag.reserve {
-  background: rgba(139, 156, 255, 0.12);
-  color: #a8b5ff;
-  border-color: rgba(139, 156, 255, 0.3);
+  background: rgba(139, 156, 255, 0.22);
+  color: #c8d2ff;
+  border-color: rgba(139, 156, 255, 0.45);
 }
 .empty-state {
   margin: 0.5rem 0 0;

--- a/cmd/throughput_dashboard/web/style.css
+++ b/cmd/throughput_dashboard/web/style.css
@@ -1,0 +1,188 @@
+:root {
+  --bg: #0b1020;
+  --card: #121a2f;
+  --text: #e8eefc;
+  --muted: #93a0bf;
+  --accent: #3dd6c6;
+  --danger: #ff5c7a;
+  --warn: #ffb020;
+  --border: #243050;
+  --good: #4ade80;
+  font-family: "IBM Plex Sans", "Segoe UI", system-ui, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: radial-gradient(1200px 600px at 10% -10%, #1a2748 0%, var(--bg) 55%);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 1.5rem 2rem 0.5rem;
+}
+
+h1 { margin: 0 0 0.25rem; font-size: 1.6rem; letter-spacing: -0.02em; }
+.sub { margin: 0; color: var(--muted); }
+
+.badge {
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  font-size: 0.75rem;
+}
+.badge-warn { background: rgba(255, 176, 32, 0.15); color: var(--warn); border: 1px solid rgba(255, 176, 32, 0.4); }
+.badge-ok { background: rgba(74, 222, 128, 0.12); color: var(--good); border: 1px solid rgba(74, 222, 128, 0.35); }
+
+.banner {
+  margin: 0.75rem 2rem 1rem;
+  padding: 0.85rem 1rem;
+  border-radius: 10px;
+  background: rgba(255, 92, 122, 0.1);
+  border: 1px solid rgba(255, 92, 122, 0.35);
+  color: #ffd0d8;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  padding: 0 2rem 2rem;
+}
+
+.card {
+  background: linear-gradient(180deg, rgba(255,255,255,0.02), transparent 40%), var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem 1.15rem 1.15rem;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.25);
+}
+
+.card h2 {
+  margin: 0 0 0.85rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #c9d6f5;
+}
+
+.row { display: flex; flex-wrap: wrap; gap: 0.75rem; }
+.stats-row { justify-content: space-between; margin-bottom: 0.85rem; }
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  min-width: 5.5rem;
+}
+.stat .label, .label {
+  color: var(--muted);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.stat .value {
+  font-size: 1.25rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+  margin-top: 0.5rem;
+}
+
+label {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+input[type="number"] {
+  width: 5.5rem;
+  background: #0a1224;
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 0.4rem 0.5rem;
+}
+
+button {
+  border: 0;
+  border-radius: 9px;
+  padding: 0.55rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+button:disabled { opacity: 0.45; cursor: not-allowed; }
+button.primary { background: var(--accent); color: #04201d; }
+button.danger { background: var(--danger); color: #2a0410; }
+button.ghost {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+.hint { color: var(--muted); font-size: 0.85rem; line-height: 1.4; }
+.hint code, code {
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.82em;
+  color: #b8e7ff;
+}
+
+.meta {
+  margin-top: 0.75rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+  gap: 1rem;
+}
+
+.log {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 220px;
+  overflow: auto;
+}
+.log li {
+  padding: 0.45rem 0;
+  border-bottom: 1px solid rgba(36, 48, 80, 0.8);
+  font-size: 0.85rem;
+  color: #d5def5;
+}
+.log li time { color: var(--muted); margin-right: 0.5rem; font-variant-numeric: tabular-nums; }
+
+.funding-box code {
+  display: block;
+  margin-top: 0.25rem;
+  word-break: break-all;
+  background: #0a1224;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.55rem 0.65rem;
+}
+
+.status { min-height: 1.2rem; font-size: 0.9rem; }
+.status.ok { color: var(--good); }
+.status.err { color: var(--danger); }
+
+footer {
+  padding: 0 2rem 2rem;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+@media (max-width: 960px) {
+  .grid { grid-template-columns: 1fr; padding: 0 1rem 1.5rem; }
+  .top, .banner { margin-left: 1rem; margin-right: 1rem; padding-left: 0; padding-right: 0; }
+  .top { padding-top: 1rem; }
+}

--- a/cmd/throughput_dashboard/web/style.css
+++ b/cmd/throughput_dashboard/web/style.css
@@ -4,31 +4,81 @@
   --text: #e8eefc;
   --muted: #93a0bf;
   --accent: #3dd6c6;
+  --accent-hover: #5ee4d4;
   --danger: #ff5c7a;
+  --danger-hover: #ff7a93;
   --warn: #ffb020;
   --border: #243050;
+  --border-strong: #354872;
   --good: #4ade80;
+  --focus: #7dd3fc;
+  --input-bg: #0a1224;
+  --radius: 14px;
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
   font-family: "IBM Plex Sans", "Segoe UI", system-ui, sans-serif;
+  color-scheme: dark;
 }
 
 * { box-sizing: border-box; }
 
+html { scroll-behavior: smooth; }
+
 body {
   margin: 0;
-  background: radial-gradient(1200px 600px at 10% -10%, #1a2748 0%, var(--bg) 55%);
+  background:
+    radial-gradient(1200px 600px at 10% -10%, #1a2748 0%, transparent 55%),
+    radial-gradient(900px 500px at 100% 0%, rgba(61, 214, 198, 0.06) 0%, transparent 45%),
+    var(--bg);
   color: var(--text);
   min-height: 100vh;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+}
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0.75rem;
+  z-index: 100;
+  background: var(--accent);
+  color: #04201d;
+  padding: 0.5rem 0.9rem;
+  border-radius: 8px;
+  font-weight: 700;
+  text-decoration: none;
+}
+.skip-link:focus {
+  left: 0.75rem;
 }
 
 .top {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
+  gap: 1rem;
   padding: 1.5rem 2rem 0.5rem;
 }
 
-h1 { margin: 0 0 0.25rem; font-size: 1.6rem; letter-spacing: -0.02em; }
-.sub { margin: 0; color: var(--muted); }
+.brand h1 {
+  margin: 0 0 0.25rem;
+  font-size: clamp(1.25rem, 2.5vw, 1.6rem);
+  letter-spacing: -0.02em;
+  font-weight: 700;
+}
+
+.sub {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.top-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+  justify-content: flex-end;
+}
 
 .badge {
   padding: 0.4rem 0.75rem;
@@ -36,9 +86,55 @@ h1 { margin: 0 0 0.25rem; font-size: 1.6rem; letter-spacing: -0.02em; }
   font-weight: 700;
   letter-spacing: 0.06em;
   font-size: 0.75rem;
+  white-space: nowrap;
 }
-.badge-warn { background: rgba(255, 176, 32, 0.15); color: var(--warn); border: 1px solid rgba(255, 176, 32, 0.4); }
-.badge-ok { background: rgba(74, 222, 128, 0.12); color: var(--good); border: 1px solid rgba(74, 222, 128, 0.35); }
+.badge-warn {
+  background: rgba(255, 176, 32, 0.15);
+  color: var(--warn);
+  border: 1px solid rgba(255, 176, 32, 0.4);
+}
+.badge-ok {
+  background: rgba(74, 222, 128, 0.12);
+  color: var(--good);
+  border: 1px solid rgba(74, 222, 128, 0.35);
+}
+
+.conn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  background: rgba(10, 18, 36, 0.55);
+}
+.conn-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--muted);
+  flex-shrink: 0;
+}
+.conn-live .conn-dot {
+  background: var(--good);
+  box-shadow: 0 0 0 0 rgba(74, 222, 128, 0.55);
+  animation: pulse 1.8s ease-out infinite;
+}
+.conn-live { color: var(--good); border-color: rgba(74, 222, 128, 0.35); }
+.conn-pending .conn-dot { background: var(--warn); }
+.conn-pending { color: var(--warn); border-color: rgba(255, 176, 32, 0.35); }
+.conn-offline .conn-dot { background: var(--danger); }
+.conn-offline { color: var(--danger); border-color: rgba(255, 92, 122, 0.35); }
+
+@keyframes pulse {
+  0% { box-shadow: 0 0 0 0 rgba(74, 222, 128, 0.55); }
+  70% { box-shadow: 0 0 0 8px rgba(74, 222, 128, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(74, 222, 128, 0); }
+}
 
 .banner {
   margin: 0.75rem 2rem 1rem;
@@ -47,6 +143,7 @@ h1 { margin: 0 0 0.25rem; font-size: 1.6rem; letter-spacing: -0.02em; }
   background: rgba(255, 92, 122, 0.1);
   border: 1px solid rgba(255, 92, 122, 0.35);
   color: #ffd0d8;
+  font-size: 0.92rem;
 }
 
 .grid {
@@ -57,11 +154,12 @@ h1 { margin: 0 0 0.25rem; font-size: 1.6rem; letter-spacing: -0.02em; }
 }
 
 .card {
-  background: linear-gradient(180deg, rgba(255,255,255,0.02), transparent 40%), var(--card);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 40%), var(--card);
   border: 1px solid var(--border);
-  border-radius: 14px;
+  border-radius: var(--radius);
   padding: 1rem 1.15rem 1.15rem;
-  box-shadow: 0 10px 30px rgba(0,0,0,0.25);
+  box-shadow: var(--shadow);
+  min-width: 0;
 }
 
 .card h2 {
@@ -69,70 +167,159 @@ h1 { margin: 0 0 0.25rem; font-size: 1.6rem; letter-spacing: -0.02em; }
   font-size: 1rem;
   font-weight: 600;
   color: #c9d6f5;
+  letter-spacing: 0.01em;
 }
 
-.row { display: flex; flex-wrap: wrap; gap: 0.75rem; }
-.stats-row { justify-content: space-between; margin-bottom: 0.85rem; }
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+.stats-row {
+  justify-content: space-between;
+  margin-bottom: 0.85rem;
+  gap: 0.85rem 1rem;
+}
 
 .stat {
   display: flex;
   flex-direction: column;
   min-width: 5.5rem;
+  gap: 0.15rem;
 }
 .stat .label, .label {
   color: var(--muted);
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
+  font-weight: 500;
 }
 .stat .value {
   font-size: 1.25rem;
   font-variant-numeric: tabular-nums;
   font-weight: 600;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+}
+.value-good { color: var(--good); }
+.value-bad { color: var(--danger); }
+.value-warn { color: var(--warn); }
+
+.state-pill {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  font-size: 0.85rem !important;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  text-transform: lowercase;
+}
+.state-running {
+  color: var(--good) !important;
+  background: rgba(74, 222, 128, 0.1);
+  border-color: rgba(74, 222, 128, 0.35);
+}
+.state-stopped {
+  color: var(--muted) !important;
+  background: rgba(147, 160, 191, 0.08);
 }
 
 .controls {
   display: flex;
   flex-wrap: wrap;
   gap: 0.6rem;
-  align-items: center;
+  align-items: flex-end;
   margin-top: 0.5rem;
 }
 
 label {
   display: flex;
-  gap: 0.4rem;
-  align-items: center;
+  flex-direction: column;
+  gap: 0.3rem;
   color: var(--muted);
-  font-size: 0.9rem;
+  font-size: 0.8rem;
+  font-weight: 500;
 }
+label.grow { flex: 1 1 12rem; min-width: 0; }
 
-input[type="number"] {
-  width: 5.5rem;
-  background: #0a1224;
+input[type="number"],
+input[type="text"] {
+  width: 100%;
+  min-width: 5.5rem;
+  background: var(--input-bg);
   border: 1px solid var(--border);
   color: var(--text);
   border-radius: 8px;
-  padding: 0.4rem 0.5rem;
+  padding: 0.45rem 0.55rem;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.9rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+input[type="number"] { width: 5.5rem; }
+input::placeholder { color: #5d6b8f; }
+input:hover { border-color: var(--border-strong); }
+input:focus {
+  outline: none;
+  border-color: var(--focus);
+  box-shadow: 0 0 0 3px rgba(125, 211, 252, 0.18);
+}
+input:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 button {
   border: 0;
   border-radius: 9px;
-  padding: 0.55rem 0.9rem;
+  padding: 0.55rem 0.95rem;
   font-weight: 600;
+  font-size: 0.9rem;
+  font-family: inherit;
   cursor: pointer;
+  transition: background 0.15s ease, opacity 0.15s ease, transform 0.05s ease;
+  white-space: nowrap;
 }
+button:active:not(:disabled) { transform: translateY(1px); }
 button:disabled { opacity: 0.45; cursor: not-allowed; }
-button.primary { background: var(--accent); color: #04201d; }
-button.danger { background: var(--danger); color: #2a0410; }
+button:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+button.primary {
+  background: var(--accent);
+  color: #04201d;
+}
+button.primary:hover:not(:disabled) { background: var(--accent-hover); }
+button.danger {
+  background: var(--danger);
+  color: #2a0410;
+}
+button.danger:hover:not(:disabled) { background: var(--danger-hover); }
 button.ghost {
   background: transparent;
   color: var(--text);
   border: 1px solid var(--border);
 }
+button.ghost:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  background: rgba(255, 255, 255, 0.03);
+}
+button.compact {
+  padding: 0.35rem 0.65rem;
+  font-size: 0.8rem;
+  align-self: stretch;
+}
+button.busy {
+  position: relative;
+  pointer-events: none;
+}
 
-.hint { color: var(--muted); font-size: 0.85rem; line-height: 1.4; }
+.hint {
+  color: var(--muted);
+  font-size: 0.85rem;
+  line-height: 1.45;
+  margin: 0.65rem 0 0;
+}
 .hint code, code {
   font-family: "IBM Plex Mono", ui-monospace, monospace;
   font-size: 0.82em;
@@ -143,37 +330,140 @@ button.ghost {
   margin-top: 0.75rem;
   color: var(--muted);
   font-size: 0.85rem;
-  gap: 1rem;
+  gap: 0.75rem 1.25rem;
+}
+.meta strong {
+  color: #d5def5;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.chart-wrap {
+  position: relative;
+  min-height: 8rem;
+}
+.chart-fallback {
+  margin: 0.5rem 0 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+  padding: 0.75rem;
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  background: rgba(10, 18, 36, 0.4);
 }
 
 .log {
   list-style: none;
-  margin: 0;
+  margin: 0.5rem 0 0;
   padding: 0;
-  max-height: 220px;
+  max-height: 240px;
   overflow: auto;
+  border: 1px solid rgba(36, 48, 80, 0.7);
+  border-radius: 10px;
+  background: rgba(10, 18, 36, 0.35);
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
 }
+.log:empty { display: none; }
 .log li {
-  padding: 0.45rem 0;
+  padding: 0.55rem 0.75rem;
   border-bottom: 1px solid rgba(36, 48, 80, 0.8);
   font-size: 0.85rem;
   color: #d5def5;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.55rem;
+  align-items: baseline;
 }
-.log li time { color: var(--muted); margin-right: 0.5rem; font-variant-numeric: tabular-nums; }
+.log li:last-child { border-bottom: 0; }
+.log li time {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 0.8rem;
+  flex-shrink: 0;
+}
+.log .tag {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.12rem 0.4rem;
+  border-radius: 4px;
+  background: rgba(255, 176, 32, 0.12);
+  color: var(--warn);
+  border: 1px solid rgba(255, 176, 32, 0.3);
+}
+.log .tag.reserve {
+  background: rgba(139, 156, 255, 0.12);
+  color: #a8b5ff;
+  border-color: rgba(139, 156, 255, 0.3);
+}
+.empty-state {
+  margin: 0.5rem 0 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+  padding: 0.85rem 0.9rem;
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  background: rgba(10, 18, 36, 0.25);
+}
+.empty-state.hidden { display: none; }
 
+.funding-box {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.fund-address-row .label { display: block; margin-bottom: 0.3rem; }
+.address-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+}
 .funding-box code {
   display: block;
-  margin-top: 0.25rem;
+  flex: 1;
+  min-width: 0;
   word-break: break-all;
-  background: #0a1224;
+  background: var(--input-bg);
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 0.55rem 0.65rem;
+  font-size: 0.82rem;
+  line-height: 1.4;
 }
 
-.status { min-height: 1.2rem; font-size: 0.9rem; }
+.advanced {
+  margin-top: 0.15rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.35rem 0.75rem 0.75rem;
+  background: rgba(10, 18, 36, 0.25);
+}
+.advanced summary {
+  cursor: pointer;
+  color: var(--muted);
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.45rem 0;
+  user-select: none;
+}
+.advanced summary:hover { color: var(--text); }
+.advanced[open] summary { color: #c9d6f5; }
+.advanced .hint { margin-top: 0.25rem; }
+.advanced .controls { margin-top: 0.55rem; }
+.advanced input[type="text"] { min-width: 0; width: 100%; }
+.advanced input[type="number"] { width: 4.5rem; }
+
+.status {
+  min-height: 1.25rem;
+  font-size: 0.9rem;
+  margin: 0.35rem 0 0;
+}
 .status.ok { color: var(--good); }
 .status.err { color: var(--danger); }
+.status.info { color: #b8e7ff; }
 
 footer {
   padding: 0 2rem 2rem;
@@ -182,7 +472,35 @@ footer {
 }
 
 @media (max-width: 960px) {
-  .grid { grid-template-columns: 1fr; padding: 0 1rem 1.5rem; }
-  .top, .banner { margin-left: 1rem; margin-right: 1rem; padding-left: 0; padding-right: 0; }
-  .top { padding-top: 1rem; }
+  .grid {
+    grid-template-columns: 1fr;
+    padding: 0 1rem 1.5rem;
+  }
+  .top {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 1rem 1rem 0.35rem;
+  }
+  .top-meta { justify-content: space-between; }
+  .banner {
+    margin: 0.65rem 1rem 0.85rem;
+  }
+  footer { padding: 0 1rem 1.5rem; }
+  .stats-row { gap: 0.75rem; }
+  .stat { min-width: calc(50% - 0.5rem); }
+  .address-actions { flex-direction: column; }
+  button.compact { align-self: flex-start; }
+}
+
+@media (max-width: 480px) {
+  .controls label { flex: 1 1 auto; }
+  input[type="number"] { width: 100%; }
+  .controls button { flex: 1 1 auto; text-align: center; }
+  .stat .value { font-size: 1.1rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .conn-live .conn-dot { animation: none; }
+  button { transition: none; }
+  html { scroll-behavior: auto; }
 }

--- a/docker-compose.throughput-dashboard.yaml
+++ b/docker-compose.throughput-dashboard.yaml
@@ -1,0 +1,65 @@
+# Mainnet throughput demo: Postgres + infra (throughput) + dashboard UI
+#
+#   export PRIVATE_KEY=<operator-wallet-hex>
+#   docker compose -f docker-compose.throughput-dashboard.yaml up --build
+#
+# UI: http://127.0.0.1:8200
+# Storage (host): http://127.0.0.1:8101
+
+services:
+  db:
+    image: postgres:17-alpine
+    volumes:
+      - db-data-throughput-dashboard:/var/lib/postgresql/data:Z
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+      - POSTGRES_DB=storage
+    ports:
+      - "127.0.0.1:5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d storage"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  infra:
+    build:
+      context: .
+      dockerfile: Dockerfile.dashboard
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "8101:8100"
+    volumes:
+      - ./infra-config-docker-throughput-mainnet.yaml:/app/infra-config-throughput.yaml:ro
+    environment:
+      # Optional overrides for mainnet services
+      - INFRA_WALLET_SERVICES_ARC_TOKEN=${INFRA_WALLET_SERVICES_ARC_TOKEN:-}
+      - INFRA_WALLET_SERVICES_WHATS_ON_CHAIN_API_KEY=${INFRA_WALLET_SERVICES_WHATS_ON_CHAIN_API_KEY:-}
+    restart: unless-stopped
+
+  dashboard:
+    build:
+      context: .
+      dockerfile: Dockerfile.dashboard
+    depends_on:
+      - infra
+    entrypoint: ["/app/dashboard"]
+    ports:
+      - "127.0.0.1:8200:8200"
+    environment:
+      - SERVER_URL=http://infra:8100
+      - BSV_NETWORK=main
+      - PRIVATE_KEY=${PRIVATE_KEY:?set PRIVATE_KEY for dashboard}
+      - HTTP_ADDR=0.0.0.0:8200
+      - TPS=${TPS:-10}
+      - WORKERS=${WORKERS:-8}
+      - ORIGINATOR=${ORIGINATOR:-throughput-dashboard.local}
+    restart: unless-stopped
+
+volumes:
+  db-data-throughput-dashboard:
+    driver: local

--- a/docker-compose.throughput-dashboard.yaml
+++ b/docker-compose.throughput-dashboard.yaml
@@ -1,10 +1,16 @@
 # Mainnet throughput demo: Postgres + infra (throughput) + dashboard UI
 #
 #   export PRIVATE_KEY=<operator-wallet-hex>
+#   # optional mainnet ARC token:
+#   # export INFRA_WALLET_SERVICES_ARC_TOKEN=...
 #   docker compose -f docker-compose.throughput-dashboard.yaml up --build
 #
-# UI: http://127.0.0.1:8200
-# Storage (host): http://127.0.0.1:8101
+# UI:            http://127.0.0.1:8200
+# Storage host:  http://127.0.0.1:8101
+# Postgres host: 127.0.0.1:5433
+#
+# PRIVATE_KEY is required (compose fails interpolation if unset).
+# WARNING: Real mainnet funds and fees.
 
 services:
   db:
@@ -32,11 +38,11 @@ services:
       db:
         condition: service_healthy
     ports:
-      - "8101:8100"
+      - "127.0.0.1:8101:8100"
     volumes:
       - ./infra-config-docker-throughput-mainnet.yaml:/app/infra-config-throughput.yaml:ro
     environment:
-      # Optional overrides for mainnet services
+      # Optional overrides for mainnet services (yaml ships placeholder ARC token)
       - INFRA_WALLET_SERVICES_ARC_TOKEN=${INFRA_WALLET_SERVICES_ARC_TOKEN:-}
       - INFRA_WALLET_SERVICES_WHATS_ON_CHAIN_API_KEY=${INFRA_WALLET_SERVICES_WHATS_ON_CHAIN_API_KEY:-}
     restart: unless-stopped
@@ -57,6 +63,7 @@ services:
       - HTTP_ADDR=0.0.0.0:8200
       - TPS=${TPS:-10}
       - WORKERS=${WORKERS:-8}
+      - SAMPLE_SECONDS=${SAMPLE_SECONDS:-1}
       - ORIGINATOR=${ORIGINATOR:-throughput-dashboard.local}
     restart: unless-stopped
 

--- a/docs/throughput-dashboard.md
+++ b/docs/throughput-dashboard.md
@@ -4,7 +4,7 @@ Demo control plane for observing **throughput-mode** wallet infrastructure:
 
 - Local Postgres + `infra_throughput` with `utxo_management.strategy: throughput`
 - Operator wallet client (holds keys) + **FuelKeeper**
-- Controllable createAction **event stream** with per-action OP_RETURN  
+- Controllable createAction **event stream** with per-action OP_RETURN
   `sha256(iteration ‖ RFC3339Nano timestamp)`
 - Web UI: start/stop stream, TPS chart, fuel/reserve/default balances, top-up feed
 - Browser **`@bsv/sdk` WalletClient** funding into the operator deposit address

--- a/docs/throughput-dashboard.md
+++ b/docs/throughput-dashboard.md
@@ -1,0 +1,122 @@
+# Throughput Demo Dashboard (Mainnet)
+
+Demo control plane for observing **throughput-mode** wallet infrastructure:
+
+- Local Postgres + `infra_throughput` with `utxo_management.strategy: throughput`
+- Operator wallet client (holds keys) + **FuelKeeper**
+- Controllable createAction **event stream** with per-action OP_RETURN  
+  `sha256(iteration ‖ RFC3339Nano timestamp)`
+- Web UI: start/stop stream, TPS chart, fuel/reserve/default balances, top-up feed
+- Browser **`@bsv/sdk` WalletClient** funding into the operator deposit address
+
+> **Mainnet.** Real BSV and fees. Dashboard defaults to `BSV_NETWORK=main` and binds the UI to localhost.
+
+Related:
+
+- Throughput UTXO design: [`examples/throughput_mode/throughput-mode.md`](../examples/throughput_mode/throughput-mode.md)
+- Fixed-payload live-test loadgen stack: [`docs/throughput-docker.md`](throughput-docker.md)
+
+## Architecture
+
+```
+Browser (http://127.0.0.1:8200)
+  └─ cmd/throughput_dashboard
+       ├─ FuelKeeper (default → reserve → fuel)
+       ├─ StreamController (rate-limited createAction)
+       └─ storage client ──► infra_throughput (:8101 host / :8100 compose)
+                                  └─ Postgres
+```
+
+The storage server never holds operator keys. Fan-out top-ups are signed in the dashboard process.
+
+## Quick start (Docker)
+
+```bash
+# Operator wallet private key (hex) — never commit this
+export PRIVATE_KEY=<hex-private-key>
+
+# Recommended for reliable mainnet broadcast:
+# export INFRA_WALLET_SERVICES_ARC_TOKEN=<mainnet-arc-token>
+# export INFRA_WALLET_SERVICES_WHATS_ON_CHAIN_API_KEY=<optional>
+
+docker compose -f docker-compose.throughput-dashboard.yaml up --build
+```
+
+Open **http://127.0.0.1:8200**
+
+| Service | Host access |
+|---|---|
+| Dashboard UI | `http://127.0.0.1:8200` |
+| Storage RPC | `http://127.0.0.1:8101` |
+| Postgres | `127.0.0.1:5433` |
+
+## Local run (infra already up)
+
+If the throughput infra is already listening on `8101`:
+
+```bash
+export PRIVATE_KEY=<hex>
+export SERVER_URL=http://127.0.0.1:8101
+export BSV_NETWORK=main
+go run ./cmd/throughput_dashboard
+```
+
+## Funding with WalletClient
+
+1. Install / unlock a MetaNet-compatible browser wallet that implements `@bsv/sdk` `WalletClient`.
+2. On the **Fund operator** panel, set satoshis (default 100 000) and click **Pay with WalletClient**.
+3. The UI pays the operator BRC-29 deposit address, then `POST /api/funding/internalize` credits the **default** basket.
+4. FuelKeeper (every ~10s when below low water) fans default → reserve chunks → exact-denomination fuel.
+
+Until fuel is available, createActions may fall back to slower default-basket funding or fail with not-enough-funds — both are counted in the UI.
+
+## Stream payload
+
+Each createAction has a single 0-sat output:
+
+```
+OP_RETURN <32-byte sha256( strconv(iteration) + time.RFC3339Nano )>
+```
+
+`AcceptDelayedBroadcast` is enabled for high-rate demos.
+
+## Environment (dashboard)
+
+| Variable | Default | Notes |
+|---|---|---|
+| `PRIVATE_KEY` | *(required)* | Operator hex key |
+| `SERVER_URL` | `http://127.0.0.1:8101` | Compose: `http://infra:8100` |
+| `BSV_NETWORK` | `main` | Mainnet-first |
+| `HTTP_ADDR` | `127.0.0.1:8200` | Compose binds `0.0.0.0:8200` published to localhost only |
+| `TPS` | `10` | Safer mainnet default (raise when funded) |
+| `WORKERS` | `8` | Concurrent createActions |
+| `SAMPLE_SECONDS` | `1` | Gauge / TPS sample interval |
+| `ORIGINATOR` | `throughput-dashboard.local` | createAction originator |
+
+## Safety checklist
+
+- [ ] You intend to use **mainnet** and accept fee burn (~denomination sats per successful action plus fan-out overhead).
+- [ ] `PRIVATE_KEY` is funded and not checked into git.
+- [ ] UI is only exposed on localhost (compose publishes `127.0.0.1:8200`).
+- [ ] Start the stream at low TPS first; confirm fuel inventory is rising after funding.
+- [ ] ARC / indexer credentials are valid for mainnet if you need reliable broadcast and internalize-by-txid.
+
+## API sketch
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/api/status` | Network, last tick, recent events |
+| `POST` | `/api/stream/start` | `{ "tps"?, "workers"? }` |
+| `POST` | `/api/stream/stop` | Stop stream (FuelKeeper keeps running) |
+| `GET` | `/api/events` | SSE: `tick`, `topup` |
+| `GET` | `/api/funding` | Deposit address + locking script hex |
+| `POST` | `/api/funding/internalize` | `{ atomic_tx_hex? , txid? , output_index? }` |
+
+## Denomination
+
+Dashboard and server share the live-test OP_RETURN profile:
+
+- `expected_tx_size_bytes: 200`, fee `100 sat/kb`, `expected_output_satoshis: 0`
+- Derived denomination **20 sats** (must match FuelKeeper leaf shape)
+
+See `config.DemoThroughput()` and `infra-config-docker-throughput-mainnet.yaml`.

--- a/docs/throughput-dashboard.md
+++ b/docs/throughput-dashboard.md
@@ -16,6 +16,22 @@ Related:
 - Throughput UTXO design: [`examples/throughput_mode/throughput-mode.md`](../examples/throughput_mode/throughput-mode.md)
 - Fixed-payload live-test loadgen stack: [`docs/throughput-docker.md`](throughput-docker.md)
 
+## Mainnet profile
+
+Matches the live-test OP_RETURN shape; fee and denomination must stay aligned with
+`config.DemoThroughput()` and `infra-config-docker-throughput-mainnet.yaml`.
+
+| Setting | Value |
+|---|---|
+| Network | `main` |
+| UTXO strategy | `throughput` |
+| Fee model | `sat/kb` value `100` |
+| Expected tx size | `200` bytes |
+| Expected output satoshis | `0` (data-only OP_RETURN) |
+| Target TPS (server pool sizing) | `1000` |
+| Derived fuel denomination | **20 sats** |
+| Dashboard default stream TPS | `10` (raise only when funded) |
+
 ## Architecture
 
 ```
@@ -29,12 +45,27 @@ Browser (http://127.0.0.1:8200)
 
 The storage server never holds operator keys. Fan-out top-ups are signed in the dashboard process.
 
-## Quick start (Docker)
+| Service | Role | Host access |
+|---|---|---|
+| `db` | Postgres 17 (`db-data-throughput-dashboard`) | `127.0.0.1:5433` |
+| `infra` | `cmd/infra_throughput` + mainnet throughput yaml | `http://127.0.0.1:8101` |
+| `dashboard` | UI + FuelKeeper + stream control | `http://127.0.0.1:8200` |
+
+## Operator runbook
+
+Follow this order: **fund → FuelKeeper → start stream**.
+
+### 1. Prerequisites
+
+1. Docker Compose v2 and a funded **operator** wallet private key (hex). Never commit keys.
+2. Optional but recommended for reliable mainnet broadcast / internalize:
+   - `INFRA_WALLET_SERVICES_ARC_TOKEN` — mainnet ARC token
+   - `INFRA_WALLET_SERVICES_WHATS_ON_CHAIN_API_KEY` — if you use WOC-backed paths
+
+### 2. Start the stack
 
 ```bash
-# Operator wallet private key (hex) — never commit this
 export PRIVATE_KEY=<hex-private-key>
-
 # Recommended for reliable mainnet broadcast:
 # export INFRA_WALLET_SERVICES_ARC_TOKEN=<mainnet-arc-token>
 # export INFRA_WALLET_SERVICES_WHATS_ON_CHAIN_API_KEY=<optional>
@@ -42,13 +73,50 @@ export PRIVATE_KEY=<hex-private-key>
 docker compose -f docker-compose.throughput-dashboard.yaml up --build
 ```
 
-Open **http://127.0.0.1:8200**
+Open **http://127.0.0.1:8200**. Compose fails fast if `PRIVATE_KEY` is unset.
 
-| Service | Host access |
-|---|---|
-| Dashboard UI | `http://127.0.0.1:8200` |
-| Storage RPC | `http://127.0.0.1:8101` |
-| Postgres | `127.0.0.1:5433` |
+### 3. Fund the operator (default basket)
+
+1. Install / unlock a MetaNet-compatible browser wallet that implements `@bsv/sdk` `WalletClient`.
+2. On the **Fund operator** panel, set satoshis (default 100 000) and click **Pay with WalletClient**.
+3. The UI pays the operator BRC-29 deposit address, then `POST /api/funding/internalize` credits the **default** basket.
+4. Alternate path: pay the deposit address externally, then internalize via atomic tx hex or `{ txid, output_index }` on the funding API.
+
+### 4. Wait for FuelKeeper
+
+FuelKeeper runs as soon as the dashboard process starts (every ~10s when below low water):
+
+1. Fans **default → reserve** chunks
+2. Mints exact-denomination **fuel** UTXOs for createAction
+
+Watch the UI balances and top-up feed. Until fuel is available, createActions may fall back to slower default-basket funding or fail with not-enough-funds — both are counted in the UI.
+
+Do **not** start a high-rate stream until fuel inventory is rising.
+
+### 5. Start the stream
+
+1. Confirm fuel/reserve gauges look healthy.
+2. Start at low TPS (compose default is `10`).
+3. Click **Start stream** (or `POST /api/stream/start` with optional `{ "tps", "workers" }`).
+4. Confirm TPS chart and event feed move; stop anytime with **Stop stream** (FuelKeeper keeps running).
+
+Each createAction has a single 0-sat output:
+
+```
+OP_RETURN <32-byte sha256( strconv(iteration) + time.RFC3339Nano )>
+```
+
+`AcceptDelayedBroadcast` is enabled for high-rate demos.
+
+### 6. Stop / tear down
+
+```bash
+# Ctrl-C if attached, or:
+docker compose -f docker-compose.throughput-dashboard.yaml down
+
+# Also drop the Postgres volume (destroys demo DB state):
+docker compose -f docker-compose.throughput-dashboard.yaml down -v
+```
 
 ## Local run (infra already up)
 
@@ -60,25 +128,6 @@ export SERVER_URL=http://127.0.0.1:8101
 export BSV_NETWORK=main
 go run ./cmd/throughput_dashboard
 ```
-
-## Funding with WalletClient
-
-1. Install / unlock a MetaNet-compatible browser wallet that implements `@bsv/sdk` `WalletClient`.
-2. On the **Fund operator** panel, set satoshis (default 100 000) and click **Pay with WalletClient**.
-3. The UI pays the operator BRC-29 deposit address, then `POST /api/funding/internalize` credits the **default** basket.
-4. FuelKeeper (every ~10s when below low water) fans default → reserve chunks → exact-denomination fuel.
-
-Until fuel is available, createActions may fall back to slower default-basket funding or fail with not-enough-funds — both are counted in the UI.
-
-## Stream payload
-
-Each createAction has a single 0-sat output:
-
-```
-OP_RETURN <32-byte sha256( strconv(iteration) + time.RFC3339Nano )>
-```
-
-`AcceptDelayedBroadcast` is enabled for high-rate demos.
 
 ## Environment (dashboard)
 
@@ -93,13 +142,23 @@ OP_RETURN <32-byte sha256( strconv(iteration) + time.RFC3339Nano )>
 | `SAMPLE_SECONDS` | `1` | Gauge / TPS sample interval |
 | `ORIGINATOR` | `throughput-dashboard.local` | createAction originator |
 
+Infra (compose) also accepts:
+
+| Variable | Notes |
+|---|---|
+| `INFRA_WALLET_SERVICES_ARC_TOKEN` | Overrides mainnet ARC token in yaml |
+| `INFRA_WALLET_SERVICES_WHATS_ON_CHAIN_API_KEY` | Optional WOC API key |
+| `POSTGRES_PASSWORD` | Defaults to `postgres` (local compose only) |
+
 ## Safety checklist
 
 - [ ] You intend to use **mainnet** and accept fee burn (~denomination sats per successful action plus fan-out overhead).
 - [ ] `PRIVATE_KEY` is funded and not checked into git.
 - [ ] UI is only exposed on localhost (compose publishes `127.0.0.1:8200`).
+- [ ] Storage RPC on the host is localhost-only (`127.0.0.1:8101`); Postgres is `127.0.0.1:5433`.
 - [ ] Start the stream at low TPS first; confirm fuel inventory is rising after funding.
 - [ ] ARC / indexer credentials are valid for mainnet if you need reliable broadcast and internalize-by-txid.
+- [ ] You know how to stop the stream and `docker compose ... down` before leaving the demo unattended.
 
 ## API sketch
 
@@ -112,11 +171,16 @@ OP_RETURN <32-byte sha256( strconv(iteration) + time.RFC3339Nano )>
 | `GET` | `/api/funding` | Deposit address + locking script hex |
 | `POST` | `/api/funding/internalize` | `{ atomic_tx_hex? , txid? , output_index? }` |
 
-## Denomination
+## Packaging files
 
-Dashboard and server share the live-test OP_RETURN profile:
+| File | Purpose |
+|---|---|
+| `Dockerfile.dashboard` | Builds `infra_throughput` + `throughput_dashboard` |
+| `docker-compose.throughput-dashboard.yaml` | db + infra + dashboard |
+| `infra-config-docker-throughput-mainnet.yaml` | Mainnet throughput server config |
 
-- `expected_tx_size_bytes: 200`, fee `100 sat/kb`, `expected_output_satoshis: 0`
-- Derived denomination **20 sats** (must match FuelKeeper leaf shape)
+Validate compose interpolation without starting containers:
 
-See `config.DemoThroughput()` and `infra-config-docker-throughput-mainnet.yaml`.
+```bash
+PRIVATE_KEY=00 docker compose -f docker-compose.throughput-dashboard.yaml config
+```

--- a/docs/throughput-docker.md
+++ b/docs/throughput-docker.md
@@ -89,6 +89,6 @@ compose from restarting a finished or failed loadgen.
   for fan-out into the `fuel` basket before measuring steady-state rate.
 - Throughput mode design: `examples/throughput_mode/throughput-mode.md` and
   `docs/superpowers/specs/2026-07-20-throughput-docker-live-test-design.md`.
-- **Mainnet demo dashboard** (start/stop stream UI, WalletClient funding):  
-  [`docs/throughput-dashboard.md`](throughput-dashboard.md) and  
+- **Mainnet demo dashboard** (start/stop stream UI, WalletClient funding, fund → FuelKeeper → stream runbook):  
+  [`docs/throughput-dashboard.md`](throughput-dashboard.md) ·  
   `docker compose -f docker-compose.throughput-dashboard.yaml up --build`.

--- a/docs/throughput-docker.md
+++ b/docs/throughput-docker.md
@@ -89,6 +89,6 @@ compose from restarting a finished or failed loadgen.
   for fan-out into the `fuel` basket before measuring steady-state rate.
 - Throughput mode design: `examples/throughput_mode/throughput-mode.md` and
   `docs/superpowers/specs/2026-07-20-throughput-docker-live-test-design.md`.
-- **Mainnet demo dashboard** (start/stop stream UI, WalletClient funding, fund → FuelKeeper → stream runbook):  
-  [`docs/throughput-dashboard.md`](throughput-dashboard.md) ·  
+- **Mainnet demo dashboard** (start/stop stream UI, WalletClient funding, fund → FuelKeeper → stream runbook):
+  [`docs/throughput-dashboard.md`](throughput-dashboard.md) ·
   `docker compose -f docker-compose.throughput-dashboard.yaml up --build`.

--- a/docs/throughput-docker.md
+++ b/docs/throughput-docker.md
@@ -89,3 +89,6 @@ compose from restarting a finished or failed loadgen.
   for fan-out into the `fuel` basket before measuring steady-state rate.
 - Throughput mode design: `examples/throughput_mode/throughput-mode.md` and
   `docs/superpowers/specs/2026-07-20-throughput-docker-live-test-design.md`.
+- **Mainnet demo dashboard** (start/stop stream UI, WalletClient funding):  
+  [`docs/throughput-dashboard.md`](throughput-dashboard.md) and  
+  `docker compose -f docker-compose.throughput-dashboard.yaml up --build`.

--- a/infra-config-docker-throughput-mainnet.yaml
+++ b/infra-config-docker-throughput-mainnet.yaml
@@ -1,14 +1,24 @@
 # =============================================================================
-# Docker Compose configuration for MAINNET throughput demo dashboard stack
+# MAINNET throughput demo — storage server config (dashboard stack)
 # =============================================================================
+# Loaded by cmd/infra_throughput as infra-config-throughput.yaml (cwd / volume).
+#
+# Locked demo profile (must match dashboard config.DemoThroughput()):
+#   bsv_network: main
+#   utxo_management.strategy: throughput
+#   fee_model: sat/kb value 100
+#   expected_tx_size_bytes: 200
+#   expected_output_satoshis: 0  → derived denomination 20 sats
+#   target_tps: 1000            (pool sizing; stream default TPS is lower)
+#
 # Usage:
 #   export PRIVATE_KEY=<operator-hex>
 #   # optional mainnet ARC token override:
 #   # export INFRA_WALLET_SERVICES_ARC_TOKEN=...
 #   docker compose -f docker-compose.throughput-dashboard.yaml up -d --build
 #
+# Operator runbook: docs/throughput-dashboard.md
 # WARNING: Real mainnet funds and fees. Use only for intentional demos.
-# Pairs with Dockerfile.dashboard and cmd/throughput_dashboard.
 # =============================================================================
 
 bsv_network: main

--- a/infra-config-docker-throughput-mainnet.yaml
+++ b/infra-config-docker-throughput-mainnet.yaml
@@ -1,0 +1,213 @@
+# =============================================================================
+# Docker Compose configuration for MAINNET throughput demo dashboard stack
+# =============================================================================
+# Usage:
+#   export PRIVATE_KEY=<operator-hex>
+#   # optional mainnet ARC token override:
+#   # export INFRA_WALLET_SERVICES_ARC_TOKEN=...
+#   docker compose -f docker-compose.throughput-dashboard.yaml up -d --build
+#
+# WARNING: Real mainnet funds and fees. Use only for intentional demos.
+# Pairs with Dockerfile.dashboard and cmd/throughput_dashboard.
+# =============================================================================
+
+bsv_network: main
+
+name: go-storage-server-throughput-mainnet
+
+# --- Server Identity (required) ---
+# Development key for local Docker only. For a durable deployment generate your own:
+#   go run cmd/infra_config_gen/main.go -k -o infra-config.yaml
+server_private_key: dc745c57de627a6d3a3ca549e0f9fb6b8f779108a1fe6fe290cc4df3461125d6
+
+# --- Database (PostgreSQL via docker-compose 'db' service) ---
+db:
+  engine: postgres
+  max_connection_idle_time: 6m0s
+  max_connection_time: 1m0s
+  max_idle_connections: 10
+  max_open_connections: 50
+
+  postgresql:
+    host: db
+    port: "5432"
+    user: postgres
+    # Local docker-compose Postgres only — not a production secret.
+    password: postgres # NOSONAR
+    db_name: storage
+    schema: public
+    ssl_mode: disable
+    time_zone: UTC
+
+# --- HTTP / Storage Server ---
+http:
+  port: 8100
+  request_price: 0
+  max_request_body_bytes: 104857600 # 100 MiB
+
+  cors:
+    enabled: true
+    allow_all_origins: true
+    allow_private_network: true
+    allowed_methods:
+      - POST
+    allowed_headers:
+      - content-type
+      - authorization
+      - x-bsv-auth-version
+      - x-bsv-auth-message-type
+      - x-bsv-auth-identity-key
+      - x-bsv-auth-nonce
+      - x-bsv-auth-your-nonce
+      - x-bsv-auth-signature
+      - x-bsv-auth-request-id
+      - x-bsv-auth-requested-certificates
+      - X-BSV-Payment
+    exposed_headers:
+      - authorization
+      - x-bsv-auth-version
+      - x-bsv-auth-message-type
+      - x-bsv-auth-identity-key
+      - x-bsv-auth-nonce
+      - x-bsv-auth-your-nonce
+      - x-bsv-auth-signature
+      - x-bsv-auth-request-id
+      - X-BSV-Payment-Version
+      - X-BSV-Payment-Satoshis-Required
+      - X-BSV-Payment-Satoshis-Paid
+      - X-BSV-Payment-Derivation-Prefix
+
+# --- Logging ---
+logging:
+  enabled: true
+  handler: json
+  level: info
+
+# --- Monitor / Background Tasks ---
+monitor:
+  enabled: true
+  tasks:
+    check_for_proofs:
+      enabled: true
+      interval_seconds: 60
+      start_immediately: false
+    fail_abandoned:
+      enabled: true
+      interval_seconds: 300
+      start_immediately: false
+    send_waiting:
+      enabled: true
+      interval_seconds: 300
+      start_immediately: true
+    un_fail:
+      enabled: true
+      interval_seconds: 600
+      start_immediately: false
+
+# --- Change Basket Defaults ---
+change_basket:
+  max_change_outputs_per_tx: 8
+  minimum_desired_utxo_value: 1000
+  number_of_desired_utxos: 32
+
+# --- Fee Model ---
+fee_model:
+  type: sat/kb
+  value: 100
+
+# --- UTXO management (throughput) — same shape as live-test OP_RETURN profile ---
+utxo_management:
+  strategy: throughput
+  throughput:
+    expected_tx_size_bytes: 200
+    expected_output_satoshis: 0
+    denomination_satoshis: 0
+    target_tps: 1000
+    expected_confirmation_seconds: 300
+    pool_headroom_factor: 1.5
+    target_pool_size: 0
+    low_water_percent: 60
+    high_water_percent: 100
+    spend_policy: prefer_mined
+    pool_basket: fuel
+    reserve_basket: reserve
+    fanout_outputs_per_tx: 100
+    fanout_max_txs_per_round: 12000
+    fanout_tree_depth: 2
+    consolidation_inputs_per_tx: 1000
+    top_up:
+      enabled: true
+      interval_seconds: 10
+      start_immediately: true
+
+# --- Transaction Status Sync ---
+synchronize_tx_statuses:
+  blocks_delay: 1
+  check_no_send_period_hours: 24
+  max_attempts: 100
+  max_rebroadcast_attempts: 0
+
+fail_abandoned:
+  min_transaction_age_seconds: 300
+
+# --- Commission (disabled by default) ---
+commission:
+  pub_key_hex: ""
+  satoshis: 0
+
+# --- Tracing (optional) ---
+tracing:
+  enabled: false
+  dialAddr: http://jaeger:4317
+  sample: 100
+
+# --- Wallet Services (mainnet defaults; override tokens via INFRA_* env) ---
+wallet_services:
+  arc:
+    enabled: true
+    url: https://arc.taal.com
+    # Set a real mainnet ARC token for production demos:
+    #   INFRA_WALLET_SERVICES_ARC_TOKEN=...
+    token: mainnet_placeholder
+    deployment_id: ""
+    callback_url: ""
+    callback_token: ""
+    wait_for: ""
+
+  whats_on_chain:
+    enabled: true
+    api_key: ""
+    bsv_update_interval: 15m0s
+    bsv_exchange_rate:
+      base: USD
+      rates: 47.52
+      timestamp: {}
+    root_for_height_retries: 3
+    root_for_height_retry_interval: 1s
+
+  bitails:
+    enabled: false
+    api_key: ""
+    script_hash_history_page_limit: 100
+
+  chaintracks:
+    enabled: false
+    mode: remote
+    remote_url: http://localhost:3011
+    bootstrap_url: ""
+    bootstrap_mode: ""
+    p2p_network: ""
+    storage_path: ""
+    p2p_storage_path: ""
+
+  exchangerates_api_key: ""
+
+  fiat_exchange_rates:
+    base: USD
+    rates:
+      EUR: 0.93
+      GBP: 0.8
+      USD: 1
+    timestamp: {}
+  fiat_update_interval: 24h0m0s
+  get_beef_max_depth: 100


### PR DESCRIPTION
## What Changed
- Adds `cmd/throughput_dashboard`: operator wallet client against local throughput storage with FuelKeeper, start/stop OP_RETURN createAction stream (`sha256(iteration‖timestamp)`), metrics sampler, and embedded web UI.
- Browser `@bsv/sdk` WalletClient funding → deposit address → `InternalizeAction` (auto-detects payment vout when change is first).
- Mainnet Docker stack: `docker-compose.throughput-dashboard.yaml`, `Dockerfile.dashboard`, `infra-config-docker-throughput-mainnet.yaml`, runbook in `docs/throughput-dashboard.md`.
- Serializes wallet storage RPCs so concurrent AuthFetch handshakes cannot deadlock FuelKeeper + sampler (UI was empty despite funded wallet).
- Unit tests for stream, funding, metrics, config, connect, and HTTP API.

## Why It Was Necessary
Operators need a local, mainnet-oriented control plane to demonstrate throughput-mode wallet infra: fund, watch fuel top-ups, and drive a measurable createAction stream without wiring Grafana first.

## Testing Performed
- `go test ./cmd/throughput_dashboard/...`
- `go build ./cmd/throughput_dashboard ./cmd/infra_throughput`
- `PRIVATE_KEY=… docker compose -f docker-compose.throughput-dashboard.yaml up --build`
- Live: WalletClient fund → default balance shown → FuelKeeper filled fuel pool (500 UTXOs) → stream start/stop UI

## Impact / Risk
- New demo tooling only; does not change funder/FuelKeeper algorithms or storage RPC protocol.
- Mainnet-first defaults burn real fees when used; UI binds to localhost; `PRIVATE_KEY` required via env.
- `.superpowers/sdd/*` task artifacts included for agent execution trail (can drop in follow-up if undesired).

## Notifications
-