### PR TITLE
feat: support ttn and tstn networks (per-network service defaults)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,30 @@ For a guided walkthrough (including faucet and local setup), see the examples ov
 
 <br>
 
+### Networks
+
+Set `bsv_network` in the config (or `BSV_NETWORK` / `<PREFIX>_BSV_NETWORK` in the env) to one of:
+
+| `bsv_network` | Description | Broadcast / merkle proofs | Headers | WhatsOnChain |
+|---|---|---|---|---|
+| `main` | Public mainnet | ARC (TAAL) + Arcade + GorillaPool failover | WhatsOnChain | ✅ |
+| `test` | Public testnet | ARC (TAAL testnet) | WhatsOnChain | ✅ |
+| `ttn` | Teranode Test Net (public scaling testnet) | Arcade (`arcade-v2-ttn-us-1.bsvblockchain.tech`) | ChainTracks (`…/chaintracks/v1`) | ✅ |
+| `tstn` | Teranode Scaling Test Net (private, per-deployment) | Arcade (`$TSTN_ARCADE_URL`) | ChainTracks (`$TSTN_CHAINTRACKS_URL`) | ❌ (not available) |
+
+`ttn` and `tstn` are testnet-based (testnet address/key encoding and overlay network).
+
+**`tstn` is private** — its endpoints are not public and must be supplied at runtime via environment variables:
+
+| Variable | Required | Meaning |
+|---|---|---|
+| `TSTN_ARCADE_URL` | Yes | Arcade broadcaster / ARC endpoint base. Also the ChainTracks fallback host. |
+| `TSTN_CHAINTRACKS_URL` | No | ChainTracks service URL. Defaults to `${TSTN_ARCADE_URL}/chaintracks/v1` when omitted. |
+
+Selecting `tstn` without at least `TSTN_ARCADE_URL` fails startup with an actionable error.
+
+<br>
+
 ## 📚 Documentation
 - Core concepts and examples: `./examples/README.md`
 - Complex example: `./examples/complex_wallet_examples/create_faucet_server/QUICK_START.md`

--- a/cmd/throughput_dashboard/internal/funding/address.go
+++ b/cmd/throughput_dashboard/internal/funding/address.go
@@ -58,7 +58,8 @@ func DeriveInfo(priv *ec.PrivateKey, network defs.BSVNetwork, suggested uint64) 
 		err  error
 	)
 	switch network {
-	case defs.NetworkTestnet:
+	case defs.NetworkTestnet, defs.NetworkTTN, defs.NetworkTSTN:
+		// ttn/tstn are testnet-based and use testnet address encoding.
 		addr, err = brc29.AddressForSelf(anyonePub, keyID, priv, brc29.WithTestNet())
 	case defs.NetworkMainnet:
 		addr, err = brc29.AddressForSelf(anyonePub, keyID, priv, brc29.WithMainNet())

--- a/infra-config.example.yaml
+++ b/infra-config.example.yaml
@@ -164,7 +164,7 @@ wallet_services:
     mode: remote
     p2p_network: ""
     p2p_storage_path: ""
-    remote_url: http://localhost:3011
+    remote_url: https://arcade-v2-us-1.bsvblockchain.tech/chaintracks/v1
     storage_path: ""
   exchangerates_api_key: 123456
   fiat_exchange_rates:

--- a/pkg/defs/arcade.go
+++ b/pkg/defs/arcade.go
@@ -11,6 +11,10 @@ const ArcGorillaPoolServiceName = "ARC-GorillaPool"
 // ArcadeURL is the default mainnet Arcade instance.
 const ArcadeURL = "https://arcade-v2-us-1.bsvblockchain.tech"
 
+// ArcadeTTNURL is the default Arcade instance for the public Teranode Test Net (ttn).
+// The same host also serves the ttn ChainTracks endpoint under /chaintracks/v1.
+const ArcadeTTNURL = "https://arcade-v2-ttn-us-1.bsvblockchain.tech"
+
 // GorillaPoolArcURL is the default mainnet GorillaPool ARC instance (failover only).
 const GorillaPoolArcURL = "https://arc.gorillapool.io"
 

--- a/pkg/defs/network.go
+++ b/pkg/defs/network.go
@@ -4,26 +4,52 @@ import (
 	"fmt"
 )
 
-// BSVNetwork represents the Bitcoin SV network type (mainnet or testnet)
+// BSVNetwork represents the Bitcoin SV network a wallet/service instance runs against.
 type BSVNetwork string
 
-// BSVNetwork constants for the different Bitcoin SV network types
+// BSVNetwork constants for the supported Bitcoin SV networks.
+//
+// main/test are the public production and public test networks. ttn/tstn are the
+// Teranode scaling networks:
+//
+//	ttn  - Teranode Test Net: a public scaling test network.
+//	tstn - Teranode Scaling Test Net: a private, per-deployment scaling test network
+//	       that runs only Arcade (broadcast + merkle proofs) and ChainTracks (headers);
+//	       it has no public WhatsOnChain / block-explorer service. Its endpoints are not
+//	       public and are supplied at runtime via environment variables (see networkconfig.go).
+//
+// ttn and tstn are testnet-based: address encoding, key derivation and overlay network
+// selection all map them to the testnet parameters.
 const (
 	NetworkMainnet BSVNetwork = "main"
 	NetworkTestnet BSVNetwork = "test"
+	NetworkTTN     BSVNetwork = "ttn"
+	NetworkTSTN    BSVNetwork = "tstn"
 )
 
 // ParseBSVNetworkStr will parse the given string and return the corresponding BSVNetwork type or an error
 func ParseBSVNetworkStr(network string) (BSVNetwork, error) {
-	return parseEnumCaseInsensitive(network, NetworkMainnet, NetworkTestnet)
+	return parseEnumCaseInsensitive(network, NetworkMainnet, NetworkTestnet, NetworkTTN, NetworkTSTN)
 }
 
 // Validate checks if the value underneath is within valid BSVNetwork values.
 func (n BSVNetwork) Validate() error {
 	switch n {
-	case NetworkMainnet, NetworkTestnet:
+	case NetworkMainnet, NetworkTestnet, NetworkTTN, NetworkTSTN:
 		return nil
 	default:
 		return fmt.Errorf("unsupported BSV network: %s", n)
 	}
+}
+
+// IsTeranode reports whether the network is one of the Teranode scaling networks (ttn/tstn).
+// These networks broadcast through Arcade and source headers from ChainTracks.
+func (n BSVNetwork) IsTeranode() bool {
+	return n == NetworkTTN || n == NetworkTSTN
+}
+
+// IsTestnetBased reports whether the network uses testnet address/key parameters.
+// This is true for test, ttn and tstn - only main uses mainnet parameters.
+func (n BSVNetwork) IsTestnetBased() bool {
+	return n != NetworkMainnet
 }

--- a/pkg/defs/network_endpoints.go
+++ b/pkg/defs/network_endpoints.go
@@ -1,0 +1,88 @@
+package defs
+
+// networkEndpoints holds the per-network default service endpoints resolved by
+// DefaultServicesConfig. It centralises the "which services run on which network"
+// policy so that spinning up an instance for main/test/ttn/tstn produces a coherent
+// broadcaster + header + lookup set.
+//
+// Summary of the policy:
+//
+//	network  ARC (merkle)         Arcade (broadcast)   GorillaPool  WhatsOnChain  ChainTracks
+//	main     arc.taal.com         arcade-v2-us-1        yes          yes           off (WoC serves headers)
+//	test     arc-test.taal.com    off                  no           yes           off
+//	ttn      arcade-v2-ttn-us-1   arcade-v2-ttn-us-1   no           yes           on (arcade host /chaintracks/v1)
+//	tstn     $TSTN_ARCADE_URL     $TSTN_ARCADE_URL     no           no            on ($TSTN_CHAINTRACKS_URL)
+//
+// The ChainTracks RemoteURL is populated for every network (derived from the Arcade host)
+// even when disabled, so enabling it never points at a stale localhost default.
+type networkEndpoints struct {
+	arcURL   string
+	arcToken string
+
+	arcadeEnabled bool
+	arcadeURL     string
+
+	gorillaEnabled bool
+	gorillaURL     string
+
+	wocEnabled bool
+
+	chaintracksEnabled bool
+	chaintracksURL     string
+}
+
+// endpointsForChain returns the default service endpoints for the given network.
+//
+// For tstn the Arcade / ChainTracks URLs come from the environment (TSTN_ARCADE_URL /
+// TSTN_CHAINTRACKS_URL) and are left empty when unset; WalletServices.Validate() then
+// surfaces an actionable error pointing at the required environment variables.
+func endpointsForChain(chain BSVNetwork) networkEndpoints {
+	switch chain {
+	case NetworkMainnet:
+		return networkEndpoints{
+			arcURL:             ArcURL,
+			arcToken:           ArcToken,
+			arcadeEnabled:      true,
+			arcadeURL:          ArcadeURL,
+			gorillaEnabled:     true,
+			gorillaURL:         GorillaPoolArcURL,
+			wocEnabled:         true,
+			chaintracksEnabled: false, // WhatsOnChain provides headers on main by default
+			chaintracksURL:     chaintracksURLFromArcade(ArcadeURL),
+		}
+	case NetworkTTN:
+		return networkEndpoints{
+			// The public ttn Arcade host is ARC-compatible and serves merkle proofs.
+			arcURL:             ArcadeTTNURL,
+			arcadeEnabled:      true,
+			arcadeURL:          ArcadeTTNURL,
+			wocEnabled:         true,
+			chaintracksEnabled: true,
+			chaintracksURL:     chaintracksURLFromArcade(ArcadeTTNURL),
+		}
+	case NetworkTSTN:
+		arcade := TstnArcadeURL()
+		// Ignore the "not configured" error here: an empty URL flows into the config and
+		// WalletServices.Validate() reports the missing environment variables with context.
+		chaintracks, _ := TstnChaintracksURL()
+		return networkEndpoints{
+			arcURL:             arcade,
+			arcadeEnabled:      true,
+			arcadeURL:          arcade,
+			wocEnabled:         false, // tstn has no WhatsOnChain / block-explorer service
+			chaintracksEnabled: true,
+			chaintracksURL:     chaintracks,
+		}
+	case NetworkTestnet:
+		fallthrough
+	default:
+		return networkEndpoints{
+			arcURL:             ArcTestURL,
+			arcToken:           ArcTestToken,
+			arcadeEnabled:      false,
+			wocEnabled:         true,
+			chaintracksEnabled: false,
+			chaintracksURL:     ChaintracksTestURL,
+		}
+	}
+}

--- a/pkg/defs/network_endpoints.go
+++ b/pkg/defs/network_endpoints.go
@@ -1,7 +1,7 @@
 package defs
 
 // networkEndpoints holds the per-network default service endpoints resolved by
-// DefaultServicesConfig. It centralises the "which services run on which network"
+// DefaultServicesConfig. It centralizes the "which services run on which network"
 // policy so that spinning up an instance for main/test/ttn/tstn produces a coherent
 // broadcaster + header + lookup set.
 //

--- a/pkg/defs/network_test.go
+++ b/pkg/defs/network_test.go
@@ -1,0 +1,72 @@
+package defs_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+)
+
+func TestParseBSVNetworkStr(t *testing.T) {
+	validCases := map[string]defs.BSVNetwork{
+		"main": defs.NetworkMainnet,
+		"MAIN": defs.NetworkMainnet,
+		"test": defs.NetworkTestnet,
+		"Test": defs.NetworkTestnet,
+		"ttn":  defs.NetworkTTN,
+		"TTN":  defs.NetworkTTN,
+		"tstn": defs.NetworkTSTN,
+		"TSTN": defs.NetworkTSTN,
+	}
+
+	for input, expected := range validCases {
+		t.Run("parses "+input, func(t *testing.T) {
+			// when:
+			network, err := defs.ParseBSVNetworkStr(input)
+
+			// then:
+			require.NoError(t, err)
+			require.Equal(t, expected, network)
+		})
+	}
+
+	invalidCases := []string{"", "mainnet", "testnet", "stn", "regtest", "unknown"}
+	for _, input := range invalidCases {
+		t.Run("rejects "+input, func(t *testing.T) {
+			// when:
+			_, err := defs.ParseBSVNetworkStr(input)
+
+			// then:
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestBSVNetworkValidate(t *testing.T) {
+	t.Run("all supported networks validate", func(t *testing.T) {
+		for _, n := range []defs.BSVNetwork{defs.NetworkMainnet, defs.NetworkTestnet, defs.NetworkTTN, defs.NetworkTSTN} {
+			require.NoError(t, n.Validate(), "network %q should be valid", n)
+		}
+	})
+
+	t.Run("unknown network is rejected", func(t *testing.T) {
+		err := defs.BSVNetwork("nope").Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported BSV network")
+	})
+}
+
+func TestBSVNetworkIsTeranode(t *testing.T) {
+	require.True(t, defs.NetworkTTN.IsTeranode())
+	require.True(t, defs.NetworkTSTN.IsTeranode())
+	require.False(t, defs.NetworkMainnet.IsTeranode())
+	require.False(t, defs.NetworkTestnet.IsTeranode())
+}
+
+func TestBSVNetworkIsTestnetBased(t *testing.T) {
+	require.False(t, defs.NetworkMainnet.IsTestnetBased())
+	require.True(t, defs.NetworkTestnet.IsTestnetBased())
+	require.True(t, defs.NetworkTTN.IsTestnetBased())
+	require.True(t, defs.NetworkTSTN.IsTestnetBased())
+}

--- a/pkg/defs/networkconfig.go
+++ b/pkg/defs/networkconfig.go
@@ -1,0 +1,62 @@
+package defs
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Runtime service-endpoint configuration for the tstn (Teranode Scaling Test Net) network.
+//
+// Unlike main, test and ttn, the tstn service endpoints are not public and must not be
+// hardcoded in this (public) source tree. They are supplied at runtime through environment
+// variables:
+//
+//	TSTN_ARCADE_URL       Arcade broadcaster / ARC endpoint base. Also the fallback host for
+//	                      ChainTracks when TSTN_CHAINTRACKS_URL is unset
+//	                      (${TSTN_ARCADE_URL}/chaintracks/v1, mirroring the ttn layout).
+//	TSTN_CHAINTRACKS_URL  ChainTracks service URL.
+//
+// tstn runs only Arcade (broadcast + merkle proofs) and ChainTracks (headers); there is no
+// WhatsOnChain / block-explorer service for tstn, so no WhatsOnChain endpoint is configured and
+// the WhatsOnChain-only lookups (raw tx, utxo status, txid status, script-hash history) are not
+// available on tstn.
+const (
+	// EnvTstnArcadeURL is the environment variable holding the tstn Arcade / ARC endpoint base.
+	EnvTstnArcadeURL = "TSTN_ARCADE_URL"
+	// EnvTstnChaintracksURL is the environment variable holding the tstn ChainTracks endpoint.
+	EnvTstnChaintracksURL = "TSTN_CHAINTRACKS_URL"
+)
+
+// readEnv returns the trimmed value of the named environment variable, or "" when unset/blank.
+func readEnv(name string) string {
+	return strings.TrimSpace(os.Getenv(name))
+}
+
+// TstnArcadeURL returns the Arcade broadcaster / ARC endpoint for tstn from TSTN_ARCADE_URL,
+// or "" when the variable is unset.
+func TstnArcadeURL() string {
+	return readEnv(EnvTstnArcadeURL)
+}
+
+// TstnChaintracksURL returns the ChainTracks service URL for tstn. It falls back to
+// ${TSTN_ARCADE_URL}/chaintracks/v1 when TSTN_CHAINTRACKS_URL is unset (mirroring the ttn
+// layout), and returns an error when neither variable is configured.
+func TstnChaintracksURL() (string, error) {
+	if explicit := readEnv(EnvTstnChaintracksURL); explicit != "" {
+		return explicit, nil
+	}
+	if arcade := TstnArcadeURL(); arcade != "" {
+		return chaintracksURLFromArcade(arcade), nil
+	}
+	return "", fmt.Errorf(
+		"tstn network requires a ChainTracks URL: set %s (or %s) in the environment",
+		EnvTstnChaintracksURL, EnvTstnArcadeURL,
+	)
+}
+
+// chaintracksURLFromArcade derives the ChainTracks endpoint from an Arcade base URL by
+// appending the /chaintracks/v1 path (the layout used by the public arcade deployments).
+func chaintracksURLFromArcade(arcadeURL string) string {
+	return strings.TrimRight(arcadeURL, "/") + "/chaintracks/v1"
+}

--- a/pkg/defs/networkconfig_test.go
+++ b/pkg/defs/networkconfig_test.go
@@ -1,0 +1,52 @@
+package defs_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+)
+
+func TestTstnArcadeURL(t *testing.T) {
+	t.Run("returns trimmed env value when set", func(t *testing.T) {
+		t.Setenv(defs.EnvTstnArcadeURL, "  https://arcade.example.tstn  ")
+		require.Equal(t, "https://arcade.example.tstn", defs.TstnArcadeURL())
+	})
+
+	t.Run("returns empty when unset", func(t *testing.T) {
+		t.Setenv(defs.EnvTstnArcadeURL, "")
+		require.Empty(t, defs.TstnArcadeURL())
+	})
+}
+
+func TestTstnChaintracksURL(t *testing.T) {
+	t.Run("uses explicit TSTN_CHAINTRACKS_URL when set", func(t *testing.T) {
+		t.Setenv(defs.EnvTstnArcadeURL, "https://arcade.example.tstn")
+		t.Setenv(defs.EnvTstnChaintracksURL, "https://ct.example.tstn/custom")
+
+		got, err := defs.TstnChaintracksURL()
+		require.NoError(t, err)
+		require.Equal(t, "https://ct.example.tstn/custom", got)
+	})
+
+	t.Run("falls back to ${TSTN_ARCADE_URL}/chaintracks/v1 when chaintracks unset", func(t *testing.T) {
+		t.Setenv(defs.EnvTstnArcadeURL, "https://arcade.example.tstn/")
+		t.Setenv(defs.EnvTstnChaintracksURL, "")
+
+		got, err := defs.TstnChaintracksURL()
+		require.NoError(t, err)
+		// trailing slash on the arcade URL is normalised away before appending the path.
+		require.Equal(t, "https://arcade.example.tstn/chaintracks/v1", got)
+	})
+
+	t.Run("errors when neither variable is set", func(t *testing.T) {
+		t.Setenv(defs.EnvTstnArcadeURL, "")
+		t.Setenv(defs.EnvTstnChaintracksURL, "")
+
+		_, err := defs.TstnChaintracksURL()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), defs.EnvTstnChaintracksURL)
+		require.Contains(t, err.Error(), defs.EnvTstnArcadeURL)
+	})
+}

--- a/pkg/defs/networkconfig_test.go
+++ b/pkg/defs/networkconfig_test.go
@@ -36,7 +36,7 @@ func TestTstnChaintracksURL(t *testing.T) {
 
 		got, err := defs.TstnChaintracksURL()
 		require.NoError(t, err)
-		// trailing slash on the arcade URL is normalised away before appending the path.
+		// trailing slash on the arcade URL is normalized away before appending the path.
 		require.Equal(t, "https://arcade.example.tstn/chaintracks/v1", got)
 	})
 

--- a/pkg/defs/services.go
+++ b/pkg/defs/services.go
@@ -79,6 +79,18 @@ func (ws *WalletServices) Validate() error {
 		return fmt.Errorf("chain is required")
 	}
 
+	// tstn endpoints are private and supplied at runtime via environment variables.
+	// Fail fast with an actionable message when they are missing, instead of surfacing
+	// a generic "arcade url is empty" later on.
+	if ws.Chain == NetworkTSTN {
+		if ws.Arcade.URL == "" {
+			return fmt.Errorf("tstn network requires %s to be set in the environment", EnvTstnArcadeURL)
+		}
+		if ws.ChaintracksClient.Enabled && ws.ChaintracksClient.RemoteURL == "" {
+			return fmt.Errorf("tstn network requires %s or %s to be set in the environment", EnvTstnChaintracksURL, EnvTstnArcadeURL)
+		}
+	}
+
 	if err = ws.FiatExchangeRates.Validate(); err != nil {
 		return fmt.Errorf("invalid fiat exchange rates: %w", err)
 	}
@@ -114,19 +126,22 @@ func (ws *WalletServices) Validate() error {
 func DefaultServicesConfig(chain BSVNetwork) WalletServices {
 	ratesTimestamp := time.Date(2023, time.December, 13, 0, 0, 0, 0, time.UTC)
 
+	ep := endpointsForChain(chain)
+
 	cfg := WalletServices{ //nolint:gosec // G101 - not hardcoded credentials, default config values
 		Chain: chain,
 		ArcConfig: ARC{
 			Enabled: true,
-			URL:     to.IfThen(chain == NetworkMainnet, ArcURL).ElseThen(ArcTestURL),
-			Token:   to.IfThen(chain == NetworkMainnet, ArcToken).ElseThen(ArcTestToken),
+			URL:     ep.arcURL,
+			Token:   ep.arcToken,
 		},
 		Arcade: Arcade{
-			Enabled: chain == NetworkMainnet,
-			// off mainnet the URL is left empty on purpose: flipping Enabled on testnet
-			// must not silently hit mainnet - Validate() then forces an explicit URL.
-			URL:               to.IfThen(chain == NetworkMainnet, ArcadeURL).ElseThen(""),
-			EventsURL:         to.IfThen(chain == NetworkMainnet, ArcadeURL).ElseThen(""),
+			Enabled: ep.arcadeEnabled,
+			// on networks without an Arcade default the URL is left empty on purpose:
+			// flipping Enabled without a URL must not silently hit mainnet - Validate()
+			// then forces an explicit URL.
+			URL:               ep.arcadeURL,
+			EventsURL:         ep.arcadeURL,
 			FullStatusUpdates: true,
 			CircuitBreaker: ArcadeCircuitBreaker{
 				FailureThreshold:           3,
@@ -134,8 +149,8 @@ func DefaultServicesConfig(chain BSVNetwork) WalletServices {
 			},
 		},
 		ArcGorillaPoolConfig: ARC{
-			Enabled: chain == NetworkMainnet,
-			URL:     to.IfThen(chain == NetworkMainnet, GorillaPoolArcURL).ElseThen(""),
+			Enabled: ep.gorillaEnabled,
+			URL:     ep.gorillaURL,
 		},
 		BHS: BHS{
 			Enabled: false,
@@ -143,7 +158,7 @@ func DefaultServicesConfig(chain BSVNetwork) WalletServices {
 			APIKey:  BHSApiKey,
 		},
 		WhatsOnChain: WhatsOnChain{
-			Enabled:           true,
+			Enabled:           ep.wocEnabled,
 			BSVUpdateInterval: to.Ptr(DefaultBSVExchangeUpdateInterval),
 			BSVExchangeRate: BSVExchangeRate{
 				Timestamp: ratesTimestamp,
@@ -159,9 +174,9 @@ func DefaultServicesConfig(chain BSVNetwork) WalletServices {
 			ScriptHashHistoryPageLimit: defaultScriptHashHistoryPageLimit,
 		},
 		ChaintracksClient: ChaintracksClient{
-			Enabled:   false,
-			Mode:      "remote",
-			RemoteURL: ChaintracksTestURL,
+			Enabled:   ep.chaintracksEnabled,
+			Mode:      ChaintracksClientModeRemote,
+			RemoteURL: ep.chaintracksURL,
 		},
 		FiatExchangeRates: FiatExchangeRates{
 			Timestamp: ratesTimestamp,

--- a/pkg/defs/services_network_test.go
+++ b/pkg/defs/services_network_test.go
@@ -1,0 +1,94 @@
+package defs_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+)
+
+func TestDefaultServicesConfigPerNetwork(t *testing.T) {
+	t.Run("main enables Arcade+GorillaPool+WoC, ChainTracks off but arcade-derived", func(t *testing.T) {
+		cfg := defs.DefaultServicesConfig(defs.NetworkMainnet)
+
+		require.Equal(t, defs.ArcURL, cfg.ArcConfig.URL)
+		require.Equal(t, defs.ArcToken, cfg.ArcConfig.Token)
+		require.True(t, cfg.Arcade.Enabled)
+		require.Equal(t, defs.ArcadeURL, cfg.Arcade.URL)
+		require.True(t, cfg.ArcGorillaPoolConfig.Enabled)
+		require.True(t, cfg.WhatsOnChain.Enabled)
+		require.False(t, cfg.ChaintracksClient.Enabled)
+		require.Equal(t, "https://arcade-v2-us-1.bsvblockchain.tech/chaintracks/v1", cfg.ChaintracksClient.RemoteURL)
+	})
+
+	t.Run("test keeps testnet ARC, Arcade off, WoC on", func(t *testing.T) {
+		cfg := defs.DefaultServicesConfig(defs.NetworkTestnet)
+
+		require.Equal(t, defs.ArcTestURL, cfg.ArcConfig.URL)
+		require.Equal(t, defs.ArcTestToken, cfg.ArcConfig.Token)
+		require.False(t, cfg.Arcade.Enabled)
+		require.Empty(t, cfg.Arcade.URL)
+		require.False(t, cfg.ArcGorillaPoolConfig.Enabled)
+		require.True(t, cfg.WhatsOnChain.Enabled)
+		require.False(t, cfg.ChaintracksClient.Enabled)
+	})
+
+	t.Run("ttn points ARC+Arcade+ChainTracks at the public ttn arcade host", func(t *testing.T) {
+		cfg := defs.DefaultServicesConfig(defs.NetworkTTN)
+
+		require.Equal(t, defs.ArcadeTTNURL, cfg.ArcConfig.URL)
+		require.True(t, cfg.Arcade.Enabled)
+		require.Equal(t, defs.ArcadeTTNURL, cfg.Arcade.URL)
+		require.Equal(t, defs.ArcadeTTNURL, cfg.Arcade.EventsURL)
+		require.False(t, cfg.ArcGorillaPoolConfig.Enabled)
+		require.True(t, cfg.WhatsOnChain.Enabled)
+		require.True(t, cfg.ChaintracksClient.Enabled)
+		require.Equal(t, defs.ChaintracksClientModeRemote, cfg.ChaintracksClient.Mode)
+		require.Equal(t, "https://arcade-v2-ttn-us-1.bsvblockchain.tech/chaintracks/v1", cfg.ChaintracksClient.RemoteURL)
+
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("tstn reads endpoints from env, disables WhatsOnChain", func(t *testing.T) {
+		t.Setenv(defs.EnvTstnArcadeURL, "https://arcade.example.tstn")
+		t.Setenv(defs.EnvTstnChaintracksURL, "")
+
+		cfg := defs.DefaultServicesConfig(defs.NetworkTSTN)
+
+		require.Equal(t, "https://arcade.example.tstn", cfg.ArcConfig.URL)
+		require.True(t, cfg.Arcade.Enabled)
+		require.Equal(t, "https://arcade.example.tstn", cfg.Arcade.URL)
+		require.False(t, cfg.ArcGorillaPoolConfig.Enabled)
+		require.False(t, cfg.WhatsOnChain.Enabled, "tstn has no WhatsOnChain service")
+		require.True(t, cfg.ChaintracksClient.Enabled)
+		// chaintracks falls back to the arcade host when TSTN_CHAINTRACKS_URL is unset.
+		require.Equal(t, "https://arcade.example.tstn/chaintracks/v1", cfg.ChaintracksClient.RemoteURL)
+
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("tstn honours an explicit TSTN_CHAINTRACKS_URL", func(t *testing.T) {
+		t.Setenv(defs.EnvTstnArcadeURL, "https://arcade.example.tstn")
+		t.Setenv(defs.EnvTstnChaintracksURL, "https://ct.example.tstn/v1")
+
+		cfg := defs.DefaultServicesConfig(defs.NetworkTSTN)
+
+		require.Equal(t, "https://ct.example.tstn/v1", cfg.ChaintracksClient.RemoteURL)
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("tstn without env vars fails validation with an actionable message", func(t *testing.T) {
+		t.Setenv(defs.EnvTstnArcadeURL, "")
+		t.Setenv(defs.EnvTstnChaintracksURL, "")
+
+		cfg := defs.DefaultServicesConfig(defs.NetworkTSTN)
+
+		require.False(t, cfg.WhatsOnChain.Enabled)
+		require.Empty(t, cfg.Arcade.URL)
+
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), defs.EnvTstnArcadeURL)
+	})
+}

--- a/pkg/defs/services_network_test.go
+++ b/pkg/defs/services_network_test.go
@@ -68,7 +68,7 @@ func TestDefaultServicesConfigPerNetwork(t *testing.T) {
 		require.NoError(t, cfg.Validate())
 	})
 
-	t.Run("tstn honours an explicit TSTN_CHAINTRACKS_URL", func(t *testing.T) {
+	t.Run("tstn honors an explicit TSTN_CHAINTRACKS_URL", func(t *testing.T) {
 		t.Setenv(defs.EnvTstnArcadeURL, "https://arcade.example.tstn")
 		t.Setenv(defs.EnvTstnChaintracksURL, "https://ct.example.tstn/v1")
 

--- a/pkg/infra/config.go
+++ b/pkg/infra/config.go
@@ -105,12 +105,71 @@ func (c *Config) OnPostLoad() error {
 	}
 	c.Services.Chain = c.BSVNetwork
 
-	// if testnet selected - switch to testnet-ARC if default config points to mainnet-ARC
-	if c.BSVNetwork == defs.NetworkTestnet && c.Services.ArcConfig.URL == defs.ArcURL {
-		c.Services.ArcConfig.URL = defs.ArcTestURL
-		c.Services.ArcConfig.Token = defs.ArcTestToken
-	}
+	// The service defaults baked in by Defaults() are for mainnet (the network is only
+	// known after the config file/env are loaded). Re-derive the network-specific service
+	// endpoints for the selected network, preserving any operator overrides.
+	c.reconcileServiceDefaultsForNetwork()
 	return nil
+}
+
+// reconcileServiceDefaultsForNetwork swaps service endpoints that still carry the mainnet
+// defaults (from Defaults()) over to the defaults for the selected network. Operator
+// overrides in the config file/env are preserved: a field is only adjusted when it still
+// equals the mainnet default value the operator did not touch. This generalises the former
+// testnet-ARC-only swap so that test/ttn/tstn also get coherent Arcade / GorillaPool /
+// WhatsOnChain / ChainTracks defaults (and for tstn, the TSTN_ARCADE_URL / TSTN_CHAINTRACKS_URL
+// runtime endpoints).
+func (c *Config) reconcileServiceDefaultsForNetwork() {
+	if c.BSVNetwork == defs.NetworkMainnet {
+		return // Defaults() already holds the mainnet service defaults.
+	}
+
+	mainDefaults := defs.DefaultServicesConfig(defs.NetworkMainnet)
+	target := defs.DefaultServicesConfig(c.BSVNetwork)
+	s := &c.Services
+
+	// ARC (TAAL / primary merkle-path source)
+	if s.ArcConfig.URL == mainDefaults.ArcConfig.URL {
+		s.ArcConfig.URL = target.ArcConfig.URL
+	}
+	if s.ArcConfig.Token == mainDefaults.ArcConfig.Token {
+		s.ArcConfig.Token = target.ArcConfig.Token
+	}
+
+	// Arcade (primary broadcaster)
+	if s.Arcade.Enabled == mainDefaults.Arcade.Enabled {
+		s.Arcade.Enabled = target.Arcade.Enabled
+	}
+	if s.Arcade.URL == mainDefaults.Arcade.URL {
+		s.Arcade.URL = target.Arcade.URL
+	}
+	if s.Arcade.EventsURL == mainDefaults.Arcade.EventsURL {
+		s.Arcade.EventsURL = target.Arcade.EventsURL
+	}
+
+	// GorillaPool ARC (mainnet-only broadcast failover)
+	if s.ArcGorillaPoolConfig.Enabled == mainDefaults.ArcGorillaPoolConfig.Enabled {
+		s.ArcGorillaPoolConfig.Enabled = target.ArcGorillaPoolConfig.Enabled
+	}
+	if s.ArcGorillaPoolConfig.URL == mainDefaults.ArcGorillaPoolConfig.URL {
+		s.ArcGorillaPoolConfig.URL = target.ArcGorillaPoolConfig.URL
+	}
+
+	// WhatsOnChain (absent on tstn)
+	if s.WhatsOnChain.Enabled == mainDefaults.WhatsOnChain.Enabled {
+		s.WhatsOnChain.Enabled = target.WhatsOnChain.Enabled
+	}
+
+	// ChainTracks (headers; enabled by default on the Teranode networks)
+	if s.ChaintracksClient.Enabled == mainDefaults.ChaintracksClient.Enabled {
+		s.ChaintracksClient.Enabled = target.ChaintracksClient.Enabled
+	}
+	if s.ChaintracksClient.Mode == mainDefaults.ChaintracksClient.Mode {
+		s.ChaintracksClient.Mode = target.ChaintracksClient.Mode
+	}
+	if s.ChaintracksClient.RemoteURL == mainDefaults.ChaintracksClient.RemoteURL {
+		s.ChaintracksClient.RemoteURL = target.ChaintracksClient.RemoteURL
+	}
 }
 
 // Validate validates the whole configuration

--- a/pkg/infra/config_test.go
+++ b/pkg/infra/config_test.go
@@ -360,6 +360,79 @@ func TestChangeBasketEnvVars(t *testing.T) {
 
 // setRequiredEnvs sets necessary environment variables for test configuration.
 // It ensures TEST_SERVER_PRIVATE_KEY is set with a valid private key value for proper test initialization.
+func TestServiceDefaultsReconciledForTestnet(t *testing.T) {
+	// given:
+	setRequiredEnvs(t)
+	t.Setenv("TEST_BSV_NETWORK", "test")
+
+	// when:
+	infraSrv, err := infra.NewServer(t.Context(), infra.WithEnvPrefix("TEST"))
+
+	// then:
+	require.NoError(t, err)
+	require.Equal(t, defs.NetworkTestnet, infraSrv.Config.BSVNetwork)
+	// testnet ARC replaces the mainnet default...
+	require.Equal(t, defs.ArcTestURL, infraSrv.Config.Services.ArcConfig.URL)
+	require.Equal(t, defs.ArcTestToken, infraSrv.Config.Services.ArcConfig.Token)
+	// ...and mainnet-only broadcasters are no longer enabled off mainnet.
+	require.False(t, infraSrv.Config.Services.Arcade.Enabled)
+	require.False(t, infraSrv.Config.Services.ArcGorillaPoolConfig.Enabled)
+	require.True(t, infraSrv.Config.Services.WhatsOnChain.Enabled)
+}
+
+func TestServiceDefaultsReconciledForTTN(t *testing.T) {
+	// given:
+	setRequiredEnvs(t)
+	t.Setenv("TEST_BSV_NETWORK", "ttn")
+
+	// when:
+	infraSrv, err := infra.NewServer(t.Context(), infra.WithEnvPrefix("TEST"))
+
+	// then:
+	require.NoError(t, err)
+	require.Equal(t, defs.NetworkTTN, infraSrv.Config.BSVNetwork)
+	require.Equal(t, defs.ArcadeTTNURL, infraSrv.Config.Services.ArcConfig.URL)
+	require.True(t, infraSrv.Config.Services.Arcade.Enabled)
+	require.Equal(t, defs.ArcadeTTNURL, infraSrv.Config.Services.Arcade.URL)
+	require.False(t, infraSrv.Config.Services.ArcGorillaPoolConfig.Enabled)
+	require.True(t, infraSrv.Config.Services.ChaintracksClient.Enabled)
+	require.Equal(t, "https://arcade-v2-ttn-us-1.bsvblockchain.tech/chaintracks/v1", infraSrv.Config.Services.ChaintracksClient.RemoteURL)
+}
+
+func TestServiceDefaultsReconciledForTSTN(t *testing.T) {
+	// given:
+	setRequiredEnvs(t)
+	t.Setenv("TEST_BSV_NETWORK", "tstn")
+	t.Setenv(defs.EnvTstnArcadeURL, "https://arcade.private.tstn")
+
+	// when:
+	infraSrv, err := infra.NewServer(t.Context(), infra.WithEnvPrefix("TEST"))
+
+	// then:
+	require.NoError(t, err)
+	require.Equal(t, defs.NetworkTSTN, infraSrv.Config.BSVNetwork)
+	require.Equal(t, "https://arcade.private.tstn", infraSrv.Config.Services.Arcade.URL)
+	require.True(t, infraSrv.Config.Services.Arcade.Enabled)
+	require.False(t, infraSrv.Config.Services.WhatsOnChain.Enabled, "tstn has no WhatsOnChain service")
+	require.True(t, infraSrv.Config.Services.ChaintracksClient.Enabled)
+	require.Equal(t, "https://arcade.private.tstn/chaintracks/v1", infraSrv.Config.Services.ChaintracksClient.RemoteURL)
+}
+
+func TestTSTNWithoutEnvFailsValidation(t *testing.T) {
+	// given: tstn selected but the private endpoints are not provided
+	setRequiredEnvs(t)
+	t.Setenv("TEST_BSV_NETWORK", "tstn")
+	t.Setenv(defs.EnvTstnArcadeURL, "")
+	t.Setenv(defs.EnvTstnChaintracksURL, "")
+
+	// when:
+	_, err := infra.NewServer(t.Context(), infra.WithEnvPrefix("TEST"))
+
+	// then:
+	require.Error(t, err)
+	require.Contains(t, err.Error(), defs.EnvTstnArcadeURL)
+}
+
 func setRequiredEnvs(t *testing.T) {
 	t.Setenv("TEST_SERVER_PRIVATE_KEY", fixtures.StorageServerPrivKey)
 }

--- a/pkg/services/internal/bitails/service.go
+++ b/pkg/services/internal/bitails/service.go
@@ -50,7 +50,8 @@ func New(httpClient *resty.Client, logger *slog.Logger, network defs.BSVNetwork,
 		SetDebug(logging.IsDebug(logger))
 
 	baseURL := ProductionURL
-	if strings.ToLower(string(network)) == "test" {
+	// test, ttn and tstn are all testnet-based and route to the testnet endpoint.
+	if network.IsTestnetBased() {
 		baseURL = TestnetURL
 	}
 

--- a/pkg/wallet/internal/mapping/mapping_overlay_network.go
+++ b/pkg/wallet/internal/mapping/mapping_overlay_network.go
@@ -10,7 +10,8 @@ func MapToOverlayNetwork(chain defs.BSVNetwork) overlay.Network {
 	switch chain {
 	case defs.NetworkMainnet:
 		return overlay.NetworkMainnet
-	case defs.NetworkTestnet:
+	case defs.NetworkTestnet, defs.NetworkTTN, defs.NetworkTSTN:
+		// ttn/tstn are testnet-based; overlay only distinguishes mainnet vs testnet.
 		return overlay.NetworkTestnet
 	default:
 		return overlay.NetworkTestnet

--- a/pkg/wallet/internal/wallet_settings_manager/wallet_settings_manager.go
+++ b/pkg/wallet/internal/wallet_settings_manager/wallet_settings_manager.go
@@ -99,7 +99,8 @@ func DefaultManager(chain defs.BSVNetwork) *WalletSettingsManager {
 	var trustedCertifiers []Certifier
 
 	switch chain {
-	case defs.NetworkTestnet:
+	case defs.NetworkTestnet, defs.NetworkTTN, defs.NetworkTSTN:
+		// ttn/tstn are testnet-based networks and use the testnet certifier set.
 		trustedCertifiers = GetTestnetDefaultCertifiers()
 	case defs.NetworkMainnet:
 		trustedCertifiers = GetDefaultCertifiers()


### PR DESCRIPTION
## What

Expands the configurable BSV network from `main`/`test` to all four networks — adding the two Teranode scaling networks — so a wallet/services instance can be spun up for each, matching [ts-stack PR #304](https://github.com/bsv-blockchain/ts-stack/pull/304).

| `bsv_network` | Broadcast / merkle proofs | Headers | WhatsOnChain |
|---|---|---|---|
| `main` | ARC (TAAL) + Arcade + GorillaPool failover | WhatsOnChain | ✅ |
| `test` | ARC (TAAL testnet) | WhatsOnChain | ✅ |
| `ttn` — Teranode Test Net (public) | Arcade `arcade-v2-ttn-us-1.bsvblockchain.tech` | ChainTracks `…/chaintracks/v1` | ✅ |
| `tstn` — Teranode Scaling Test Net (private) | Arcade `$TSTN_ARCADE_URL` | ChainTracks `$TSTN_CHAINTRACKS_URL` | ❌ |

`ttn`/`tstn` are testnet-based (testnet address/key encoding, overlay = testnet).

## tstn is private — endpoints via env

`tstn` service endpoints are not public and are supplied at runtime:

| Variable | Required | Meaning |
|---|---|---|
| `TSTN_ARCADE_URL` | Yes | Arcade broadcaster / ARC endpoint base; also the ChainTracks fallback host |
| `TSTN_CHAINTRACKS_URL` | No | ChainTracks URL; defaults to `${TSTN_ARCADE_URL}/chaintracks/v1` |

Selecting `tstn` without at least `TSTN_ARCADE_URL` fails startup with an actionable error.

## Changes

- **`pkg/defs/network.go`** — add `NetworkTTN`/`NetworkTSTN`; `ParseBSVNetworkStr` + `Validate` accept them; `IsTeranode`/`IsTestnetBased` helpers.
- **`pkg/defs/network_endpoints.go`** (new) — per-network endpoint resolver replacing the binary `mainnet`-vs-else fork in `DefaultServicesConfig`. ChainTracks URLs are derived uniformly from the Arcade host (`<arcade>/chaintracks/v1`) — **no `babbage.systems` host**.
- **`pkg/defs/networkconfig.go`** (new) — `TstnArcadeURL()` / `TstnChaintracksURL()` env resolution with fallback + error, mirroring `services/networkConfig.ts`.
- **WhatsOnChain gated off for `tstn`**; `WalletServices.Validate()` fails fast on missing tstn env.
- **`pkg/infra/config.go`** — `OnPostLoad` reconciles service defaults for the selected network (generalises the former testnet-ARC-only swap; also fixes `test`/`ttn`/`tstn` inheriting mainnet Arcade/GorillaPool defaults). Operator overrides are preserved.
- Map `ttn`/`tstn` → testnet for overlay network, trusted certifiers, Bitails and brc29 address derivation.
- README + `infra-config.example.yaml`.

## go-sdk

No changes needed — its ARC broadcaster, ChainTracks (`headers_client`) chaintracker and `spv.Verify` are URL/param driven, and the SDK testnet address/HD params already cover `ttn`/`tstn`. (Verified by an adversarial cross-repo audit.)

## Testing

- `go build ./...`, `go vet`, `gofmt` clean.
- New tests: network parse/validate, `Tstn*URL` env behavior (set / fallback / error), `DefaultServicesConfig` per-network (incl. tstn WoC-off + validation), and infra per-network reconciliation (test/ttn/tstn + tstn-without-env failure).
- `pkg/defs`, `pkg/infra`, `pkg/services/...`, `pkg/wallet` (incl. BRC-100 conformance) all green.

## Notes / follow-ups

- `GetNetwork` continues to return the internal chain id (`main`/`test`/`ttn`/`tstn`) — this matches the existing documented BRC-100 divergence (`brc100_conformance_test.go`), so `ttn`/`tstn` are returned as-is rather than collapsed to `testnet`.
- Embedded ChainTracks `p2p_network` still accepts `main`/`test`/`stn` only (the remote-URL path used here is unaffected); wiring ttn/tstn through embedded mode is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)