### PR TITLE
feat: add aborted status as standarizedtxstatus; fix shadowing aborted with failed

### DIFF
--- a/pkg/storage/provider.go
+++ b/pkg/storage/provider.go
@@ -1286,11 +1286,12 @@ func (p *Provider) ListTransactions(ctx context.Context, auth wdk.AuthID, args w
 	transactions := make([]wdk.CurrentTxStatus, 0, len(knownTxs))
 	for _, ktx := range knownTxs {
 		status := ktx.Status.ToStandardizedStatus()
-		switch txStatusMap[ktx.TxID] {
+		switch txStatusMap[ktx.TxID] { //nolint:exhaustive // only Failed/Aborted override the KnownTx-derived status; all other TxStatus values keep it
 		case wdk.TxStatusFailed:
 			status = wdk.TxUpdateStatusFailed
 		case wdk.TxStatusAborted:
 			status = wdk.TxUpdateStatusAborted
+		default:
 		}
 
 		txUpdate := wdk.CurrentTxStatus{

--- a/pkg/storage/provider.go
+++ b/pkg/storage/provider.go
@@ -1286,8 +1286,11 @@ func (p *Provider) ListTransactions(ctx context.Context, auth wdk.AuthID, args w
 	transactions := make([]wdk.CurrentTxStatus, 0, len(knownTxs))
 	for _, ktx := range knownTxs {
 		status := ktx.Status.ToStandardizedStatus()
-		if s := txStatusMap[ktx.TxID]; s == wdk.TxStatusFailed || s == wdk.TxStatusAborted {
+		switch txStatusMap[ktx.TxID] {
+		case wdk.TxStatusFailed:
 			status = wdk.TxUpdateStatusFailed
+		case wdk.TxStatusAborted:
+			status = wdk.TxUpdateStatusAborted
 		}
 
 		txUpdate := wdk.CurrentTxStatus{

--- a/pkg/storage/provider_list_transactions_test.go
+++ b/pkg/storage/provider_list_transactions_test.go
@@ -140,15 +140,16 @@ func TestListTransactions_FilterByLabels(t *testing.T) {
 }
 
 // TestListTransactions_AbortedTxReportedAsTerminal proves ListTransactions reports
-// an aborted tx as terminal (Failed) even though its underlying KnownTx row is left
-// in a non-terminal ProvenTxReq status ('nosend'). AbortAction only flips the
-// Transaction to 'aborted'; it never touches the (possibly shared) KnownTx row, so a
-// tx created via ProcessAction(IsNoSend:true) and then aborted keeps KnownTx at
-// 'nosend'. Before the fix, the standardized-status override in ListTransactions only
-// fired for txStatusMap[txID] == TxStatusFailed, so this case fell through to the base
-// KnownTx-derived status (nosend -> Waiting) - reporting a dead, input-released tx as
-// still in-flight. The toolbox-owned standardized-status surface must always read
-// 'aborted' as terminal; the retryable nuance lives only on the raw TxStatus.
+// an aborted tx as terminal (Aborted), not Waiting, even though its underlying KnownTx
+// row is left in a non-terminal ProvenTxReq status ('nosend'). AbortAction only flips
+// the Transaction to 'aborted'; it never touches the (possibly shared) KnownTx row, so
+// a tx created via ProcessAction(IsNoSend:true) and then aborted keeps KnownTx at
+// 'nosend'. Without the standardized-status override in ListTransactions, this case
+// would fall through to the base KnownTx-derived status (nosend -> Waiting) - reporting
+// a dead, input-released tx as still in-flight. Aborted is reported as its own
+// standardized status, distinct from Failed: unlike a broadcast rejection, an aborted
+// tx was never sent to the network, so callers polling ListTransactions for idempotency
+// can tell it's safe to rebuild and retry from scratch.
 func TestListTransactions_AbortedTxReportedAsTerminal(t *testing.T) {
 	// Given:
 	ctx := t.Context()
@@ -193,10 +194,10 @@ func TestListTransactions_AbortedTxReportedAsTerminal(t *testing.T) {
 	}
 	result, err := activeStorage.ListTransactions(ctx, testusers.Alice.AuthID(), args)
 
-	// Then: reported as terminal (Failed), NOT Waiting, despite the KnownTx row
-	// still sitting at the non-terminal 'nosend' status
+	// Then: reported as terminal (Aborted), NOT Waiting or Failed, despite the KnownTx
+	// row still sitting at the non-terminal 'nosend' status
 	require.NoError(t, err)
 	require.Len(t, result.Transactions, 1)
 	assert.Equal(t, txID, result.Transactions[0].TxID)
-	assert.Equal(t, wdk.TxUpdateStatusFailed, result.Transactions[0].Status)
+	assert.Equal(t, wdk.TxUpdateStatusAborted, result.Transactions[0].Status)
 }

--- a/pkg/wdk/tx_status.go
+++ b/pkg/wdk/tx_status.go
@@ -58,7 +58,7 @@ func (s TxStatus) ToStandardizedStatus() StandardizedTxStatus {
 	case TxStatusFailed:
 		return TxUpdateStatusInvalidTx
 	case TxStatusAborted:
-		return TxUpdateStatusFailed
+		return TxUpdateStatusAborted
 	default:
 		return TxUpdateStatusUnknown
 	}
@@ -257,6 +257,11 @@ const (
 	TxUpdateStatusMined        StandardizedTxStatus = "mined"
 	TxUpdateStatusUnknown      StandardizedTxStatus = "unknown"
 	TxUpdateStatusFailed       StandardizedTxStatus = "failed"
+	// TxUpdateStatusAborted marks a tx that was never broadcast (see TxStatusAborted) -
+	// distinct from TxUpdateStatusFailed (broadcast and rejected by the network), so
+	// callers polling ListTransactions can tell "safe to rebuild and retry" apart from
+	// "permanently rejected".
+	TxUpdateStatusAborted StandardizedTxStatus = "aborted"
 )
 
 // String returns the string representation of StandardizedTxStatus

--- a/pkg/wdk/tx_status_test.go
+++ b/pkg/wdk/tx_status_test.go
@@ -271,7 +271,7 @@ func TestTxStatusMappings(t *testing.T) {
 		{wdk.TxStatusNoSend, wdk.UTXOStatusUnknown, wdk.TxUpdateStatusWaiting},
 		{wdk.TxStatusNonFinal, wdk.UTXOStatusUnknown, wdk.TxUpdateStatusWaiting},
 		{wdk.TxStatusUnfail, wdk.UTXOStatusUnknown, wdk.TxUpdateStatusWaiting},
-		{wdk.TxStatusAborted, wdk.UTXOStatusUnknown, wdk.TxUpdateStatusFailed},
+		{wdk.TxStatusAborted, wdk.UTXOStatusUnknown, wdk.TxUpdateStatusAborted},
 	}
 
 	allStatuses := []wdk.TxStatus{


### PR DESCRIPTION
## What Changed
- Added `TxUpdateStatusAborted` (`"aborted"`) to `StandardizedTxStatus`, so an abort has its own value on the standardized surface instead of borrowing `failed`.
- `TxStatus.ToStandardizedStatus()` now maps `TxStatusAborted` to `TxUpdateStatusAborted` (previously `TxUpdateStatusFailed`).
- `ListTransactions` replaces the combined `if s == TxStatusFailed || s == TxStatusAborted` override with a `switch`, so `failed` reports `failed` and `aborted` reports `aborted` — previously both collapsed onto `failed`.
- Updated the `TestTxStatusMappings` table and `TestListTransactions_AbortedTxReportedAsTerminal` to pin the new value.

## Why It Was Necessary
Follow-up to the review comments left on #961 after it merged: `aborted` was added as a stored `TxStatus`, but on the standardized surface it was shadowed by `failed`, so nothing downstream could tell the two apart.

They mean opposite things to a caller. A `failed` transaction was broadcast and rejected by the network — permanent. An `aborted` one was never broadcast at all (`AbortAction`, a cancelled `ProcessAction`, or the `fail_abandoned` sweep) and has had its inputs released, so it is safe to rebuild and retry from scratch. `ListTransactions` is the method callers use for idempotency, and it is the only one returning transaction data, so the distinction has to be visible there for a caller to decide between retrying and giving up.

The `ListTransactions` override also mattered on its own: `AbortAction` flips the `Transaction` to `aborted` without touching the (possibly shared) `KnownTx` row, which stays at `nosend`. Without the override, an aborted transaction fell through to the `KnownTx`-derived status and was reported as `waiting` — a dead, input-released transaction advertised as still in flight.

## Testing Performed
- `TestTxStatusMappings` — asserts `TxStatusAborted` maps to `TxUpdateStatusAborted` for both the UTXO and standardized mappings.
- `TestListTransactions_AbortedTxReportedAsTerminal` — creates a tx via `ProcessAction(IsNoSend: true)`, confirms the `KnownTx` row really is `nosend`, aborts it, then asserts `ListTransactions` reports `aborted` rather than `waiting` or `failed`.
- Full CI suite on the PR.

## Impact / Risk
`StandardizedTxStatus` gains a value, and one existing mapping changes: consumers that switch on the standardized status will now see `"aborted"` where they previously saw `"failed"`. Anything treating `failed` as "the terminal bucket" needs to handle `aborted` too, or it will fall through to a default branch. The stored `TxStatus` values are untouched, so this is a reporting change only — no migration, no change to which transactions are returned.

Known limitation, not addressed here: `ListTransactions` is driven by the `KnownTx` query, and a `KnownTx` row only exists once a transaction has been signed and spent. A transaction aborted before signing has no such row and is omitted from the result entirely, which a caller cannot distinguish from one that was never created. Followed up in #972.

## Notifications
- @kuba-4chain
