### PR TITLE
Report transactions aborted before signing in ListTransactions

### DIFF
--- a/pkg/storage/provider.go
+++ b/pkg/storage/provider.go
@@ -1260,9 +1260,12 @@ func (p *Provider) ListTransactions(ctx context.Context, auth wdk.AuthID, args w
 	}
 
 	if len(txIDs) == 0 {
+		// No signed transaction, but a locally-terminal one (aborted before it was
+		// ever signed) still has to be reported - see localOnlyTerminalTxs.
+		localOnly := localOnlyTerminalTxs(userTxs, nil, args)
 		return &wdk.ListTransactionsResult{
-			TotalTransactions: 0,
-			Transactions:      []wdk.CurrentTxStatus{},
+			TotalTransactions: primitives.PositiveInteger(uint64(len(localOnly))),
+			Transactions:      localOnly,
 		}, nil
 	}
 
@@ -1285,6 +1288,7 @@ func (p *Provider) ListTransactions(ctx context.Context, auth wdk.AuthID, args w
 	}
 
 	transactions := make([]wdk.CurrentTxStatus, 0, len(knownTxs))
+	reported := make(map[string]struct{}, len(knownTxs))
 	for _, ktx := range knownTxs {
 		status := ktx.Status.ToStandardizedStatus()
 		switch txStatusMap[ktx.TxID] { //nolint:exhaustive // only Failed/Aborted override the KnownTx-derived status; all other TxStatus values keep it
@@ -1322,12 +1326,78 @@ func (p *Provider) ListTransactions(ctx context.Context, auth wdk.AuthID, args w
 		}
 
 		transactions = append(transactions, txUpdate)
+
+		reported[ktx.TxID] = struct{}{}
 	}
+
+	// A transaction aborted before it was ever signed has no KnownTx row at all, so
+	// the query above cannot see it. Append those separately; otherwise an aborted
+	// action is indistinguishable from one that never existed.
+	localOnly := localOnlyTerminalTxs(userTxs, reported, args)
+	transactions = append(transactions, localOnly...)
+	totalCount += uint64(len(localOnly))
 
 	return &wdk.ListTransactionsResult{
 		TotalTransactions: primitives.PositiveInteger(totalCount),
 		Transactions:      transactions,
 	}, nil
+}
+
+// localOnlyTerminalTxs reports the user transactions that reached a terminal local
+// status without leaving a KnownTx row behind.
+//
+// ListTransactions is driven by KnownTx, which only gains a row once a transaction is
+// signed and spent. AbortAction, the fail_abandoned sweep and a canceled ProcessAction
+// can all mark a Transaction 'aborted' before that ever happens, and the same is true of
+// 'failed'. Such a transaction would otherwise be missing from the result entirely -
+// which callers using ListTransactions for idempotency cannot distinguish from a
+// transaction that was never created, even though the two demand opposite responses:
+// an aborted action has had its inputs released and is safe to rebuild and retry.
+//
+// Only terminal statuses are surfaced. In-flight local states (unsigned, nosend) are
+// deliberately left out so the reported set stays the transactions the caller can act
+// on. When args.Status is set the caller is filtering on a ProvenTxReqStatus, which by
+// definition no KnownTx-less transaction can satisfy, so nothing is added.
+//
+// TxID is empty for a transaction aborted before signing, since none was ever assigned;
+// callers match those on Reference.
+func localOnlyTerminalTxs(userTxs []*entity.Transaction, reported map[string]struct{}, args wdk.ListTransactionsArgs) []wdk.CurrentTxStatus {
+	if args.Status != nil {
+		return nil
+	}
+
+	localOnly := make([]wdk.CurrentTxStatus, 0)
+	for _, tx := range userTxs {
+		// Mirrors the override applied to the KnownTx-backed rows above rather than
+		// TxStatus.ToStandardizedStatus(), which maps 'failed' to InvalidTx. Both halves
+		// of a single result set must label the same local status the same way.
+		var status wdk.StandardizedTxStatus
+		switch tx.Status { //nolint:exhaustive // only the terminal local statuses are reported here
+		case wdk.TxStatusAborted:
+			status = wdk.TxUpdateStatusAborted
+		case wdk.TxStatusFailed:
+			status = wdk.TxUpdateStatusFailed
+		default:
+			continue
+		}
+
+		txID := ""
+		if tx.TxID != nil {
+			if _, ok := reported[*tx.TxID]; ok {
+				continue
+			}
+			txID = *tx.TxID
+		}
+
+		localOnly = append(localOnly, wdk.CurrentTxStatus{
+			TxID:      txID,
+			Status:    status,
+			Reference: tx.Reference,
+			Labels:    tx.Labels,
+		})
+	}
+
+	return localOnly
 }
 
 // ProcessNewTip updates the last checked block and runs transaction synchronization.

--- a/pkg/storage/provider_list_transactions_test.go
+++ b/pkg/storage/provider_list_transactions_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/entity"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/randomizer"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/storage"
@@ -200,4 +201,121 @@ func TestListTransactions_AbortedTxReportedAsTerminal(t *testing.T) {
 	require.Len(t, result.Transactions, 1)
 	assert.Equal(t, txID, result.Transactions[0].TxID)
 	assert.Equal(t, wdk.TxUpdateStatusAborted, result.Transactions[0].Status)
+}
+
+// TestListTransactions_AbortedBeforeSigningIsReported covers the abort that happens
+// before a transaction is ever signed - the case the standardized-status override alone
+// does not reach.
+//
+// ListTransactions is driven by KnownTx, and a KnownTx row only appears once the
+// transaction is signed and spent. Aborting straight after CreateAction therefore leaves
+// nothing for that query to return, so the action used to vanish from the result set
+// entirely. For a caller polling ListTransactions for idempotency that is the worst
+// possible answer: absent is indistinguishable from never-created, yet the two require
+// opposite responses - an aborted action has had its inputs released and must be rebuilt.
+func TestListTransactions_AbortedBeforeSigningIsReported(t *testing.T) {
+	// Given:
+	ctx := t.Context()
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+
+	activeStorage := given.Provider().WithRandomizer(randomizer.NewTestRandomizer()).GORM()
+
+	// and: a transaction created but never processed, so no KnownTx row exists for it
+	createResult, _ := given.Action(activeStorage).Created()
+
+	// and: aborted while still unsigned
+	_, err := activeStorage.AbortAction(ctx, testusers.Alice.AuthID(), wdk.AbortActionArgs{
+		Reference: primitives.Base64String(createResult.Reference),
+	})
+	require.NoError(t, err)
+
+	testabilities.ThenDBState(t, activeStorage).
+		HasUserTransactionByReference(testusers.Alice, createResult.Reference).
+		WithStatus(wdk.TxStatusAborted)
+
+	// When:
+	result, err := activeStorage.ListTransactions(ctx, testusers.Alice.AuthID(), wdk.ListTransactionsArgs{
+		Limit:  50,
+		Offset: 0,
+	})
+
+	// Then: the aborted action is present and reported as Aborted, matched on Reference
+	// because no TxID was ever assigned to it.
+	require.NoError(t, err)
+
+	var aborted *wdk.CurrentTxStatus
+	for i := range result.Transactions {
+		if result.Transactions[i].Reference == createResult.Reference {
+			aborted = &result.Transactions[i]
+			break
+		}
+	}
+	require.NotNil(t, aborted, "aborted tx must be reported, not silently omitted")
+	assert.Equal(t, wdk.TxUpdateStatusAborted, aborted.Status)
+	assert.Empty(t, aborted.TxID, "no TxID is assigned before signing")
+}
+
+// TestListTransactions_FailedAndAbortedAreDistinguishable pins the distinction the
+// status exists for. Both are terminal, but only one is retryable: an aborted
+// transaction was never broadcast and its inputs are released, so it is safe to rebuild
+// from scratch, whereas a failed one was rejected by the network. Collapsing them onto a
+// single status would leave callers unable to decide between retrying and giving up.
+func TestListTransactions_FailedAndAbortedAreDistinguishable(t *testing.T) {
+	tests := map[string]struct {
+		status     wdk.TxStatus
+		wantStatus wdk.StandardizedTxStatus
+	}{
+		"aborted is reported as aborted": {
+			status:     wdk.TxStatusAborted,
+			wantStatus: wdk.TxUpdateStatusAborted,
+		},
+		"failed is reported as failed": {
+			status:     wdk.TxStatusFailed,
+			wantStatus: wdk.TxUpdateStatusFailed,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Given:
+			ctx := t.Context()
+			given, cleanup := testabilities.Given(t)
+			defer cleanup()
+
+			activeStorage := given.Provider().WithRandomizer(randomizer.NewTestRandomizer()).GORM()
+
+			createResult, _ := given.Action(activeStorage).Created()
+
+			// and: driven into the terminal status under test
+			userTxs, err := activeStorage.TransactionEntity().Read().
+				Reference().Equals(createResult.Reference).Find(ctx)
+			require.NoError(t, err)
+			require.Len(t, userTxs, 1)
+
+			require.NoError(t, activeStorage.TransactionEntity().Update(ctx, &entity.TransactionUpdateSpecification{
+				ID:     userTxs[0].ID,
+				Status: to.Ptr(tt.status),
+			}))
+
+			// When:
+			result, err := activeStorage.ListTransactions(ctx, testusers.Alice.AuthID(), wdk.ListTransactionsArgs{
+				Limit:  50,
+				Offset: 0,
+			})
+
+			// Then:
+			require.NoError(t, err)
+
+			var found *wdk.CurrentTxStatus
+			for i := range result.Transactions {
+				if result.Transactions[i].Reference == createResult.Reference {
+					found = &result.Transactions[i]
+					break
+				}
+			}
+			require.NotNil(t, found, "terminal tx must be reported")
+			assert.Equal(t, tt.wantStatus, found.Status)
+		})
+	}
 }


### PR DESCRIPTION
## What Changed
- `ListTransactions` now also reports user transactions that reached a terminal local status (`aborted`, `failed`) without leaving a `KnownTx` row behind, extracted into a `localOnlyTerminalTxs` helper.
- Two regression tests: one for the abort-before-signing case, one table-driven test pinning `aborted` and `failed` to distinct standardized statuses.

## Why It Was Necessary
Completes the post-merge review on #961. #971 made `aborted` a distinct `StandardizedTxStatus` and overrode it in `ListTransactions`, which fixed reporting **for transactions that have a `KnownTx` row** — but that row only appears once a transaction has been signed and spent (`upsertKnownTx`, inside `SpendTransaction`).

`AbortAction`, the `fail_abandoned` sweep and a canceled `ProcessAction` can all mark a `Transaction` `aborted` before that ever happens. Those transactions had nothing for the `KnownTx` query to return, so they were dropped from the result entirely. Measured on `main` before the change — a `CreateAction` followed by `AbortAction`, then `ListTransactions`:

```
total=1  len=1
  tx=57cb5176... status=broadcasted     <- fixture funding tx only; the aborted tx is absent
```

`ListTransactions` is the method callers use for idempotency, and it is the only one returning transaction data. "Absent" is indistinguishable from "never created", yet the two demand opposite responses: an aborted action has had its inputs released and must be rebuilt, whereas a missing one has to be created for the first time. After the change the aborted transaction is reported with `status=aborted`.

## Testing Performed
- `TestListTransactions_AbortedBeforeSigningIsReported` — creates a transaction, aborts it while still unsigned, asserts it is present and reported as `aborted`, matched on `Reference` since no `TxID` was ever assigned.
- `TestListTransactions_FailedAndAbortedAreDistinguishable` — drives a `KnownTx`-less transaction into each terminal status and asserts `aborted` reports `aborted` and `failed` reports `failed`.
- Both were confirmed to fail against `provider.go` from `main` and pass with the change, so they are genuine regression tests rather than assertions of current behavior.
- `./pkg/storage/...`, `./pkg/wdk/...` and `./pkg/internal/storage/...` pass; `go vet` and `gofmt` clean.

## Impact / Risk
Additive to the result set: transactions that were previously omitted are now returned. Nothing that was already reported changes, and no stored data or migration is involved.

Two deliberate constraints keep the blast radius small:
- Only terminal local statuses are surfaced. In-flight states (`unsigned`, `nosend`) are left out, so the result stays the set of transactions a caller can act on.
- When `args.Status` is set the caller is filtering on a `ProvenTxReqStatus`, which no `KnownTx`-less transaction can satisfy by definition, so nothing is added and the filter's meaning is preserved.

Callers that treat `failed` as the single terminal bucket need to handle `aborted` as well — already true as of #971, but more visible now that these transactions actually appear.

Worth a reviewer's eye: the helper deliberately mirrors the existing `KnownTx`-backed override (`failed` → `failed`) instead of calling `TxStatus.ToStandardizedStatus()`, which maps `failed` → `invalidTx`. Both halves of one result set have to label the same local status identically, but that divergence still exists in `wdk` and may deserve reconciling separately.

`TxID` is empty for a transaction aborted before signing, since none was ever assigned; callers match those on `Reference`.

## Notifications
- @kuba-4chain
