### PR TITLE
fix(storage): post unconfirmed parents before children in delayed broadcast

### DIFF
--- a/pkg/storage/internal/service/background_broadcaster.go
+++ b/pkg/storage/internal/service/background_broadcaster.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
+	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/bsv-blockchain/go-sdk/transaction"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/logging"
@@ -32,6 +34,18 @@ const (
 	// BackgroundBroadcasterChannelSize is the default buffer size for the
 	// broadcast channel. Add() drops to the cron fallback once it is full.
 	BackgroundBroadcasterChannelSize = 1000
+
+	// defaultMaxParentWait bounds how long a child waits for its unconfirmed
+	// parent to be posted to the broadcaster before it is posted anyway. It is a
+	// safety net against a parent that is never broadcast here (e.g. an external
+	// unconfirmed source): the child is not held forever. In steady state the
+	// parent posts within milliseconds and the child is released immediately, so
+	// this deadline is rarely reached.
+	defaultMaxParentWait = 30 * time.Second
+
+	// parentWaitSweepInterval is how often parked children are re-checked for an
+	// expired parent-wait deadline.
+	parentWaitSweepInterval = time.Second
 )
 
 // Sizing configures the broadcaster's capacity. Zero values select the
@@ -39,6 +53,9 @@ const (
 type Sizing struct {
 	Workers     int
 	ChannelSize int
+	// MaxParentWait bounds how long a child is held waiting for its unconfirmed
+	// parent to be posted before being force-posted. Zero selects the default.
+	MaxParentWait time.Duration
 }
 
 func (s Sizing) workers() int {
@@ -53,6 +70,13 @@ func (s Sizing) channelSize() int {
 		return BackgroundBroadcasterChannelSize
 	}
 	return s.ChannelSize
+}
+
+func (s Sizing) maxParentWait() time.Duration {
+	if s.MaxParentWait <= 0 {
+		return defaultMaxParentWait
+	}
+	return s.MaxParentWait
 }
 
 type broadcaster interface {
@@ -71,12 +95,24 @@ type BackgroundBroadcaster struct {
 	// optional notification channel
 	txBroadcastedChannel chan<- wdk.CurrentTxStatus
 
+	// Dependency ordering: Arcade forwards to Teranode in the order it receives
+	// transactions, so a child that spends an unconfirmed parent must be POSTed
+	// after that parent — otherwise Teranode rejects the child (its input isn't
+	// in the UTXO set yet). Because parent and child arrive as independent
+	// concurrent items drained by many workers, we gate here: a child is held
+	// until every unconfirmed parent it spends has been posted.
+	depMu   sync.Mutex
+	posted  map[string]struct{}          // txids whose Arcade POST returned successfully
+	waiting map[string][]broadcastItem   // children parked under an unposted parent txid
+
 	stopOnce sync.Once
 }
 
 type broadcastItem struct {
 	beef  *transaction.Beef
 	txIDs []string
+	// deadline is when the item may be posted regardless of unposted parents.
+	deadline time.Time
 }
 
 func NewBackgroundBroadcaster(ctx context.Context, parentLogger *slog.Logger, broadcastHandler broadcaster, txBroadcastedChannel chan<- wdk.CurrentTxStatus, sizing Sizing) *BackgroundBroadcaster {
@@ -90,6 +126,8 @@ func NewBackgroundBroadcaster(ctx context.Context, parentLogger *slog.Logger, br
 		logger:               logger,
 		broadcastHandler:     broadcastHandler,
 		txBroadcastedChannel: txBroadcastedChannel,
+		posted:               make(map[string]struct{}),
+		waiting:              make(map[string][]broadcastItem),
 	}
 }
 
@@ -98,6 +136,8 @@ func (bb *BackgroundBroadcaster) Start() {
 		bb.wg.Add(1)
 		go bb.worker()
 	}
+	bb.wg.Add(1)
+	go bb.parentWaitSweeper()
 }
 
 func (bb *BackgroundBroadcaster) Stop() {
@@ -110,8 +150,9 @@ func (bb *BackgroundBroadcaster) Stop() {
 
 func (bb *BackgroundBroadcaster) Add(beef *transaction.Beef, txIDs []string) (added bool) {
 	bb.logger.InfoContext(bb.ctx, "Adding new beef to delayed broadcast", "txIDs", txIDs)
+	item := broadcastItem{beef: beef, txIDs: txIDs, deadline: time.Now().Add(bb.sizing.maxParentWait())}
 	select {
-	case bb.broadcastChannel <- broadcastItem{beef: beef, txIDs: txIDs}:
+	case bb.broadcastChannel <- item:
 		return true
 	default:
 		return false
@@ -129,11 +170,139 @@ func (bb *BackgroundBroadcaster) worker() {
 			if !ok {
 				return
 			}
-			if err := bb.broadcast(&item); err != nil {
-				bb.logger.ErrorContext(bb.ctx, "Failed to broadcast transaction", "error", err, "txIDs", item.txIDs)
-			} else {
-				bb.logger.InfoContext(bb.ctx, "Successfully broadcasted transaction", "txIDs", item.txIDs)
+			bb.process(item)
+		}
+	}
+}
+
+// process posts the item once its unconfirmed parents have been posted (or its
+// wait deadline has passed), parking it otherwise.
+func (bb *BackgroundBroadcaster) process(item broadcastItem) {
+	if !time.Now().After(item.deadline) {
+		bb.depMu.Lock()
+		if parent := bb.firstUnpostedParentLocked(item); parent != "" {
+			bb.waiting[parent] = append(bb.waiting[parent], item)
+			bb.depMu.Unlock()
+			bb.logger.DebugContext(bb.ctx, "holding child until parent is posted", "parent", parent, "txIDs", item.txIDs)
+			return
+		}
+		bb.depMu.Unlock()
+	}
+
+	if err := bb.broadcast(&item); err != nil {
+		bb.logger.ErrorContext(bb.ctx, "Failed to broadcast transaction", "error", err, "txIDs", item.txIDs)
+		return
+	}
+	bb.logger.InfoContext(bb.ctx, "Successfully broadcasted transaction", "txIDs", item.txIDs)
+	bb.markPostedAndRelease(item.txIDs)
+}
+
+// firstUnpostedParentLocked returns the txid of the first unconfirmed parent that
+// this item spends and that has not yet been posted, or "" if it is ready.
+// A parent is gate-worthy only when it is present in the item's beef as a raw,
+// un-mined transaction (transaction.RawTx): a mined parent (RawTxAndBumpIndex)
+// is already in the UTXO set, and a txid-only / absent parent is not something
+// this broadcaster is responsible for. Caller must hold depMu.
+func (bb *BackgroundBroadcaster) firstUnpostedParentLocked(item broadcastItem) string {
+	if item.beef == nil {
+		return ""
+	}
+	for _, txID := range item.txIDs {
+		hash, err := chainhash.NewHashFromHex(txID)
+		if err != nil {
+			continue
+		}
+		tx := item.beef.FindTransactionByHash(hash)
+		if tx == nil {
+			continue
+		}
+		for _, in := range tx.Inputs {
+			if in.SourceTXID == nil {
+				continue
 			}
+			parentBeefTx := item.beef.Transactions[*in.SourceTXID]
+			if parentBeefTx == nil || parentBeefTx.DataFormat != transaction.RawTx {
+				continue // absent, txid-only, or mined (bump) parent → no gating
+			}
+			parentID := in.SourceTXID.String()
+			if _, ok := bb.posted[parentID]; ok {
+				continue
+			}
+			return parentID
+		}
+	}
+	return ""
+}
+
+// markPostedAndRelease records the posted txids and re-queues any children that
+// were waiting on them.
+func (bb *BackgroundBroadcaster) markPostedAndRelease(txIDs []string) {
+	bb.depMu.Lock()
+	var released []broadcastItem
+	for _, txID := range txIDs {
+		bb.posted[txID] = struct{}{}
+		if children, ok := bb.waiting[txID]; ok {
+			released = append(released, children...)
+			delete(bb.waiting, txID)
+		}
+	}
+	bb.depMu.Unlock()
+	bb.requeue(released)
+}
+
+// requeue puts released/expired items back on the broadcast channel without
+// blocking the caller (a full channel would otherwise deadlock a worker).
+func (bb *BackgroundBroadcaster) requeue(items []broadcastItem) {
+	if len(items) == 0 {
+		return
+	}
+	bb.wg.Add(1)
+	go func() {
+		defer bb.wg.Done()
+		for _, it := range items {
+			select {
+			case bb.broadcastChannel <- it:
+			case <-bb.ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+// parentWaitSweeper force-posts children whose parent-wait deadline has passed so
+// a never-posted parent cannot hold them forever.
+func (bb *BackgroundBroadcaster) parentWaitSweeper() {
+	defer bb.wg.Done()
+	ticker := time.NewTicker(parentWaitSweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-bb.ctx.Done():
+			return
+		case <-ticker.C:
+			now := time.Now()
+			bb.depMu.Lock()
+			var expired []broadcastItem
+			for parent, children := range bb.waiting {
+				kept := children[:0]
+				for _, it := range children {
+					if now.After(it.deadline) {
+						expired = append(expired, it)
+					} else {
+						kept = append(kept, it)
+					}
+				}
+				if len(kept) == 0 {
+					delete(bb.waiting, parent)
+				} else {
+					bb.waiting[parent] = kept
+				}
+			}
+			bb.depMu.Unlock()
+			if len(expired) > 0 {
+				bb.logger.WarnContext(bb.ctx, "parent-wait deadline reached, force-posting children", "count", len(expired))
+			}
+			bb.requeue(expired)
 		}
 	}
 }

--- a/pkg/storage/internal/service/background_broadcaster.go
+++ b/pkg/storage/internal/service/background_broadcaster.go
@@ -35,26 +35,33 @@ const (
 	// broadcast channel. Add() drops to the cron fallback once it is full.
 	BackgroundBroadcasterChannelSize = 1000
 
-	// defaultMaxParentWait bounds how long a child waits for its unconfirmed
-	// parent to be posted to the broadcaster before it is posted anyway. It is a
-	// safety net against a parent that is never broadcast here (e.g. an external
-	// unconfirmed source): the child is not held forever. In steady state the
-	// parent posts within milliseconds and the child is released immediately, so
-	// this deadline is rarely reached.
+	// defaultMaxParentWait bounds how long a child waits for an unconfirmed parent
+	// that this pool has itself been asked to broadcast. Such a parent is going to
+	// be posted here, so the wait is generous; it only guards against a parent
+	// whose own POST keeps failing. In steady state the parent posts within
+	// milliseconds and the child is released immediately.
 	defaultMaxParentWait = 30 * time.Second
 
-	// defaultPostedRetention is how long a successfully posted txid is remembered
-	// so that a later child spending it need not wait. It only has to cover the
+	// defaultUnknownParentWait bounds how long a child waits for an unconfirmed
+	// parent this pool has never been asked to broadcast. Such a parent is not
+	// coming: it was posted by the non-delayed path, by the send_waiting cron
+	// (which is where Add's overflow goes), by a previous process lifetime, or by
+	// another wallet entirely. The wait is therefore only long enough to cover the
+	// race this gating exists for — parent and child enqueued concurrently, child
+	// first — after which the child is posted rather than stalled.
+	defaultUnknownParentWait = 500 * time.Millisecond
+
+	// defaultPostedRetention is how long posted and enqueued txids are remembered
+	// for the benefit of children that reference them. It only has to cover the
 	// gap between a parent's POST and the arrival of a child that spends it —
-	// normally milliseconds — so a generous window still bounds the posted set to
-	// the transactions of that window rather than the process lifetime. Forgetting
-	// a parent too early costs a child at most MaxParentWait of latency, never
-	// correctness.
+	// normally milliseconds — so a generous window still bounds those sets to the
+	// transactions of that window rather than the process lifetime. Forgetting a
+	// parent early costs a child a short wait, never correctness.
 	defaultPostedRetention = 2 * time.Hour
 
-	// parentWaitSweepInterval is how often parked children are re-checked for an
-	// expired parent-wait deadline (and the posted set pruned).
-	parentWaitSweepInterval = time.Second
+	// defaultSweepInterval is how often parked children are re-checked for an
+	// expired parent wait (and the posted/enqueued sets pruned).
+	defaultSweepInterval = 250 * time.Millisecond
 )
 
 // Sizing configures the broadcaster's capacity. Zero values select the
@@ -62,12 +69,18 @@ const (
 type Sizing struct {
 	Workers     int
 	ChannelSize int
-	// MaxParentWait bounds how long a child is held waiting for its unconfirmed
-	// parent to be posted before being force-posted. Zero selects the default.
+	// MaxParentWait bounds how long a child is held waiting for an unconfirmed
+	// parent that this pool is going to post. Zero selects the default.
 	MaxParentWait time.Duration
-	// PostedRetention bounds how long posted txids are remembered for the benefit
-	// of children that arrive later. Zero selects the default.
+	// UnknownParentWait bounds how long a child is held waiting for an unconfirmed
+	// parent that this pool has not been asked to post. Zero selects the default.
+	UnknownParentWait time.Duration
+	// PostedRetention bounds how long posted and enqueued txids are remembered for
+	// the benefit of children that arrive later. Zero selects the default.
 	PostedRetention time.Duration
+	// SweepInterval is how often parked children are re-checked. Zero selects the
+	// default.
+	SweepInterval time.Duration
 }
 
 func (s Sizing) workers() int {
@@ -91,11 +104,25 @@ func (s Sizing) maxParentWait() time.Duration {
 	return s.MaxParentWait
 }
 
+func (s Sizing) unknownParentWait() time.Duration {
+	if s.UnknownParentWait <= 0 {
+		return defaultUnknownParentWait
+	}
+	return s.UnknownParentWait
+}
+
 func (s Sizing) postedRetention() time.Duration {
 	if s.PostedRetention <= 0 {
 		return defaultPostedRetention
 	}
 	return s.PostedRetention
+}
+
+func (s Sizing) sweepInterval() time.Duration {
+	if s.SweepInterval <= 0 {
+		return defaultSweepInterval
+	}
+	return s.SweepInterval
 }
 
 type broadcaster interface {
@@ -121,13 +148,12 @@ type BackgroundBroadcaster struct {
 	// concurrent items drained by many workers, we gate here: a child is held
 	// until every unconfirmed parent it spends has been posted.
 	depMu sync.Mutex
-	// posted maps a txid whose Arcade POST returned successfully to when that
-	// happened; postedOrder holds the same txids in insertion (i.e. ascending
-	// time) order so the sweeper can prune expired entries from its front instead
-	// of scanning the whole map.
-	posted      map[string]time.Time
-	postedOrder []postedTxID
-	waiting     map[string][]broadcastItem // children parked under an unposted parent txid
+	// enqueued holds txids this pool has been asked to broadcast, posted those
+	// whose Arcade POST returned successfully. Together they answer "will this
+	// parent be posted here, and has it been?" — the two questions gating a child.
+	enqueued txidSet
+	posted   txidSet
+	waiting  map[string][]broadcastItem // children parked under an unposted parent txid
 
 	// requeueQueue holds items whose parent has been posted (or whose wait
 	// expired) until the dispatcher can put them back on broadcastChannel.
@@ -138,25 +164,65 @@ type BackgroundBroadcaster struct {
 	stopOnce sync.Once
 }
 
-// postedTxID is a posted txid together with the time it was posted, kept for
-// retention pruning.
-type postedTxID struct {
+// txidSet remembers txids for a bounded time window. Entries are appended in
+// ascending time order, so pruning walks the front of the slice and costs only
+// what it removes instead of scanning everything remembered — the set must not
+// grow with the lifetime transaction volume of a long-lived storage service.
+type txidSet struct {
+	at    map[string]time.Time
+	order []txidAt
+}
+
+type txidAt struct {
 	txID string
 	at   time.Time
+}
+
+func newTxidSet() txidSet {
+	return txidSet{at: make(map[string]time.Time)}
+}
+
+func (s *txidSet) add(txID string, now time.Time) {
+	s.at[txID] = now
+	s.order = append(s.order, txidAt{txID: txID, at: now})
+}
+
+func (s *txidSet) has(txID string) bool {
+	_, ok := s.at[txID]
+	return ok
+}
+
+// prune drops every txid added at or before cutoff.
+func (s *txidSet) prune(cutoff time.Time) {
+	pruned := 0
+	for ; pruned < len(s.order); pruned++ {
+		entry := s.order[pruned]
+		if entry.at.After(cutoff) {
+			break
+		}
+		// A re-added txid has a newer map timestamp and a later order entry; drop it
+		// only when this entry is the newest one for that txid.
+		if at, ok := s.at[entry.txID]; ok && !at.After(entry.at) {
+			delete(s.at, entry.txID)
+		}
+	}
+	if pruned > 0 {
+		s.order = append(s.order[:0], s.order[pruned:]...)
+	}
 }
 
 type broadcastItem struct {
 	beef  *transaction.Beef
 	txIDs []string
-	// deadline is when a parked item may be posted regardless of unposted
-	// parents. It stays zero until the item is first parked: the parent wait must
-	// measure time spent waiting for a parent, not time spent queued behind other
-	// work. Starting it at Add() time would let a backlog (posts slower than
-	// creates — the high-TPS regime this gating exists for) expire the wait before
-	// a worker ever inspects the item, force-posting the child out of order.
-	deadline time.Time
+	// parkedAt is when the item was first held for a parent, and zero until then:
+	// the parent wait must measure time spent waiting for a parent, not time spent
+	// queued behind other work. Starting the clock at Add() time would let a
+	// backlog (posts slower than creates — the high-TPS regime this gating exists
+	// for) expire the wait before a worker ever inspects the item, force-posting
+	// the child out of order.
+	parkedAt time.Time
 	// force skips parent gating entirely. Only the sweeper sets it, on items whose
-	// parent-wait deadline has passed.
+	// parent wait has run out.
 	force bool
 }
 
@@ -171,7 +237,8 @@ func NewBackgroundBroadcaster(ctx context.Context, parentLogger *slog.Logger, br
 		logger:               logger,
 		broadcastHandler:     broadcastHandler,
 		txBroadcastedChannel: txBroadcastedChannel,
-		posted:               make(map[string]time.Time),
+		enqueued:             newTxidSet(),
+		posted:               newTxidSet(),
 		waiting:              make(map[string][]broadcastItem),
 		requeueWake:          make(chan struct{}, 1),
 	}
@@ -201,9 +268,21 @@ func (bb *BackgroundBroadcaster) Add(beef *transaction.Beef, txIDs []string) (ad
 	item := broadcastItem{beef: beef, txIDs: parentsFirst(beef, txIDs)}
 	select {
 	case bb.broadcastChannel <- item:
+		// Only an accepted item is remembered: what overflows to the cron fallback is
+		// not going to be posted here, and children must not wait for it.
+		bb.markEnqueued(item.txIDs)
 		return true
 	default:
 		return false
+	}
+}
+
+func (bb *BackgroundBroadcaster) markEnqueued(txIDs []string) {
+	now := time.Now()
+	bb.depMu.Lock()
+	defer bb.depMu.Unlock()
+	for _, txID := range txIDs {
+		bb.enqueued.add(txID, now)
 	}
 }
 
@@ -240,9 +319,8 @@ func (bb *BackgroundBroadcaster) process(item broadcastItem) {
 }
 
 // park holds the item under the first unconfirmed parent it spends that has not
-// been posted yet, reporting whether it was parked. The parent-wait deadline
-// starts on the first park, so an item re-parked under a second parent still
-// waits at most MaxParentWait in total.
+// been posted yet, reporting whether it was parked. The wait clock starts on the
+// first park, so an item re-parked under a second parent does not start over.
 func (bb *BackgroundBroadcaster) park(item *broadcastItem) bool {
 	bb.depMu.Lock()
 	parent := bb.firstUnpostedParentLocked(*item)
@@ -250,8 +328,8 @@ func (bb *BackgroundBroadcaster) park(item *broadcastItem) bool {
 		bb.depMu.Unlock()
 		return false
 	}
-	if item.deadline.IsZero() {
-		item.deadline = time.Now().Add(bb.sizing.maxParentWait())
+	if item.parkedAt.IsZero() {
+		item.parkedAt = time.Now()
 	}
 	bb.waiting[parent] = append(bb.waiting[parent], *item)
 	bb.depMu.Unlock()
@@ -265,9 +343,9 @@ func (bb *BackgroundBroadcaster) park(item *broadcastItem) bool {
 //
 // Note that posted is local to this broadcaster's delayed pool, not global
 // network state: a parent posted by the non-delayed path, by the send_waiting
-// cron fallback (which is what happens when this pool's channel is full), or by a
-// previous process lifetime is absent from it. A child of such a parent waits out
-// MaxParentWait and is then force-posted, which costs latency, never correctness.
+// cron fallback, or by a previous process lifetime is absent from it. Such a
+// parent is also absent from enqueued, so parentWaitLocked holds its children for
+// the short unknown-parent grace only rather than stalling them.
 //
 // Caller must hold depMu.
 func (bb *BackgroundBroadcaster) firstUnpostedParentLocked(item broadcastItem) string {
@@ -307,7 +385,7 @@ func (bb *BackgroundBroadcaster) firstUnpostedParentOfLocked(beef *transaction.B
 		if _, ok := subjects[parentID]; ok {
 			continue // posted by this very item, ahead of this child
 		}
-		if _, ok := bb.posted[parentID]; ok {
+		if bb.posted.has(parentID) {
 			continue
 		}
 		parentBeefTx := beef.Transactions[*in.SourceTXID]
@@ -391,8 +469,7 @@ func (bb *BackgroundBroadcaster) markPostedAndRelease(txIDs []string) {
 	bb.depMu.Lock()
 	var released []broadcastItem
 	for _, txID := range txIDs {
-		bb.posted[txID] = now
-		bb.postedOrder = append(bb.postedOrder, postedTxID{txID: txID, at: now})
+		bb.posted.add(txID, now)
 		if children, ok := bb.waiting[txID]; ok {
 			released = append(released, children...)
 			delete(bb.waiting, txID)
@@ -460,12 +537,12 @@ func (bb *BackgroundBroadcaster) drainRequeue() bool {
 	}
 }
 
-// parentWaitSweeper force-posts children whose parent-wait deadline has passed so
-// a never-posted parent cannot hold them forever, and prunes the posted set so it
-// cannot grow with lifetime transaction volume.
+// parentWaitSweeper force-posts children whose parent wait has run out so a
+// never-posted parent cannot hold them forever, and prunes the remembered txids
+// so they cannot grow with lifetime transaction volume.
 func (bb *BackgroundBroadcaster) parentWaitSweeper() {
 	defer bb.wg.Done()
-	ticker := time.NewTicker(parentWaitSweepInterval)
+	ticker := time.NewTicker(bb.sizing.sweepInterval())
 	defer ticker.Stop()
 	for {
 		select {
@@ -480,25 +557,27 @@ func (bb *BackgroundBroadcaster) parentWaitSweeper() {
 func (bb *BackgroundBroadcaster) sweep(now time.Time) {
 	bb.depMu.Lock()
 	expired := bb.takeExpiredLocked(now)
-	bb.prunePostedLocked(now)
+	cutoff := now.Add(-bb.sizing.postedRetention())
+	bb.enqueued.prune(cutoff)
+	bb.posted.prune(cutoff)
 	bb.depMu.Unlock()
 
 	if len(expired) == 0 {
 		return
 	}
-	bb.logger.WarnContext(bb.ctx, "parent-wait deadline reached, force-posting children", "count", len(expired))
+	bb.logger.WarnContext(bb.ctx, "parent wait ran out, force-posting children", "count", len(expired))
 	bb.requeue(expired)
 }
 
-// takeExpiredLocked removes and returns the parked items whose parent-wait
-// deadline has passed, flagged to skip gating on their next attempt. Caller must
-// hold depMu.
+// takeExpiredLocked removes and returns the parked items whose parent wait has
+// run out, flagged to skip gating on their next attempt. Caller must hold depMu.
 func (bb *BackgroundBroadcaster) takeExpiredLocked(now time.Time) []broadcastItem {
 	var expired []broadcastItem
 	for parent, children := range bb.waiting {
+		wait := bb.parentWaitLocked(parent)
 		kept := children[:0]
 		for _, item := range children {
-			if now.After(item.deadline) {
+			if now.Sub(item.parkedAt) > wait {
 				item.force = true
 				expired = append(expired, item)
 				continue
@@ -514,27 +593,19 @@ func (bb *BackgroundBroadcaster) takeExpiredLocked(now time.Time) []broadcastIte
 	return expired
 }
 
-// prunePostedLocked drops posted txids older than the retention window.
-// postedOrder is in ascending time order, so pruning stops at the first entry
-// still inside the window and costs only what it removes. Caller must hold depMu.
-func (bb *BackgroundBroadcaster) prunePostedLocked(now time.Time) {
-	cutoff := now.Add(-bb.sizing.postedRetention())
-
-	pruned := 0
-	for ; pruned < len(bb.postedOrder); pruned++ {
-		entry := bb.postedOrder[pruned]
-		if entry.at.After(cutoff) {
-			break
-		}
-		// A re-posted txid has a newer map timestamp and a later order entry; drop
-		// it only when this entry is the newest one for that txid.
-		if at, ok := bb.posted[entry.txID]; ok && !at.After(entry.at) {
-			delete(bb.posted, entry.txID)
-		}
+// parentWaitLocked is how long a child may be held for this parent: the full
+// MaxParentWait once the parent is known to this pool, because it was enqueued
+// here and so will be posted here, and only the short UnknownParentWait grace
+// otherwise. An unknown parent is not coming — it went out by another path, in an
+// earlier process, or from another wallet — and its children must not stall
+// waiting for a POST that will never happen here. The grace still covers a parent
+// enqueued moments after its child, which is the race this gating exists for.
+// Caller must hold depMu.
+func (bb *BackgroundBroadcaster) parentWaitLocked(parentID string) time.Duration {
+	if bb.enqueued.has(parentID) {
+		return bb.sizing.maxParentWait()
 	}
-	if pruned > 0 {
-		bb.postedOrder = append(bb.postedOrder[:0], bb.postedOrder[pruned:]...)
-	}
+	return bb.sizing.unknownParentWait()
 }
 
 func (bb *BackgroundBroadcaster) broadcast(item *broadcastItem) (err error) {

--- a/pkg/storage/internal/service/background_broadcaster.go
+++ b/pkg/storage/internal/service/background_broadcaster.go
@@ -43,8 +43,17 @@ const (
 	// this deadline is rarely reached.
 	defaultMaxParentWait = 30 * time.Second
 
+	// defaultPostedRetention is how long a successfully posted txid is remembered
+	// so that a later child spending it need not wait. It only has to cover the
+	// gap between a parent's POST and the arrival of a child that spends it —
+	// normally milliseconds — so a generous window still bounds the posted set to
+	// the transactions of that window rather than the process lifetime. Forgetting
+	// a parent too early costs a child at most MaxParentWait of latency, never
+	// correctness.
+	defaultPostedRetention = 2 * time.Hour
+
 	// parentWaitSweepInterval is how often parked children are re-checked for an
-	// expired parent-wait deadline.
+	// expired parent-wait deadline (and the posted set pruned).
 	parentWaitSweepInterval = time.Second
 )
 
@@ -56,6 +65,9 @@ type Sizing struct {
 	// MaxParentWait bounds how long a child is held waiting for its unconfirmed
 	// parent to be posted before being force-posted. Zero selects the default.
 	MaxParentWait time.Duration
+	// PostedRetention bounds how long posted txids are remembered for the benefit
+	// of children that arrive later. Zero selects the default.
+	PostedRetention time.Duration
 }
 
 func (s Sizing) workers() int {
@@ -77,6 +89,13 @@ func (s Sizing) maxParentWait() time.Duration {
 		return defaultMaxParentWait
 	}
 	return s.MaxParentWait
+}
+
+func (s Sizing) postedRetention() time.Duration {
+	if s.PostedRetention <= 0 {
+		return defaultPostedRetention
+	}
+	return s.PostedRetention
 }
 
 type broadcaster interface {
@@ -101,18 +120,44 @@ type BackgroundBroadcaster struct {
 	// in the UTXO set yet). Because parent and child arrive as independent
 	// concurrent items drained by many workers, we gate here: a child is held
 	// until every unconfirmed parent it spends has been posted.
-	depMu   sync.Mutex
-	posted  map[string]struct{}          // txids whose Arcade POST returned successfully
-	waiting map[string][]broadcastItem   // children parked under an unposted parent txid
+	depMu sync.Mutex
+	// posted maps a txid whose Arcade POST returned successfully to when that
+	// happened; postedOrder holds the same txids in insertion (i.e. ascending
+	// time) order so the sweeper can prune expired entries from its front instead
+	// of scanning the whole map.
+	posted      map[string]time.Time
+	postedOrder []postedTxID
+	waiting     map[string][]broadcastItem // children parked under an unposted parent txid
+
+	// requeueQueue holds items whose parent has been posted (or whose wait
+	// expired) until the dispatcher can put them back on broadcastChannel.
+	requeueMu    sync.Mutex
+	requeueQueue []broadcastItem
+	requeueWake  chan struct{}
 
 	stopOnce sync.Once
+}
+
+// postedTxID is a posted txid together with the time it was posted, kept for
+// retention pruning.
+type postedTxID struct {
+	txID string
+	at   time.Time
 }
 
 type broadcastItem struct {
 	beef  *transaction.Beef
 	txIDs []string
-	// deadline is when the item may be posted regardless of unposted parents.
+	// deadline is when a parked item may be posted regardless of unposted
+	// parents. It stays zero until the item is first parked: the parent wait must
+	// measure time spent waiting for a parent, not time spent queued behind other
+	// work. Starting it at Add() time would let a backlog (posts slower than
+	// creates — the high-TPS regime this gating exists for) expire the wait before
+	// a worker ever inspects the item, force-posting the child out of order.
 	deadline time.Time
+	// force skips parent gating entirely. Only the sweeper sets it, on items whose
+	// parent-wait deadline has passed.
+	force bool
 }
 
 func NewBackgroundBroadcaster(ctx context.Context, parentLogger *slog.Logger, broadcastHandler broadcaster, txBroadcastedChannel chan<- wdk.CurrentTxStatus, sizing Sizing) *BackgroundBroadcaster {
@@ -126,8 +171,9 @@ func NewBackgroundBroadcaster(ctx context.Context, parentLogger *slog.Logger, br
 		logger:               logger,
 		broadcastHandler:     broadcastHandler,
 		txBroadcastedChannel: txBroadcastedChannel,
-		posted:               make(map[string]struct{}),
+		posted:               make(map[string]time.Time),
 		waiting:              make(map[string][]broadcastItem),
+		requeueWake:          make(chan struct{}, 1),
 	}
 }
 
@@ -138,6 +184,8 @@ func (bb *BackgroundBroadcaster) Start() {
 	}
 	bb.wg.Add(1)
 	go bb.parentWaitSweeper()
+	bb.wg.Add(1)
+	go bb.requeueDispatcher()
 }
 
 func (bb *BackgroundBroadcaster) Stop() {
@@ -150,7 +198,7 @@ func (bb *BackgroundBroadcaster) Stop() {
 
 func (bb *BackgroundBroadcaster) Add(beef *transaction.Beef, txIDs []string) (added bool) {
 	bb.logger.InfoContext(bb.ctx, "Adding new beef to delayed broadcast", "txIDs", txIDs)
-	item := broadcastItem{beef: beef, txIDs: txIDs, deadline: time.Now().Add(bb.sizing.maxParentWait())}
+	item := broadcastItem{beef: beef, txIDs: parentsFirst(beef, txIDs)}
 	select {
 	case bb.broadcastChannel <- item:
 		return true
@@ -175,18 +223,12 @@ func (bb *BackgroundBroadcaster) worker() {
 	}
 }
 
-// process posts the item once its unconfirmed parents have been posted (or its
-// wait deadline has passed), parking it otherwise.
+// process posts the item once its unconfirmed parents have been posted, parking
+// it otherwise. Only the sweeper's force flag bypasses the gate, so an item is
+// never posted out of order merely because it queued for a long time.
 func (bb *BackgroundBroadcaster) process(item broadcastItem) {
-	if !time.Now().After(item.deadline) {
-		bb.depMu.Lock()
-		if parent := bb.firstUnpostedParentLocked(item); parent != "" {
-			bb.waiting[parent] = append(bb.waiting[parent], item)
-			bb.depMu.Unlock()
-			bb.logger.DebugContext(bb.ctx, "holding child until parent is posted", "parent", parent, "txIDs", item.txIDs)
-			return
-		}
-		bb.depMu.Unlock()
+	if !item.force && bb.park(&item) {
+		return
 	}
 
 	if err := bb.broadcast(&item); err != nil {
@@ -197,80 +239,230 @@ func (bb *BackgroundBroadcaster) process(item broadcastItem) {
 	bb.markPostedAndRelease(item.txIDs)
 }
 
+// park holds the item under the first unconfirmed parent it spends that has not
+// been posted yet, reporting whether it was parked. The parent-wait deadline
+// starts on the first park, so an item re-parked under a second parent still
+// waits at most MaxParentWait in total.
+func (bb *BackgroundBroadcaster) park(item *broadcastItem) bool {
+	bb.depMu.Lock()
+	parent := bb.firstUnpostedParentLocked(*item)
+	if parent == "" {
+		bb.depMu.Unlock()
+		return false
+	}
+	if item.deadline.IsZero() {
+		item.deadline = time.Now().Add(bb.sizing.maxParentWait())
+	}
+	bb.waiting[parent] = append(bb.waiting[parent], *item)
+	bb.depMu.Unlock()
+
+	bb.logger.DebugContext(bb.ctx, "holding child until parent is posted", "parent", parent, "txIDs", item.txIDs)
+	return true
+}
+
 // firstUnpostedParentLocked returns the txid of the first unconfirmed parent that
 // this item spends and that has not yet been posted, or "" if it is ready.
-// A parent is gate-worthy only when it is present in the item's beef as a raw,
-// un-mined transaction (transaction.RawTx): a mined parent (RawTxAndBumpIndex)
-// is already in the UTXO set, and a txid-only / absent parent is not something
-// this broadcaster is responsible for. Caller must hold depMu.
+//
+// Note that posted is local to this broadcaster's delayed pool, not global
+// network state: a parent posted by the non-delayed path, by the send_waiting
+// cron fallback (which is what happens when this pool's channel is full), or by a
+// previous process lifetime is absent from it. A child of such a parent waits out
+// MaxParentWait and is then force-posted, which costs latency, never correctness.
+//
+// Caller must hold depMu.
 func (bb *BackgroundBroadcaster) firstUnpostedParentLocked(item broadcastItem) string {
 	if item.beef == nil {
 		return ""
 	}
+	subjects := make(map[string]struct{}, len(item.txIDs))
 	for _, txID := range item.txIDs {
-		hash, err := chainhash.NewHashFromHex(txID)
-		if err != nil {
-			continue
-		}
-		tx := item.beef.FindTransactionByHash(hash)
-		if tx == nil {
-			continue
-		}
-		for _, in := range tx.Inputs {
-			if in.SourceTXID == nil {
-				continue
-			}
-			parentBeefTx := item.beef.Transactions[*in.SourceTXID]
-			if parentBeefTx == nil || parentBeefTx.DataFormat != transaction.RawTx {
-				continue // absent, txid-only, or mined (bump) parent → no gating
-			}
-			parentID := in.SourceTXID.String()
-			if _, ok := bb.posted[parentID]; ok {
-				continue
-			}
-			return parentID
+		subjects[txID] = struct{}{}
+	}
+	for _, txID := range item.txIDs {
+		if parent := bb.firstUnpostedParentOfLocked(item.beef, txID, subjects); parent != "" {
+			return parent
 		}
 	}
 	return ""
 }
 
+// firstUnpostedParentOfLocked returns the first gate-worthy parent of a single
+// subject transaction. A parent is gate-worthy only when it is present in the
+// beef as a raw, un-mined transaction (transaction.RawTx): a mined parent
+// (RawTxAndBumpIndex) is already in the UTXO set, and a txid-only / absent parent
+// is not something this broadcaster is responsible for. A parent that is itself a
+// subject of the same item is not gate-worthy either — parentsFirst ordered it
+// ahead of its children, so it goes upstream first within the same request.
+// Caller must hold depMu.
+func (bb *BackgroundBroadcaster) firstUnpostedParentOfLocked(beef *transaction.Beef, txID string, subjects map[string]struct{}) string {
+	tx := beefTx(beef, txID)
+	if tx == nil {
+		return ""
+	}
+	for _, in := range tx.Inputs {
+		if in.SourceTXID == nil {
+			continue
+		}
+		parentID := in.SourceTXID.String()
+		if _, ok := subjects[parentID]; ok {
+			continue // posted by this very item, ahead of this child
+		}
+		if _, ok := bb.posted[parentID]; ok {
+			continue
+		}
+		parentBeefTx := beef.Transactions[*in.SourceTXID]
+		if parentBeefTx == nil || parentBeefTx.DataFormat != transaction.RawTx {
+			continue // absent, txid-only, or mined (bump) parent → no gating
+		}
+		return parentID
+	}
+	return ""
+}
+
+// parentsFirst returns txIDs reordered so that a transaction spending another
+// transaction of the same batch comes after it, preserving the input order
+// otherwise. PostFromBEEF posts a batch in slice order and Arcade forwards
+// upstream in receive order, so an unordered batch could post a child before the
+// parent it shares a request with. The input slice is not modified.
+func parentsFirst(beef *transaction.Beef, txIDs []string) []string {
+	if beef == nil || len(txIDs) < 2 {
+		return append([]string(nil), txIDs...)
+	}
+
+	batch := make(map[string]struct{}, len(txIDs))
+	for _, txID := range txIDs {
+		batch[txID] = struct{}{}
+	}
+
+	ordered := make([]string, 0, len(txIDs))
+	visited := make(map[string]struct{}, len(txIDs))
+
+	var visit func(txID string)
+	visit = func(txID string) {
+		if _, seen := visited[txID]; seen {
+			return
+		}
+		visited[txID] = struct{}{} // marked before recursing, so a cycle cannot loop forever
+		for _, parentID := range batchParents(beef, txID, batch) {
+			visit(parentID)
+		}
+		ordered = append(ordered, txID)
+	}
+	for _, txID := range txIDs {
+		visit(txID)
+	}
+	return ordered
+}
+
+// batchParents returns the txids spent by txID that are also subjects of the same
+// batch.
+func batchParents(beef *transaction.Beef, txID string, batch map[string]struct{}) []string {
+	tx := beefTx(beef, txID)
+	if tx == nil {
+		return nil
+	}
+	var parents []string
+	for _, in := range tx.Inputs {
+		if in.SourceTXID == nil {
+			continue
+		}
+		parentID := in.SourceTXID.String()
+		if _, ok := batch[parentID]; ok {
+			parents = append(parents, parentID)
+		}
+	}
+	return parents
+}
+
+// beefTx looks a subject transaction up in a beef by its hex txid.
+func beefTx(beef *transaction.Beef, txID string) *transaction.Transaction {
+	hash, err := chainhash.NewHashFromHex(txID)
+	if err != nil {
+		return nil
+	}
+	return beef.FindTransactionByHash(hash)
+}
+
 // markPostedAndRelease records the posted txids and re-queues any children that
 // were waiting on them.
 func (bb *BackgroundBroadcaster) markPostedAndRelease(txIDs []string) {
+	now := time.Now()
+
 	bb.depMu.Lock()
 	var released []broadcastItem
 	for _, txID := range txIDs {
-		bb.posted[txID] = struct{}{}
+		bb.posted[txID] = now
+		bb.postedOrder = append(bb.postedOrder, postedTxID{txID: txID, at: now})
 		if children, ok := bb.waiting[txID]; ok {
 			released = append(released, children...)
 			delete(bb.waiting, txID)
 		}
 	}
 	bb.depMu.Unlock()
+
 	bb.requeue(released)
 }
 
-// requeue puts released/expired items back on the broadcast channel without
-// blocking the caller (a full channel would otherwise deadlock a worker).
+// requeue hands released/expired items to the requeue dispatcher. It neither
+// blocks (a full broadcast channel would otherwise deadlock the very workers
+// meant to drain it) nor touches bb.wg: growing the WaitGroup from a worker races
+// with Stop's Wait ("WaitGroup misuse: Add called concurrently with Wait"), so
+// the only requeue goroutine is the long-lived one Start creates.
 func (bb *BackgroundBroadcaster) requeue(items []broadcastItem) {
 	if len(items) == 0 {
 		return
 	}
-	bb.wg.Add(1)
-	go func() {
-		defer bb.wg.Done()
-		for _, it := range items {
-			select {
-			case bb.broadcastChannel <- it:
-			case <-bb.ctx.Done():
+
+	bb.requeueMu.Lock()
+	bb.requeueQueue = append(bb.requeueQueue, items...)
+	bb.requeueMu.Unlock()
+
+	select {
+	case bb.requeueWake <- struct{}{}:
+	default: // a wake-up is already pending and drains everything queued by then
+	}
+}
+
+// requeueDispatcher puts requeued items back on the broadcast channel.
+func (bb *BackgroundBroadcaster) requeueDispatcher() {
+	defer bb.wg.Done()
+	for {
+		select {
+		case <-bb.ctx.Done():
+			return
+		case <-bb.requeueWake:
+			if !bb.drainRequeue() {
 				return
 			}
 		}
-	}()
+	}
+}
+
+// drainRequeue moves everything queued so far onto the broadcast channel,
+// reporting false if the broadcaster is shutting down.
+func (bb *BackgroundBroadcaster) drainRequeue() bool {
+	for {
+		bb.requeueMu.Lock()
+		batch := bb.requeueQueue
+		bb.requeueQueue = nil
+		bb.requeueMu.Unlock()
+
+		if len(batch) == 0 {
+			return true
+		}
+		for _, item := range batch {
+			select {
+			case bb.broadcastChannel <- item:
+			case <-bb.ctx.Done():
+				return false
+			}
+		}
+	}
 }
 
 // parentWaitSweeper force-posts children whose parent-wait deadline has passed so
-// a never-posted parent cannot hold them forever.
+// a never-posted parent cannot hold them forever, and prunes the posted set so it
+// cannot grow with lifetime transaction volume.
 func (bb *BackgroundBroadcaster) parentWaitSweeper() {
 	defer bb.wg.Done()
 	ticker := time.NewTicker(parentWaitSweepInterval)
@@ -280,30 +472,68 @@ func (bb *BackgroundBroadcaster) parentWaitSweeper() {
 		case <-bb.ctx.Done():
 			return
 		case <-ticker.C:
-			now := time.Now()
-			bb.depMu.Lock()
-			var expired []broadcastItem
-			for parent, children := range bb.waiting {
-				kept := children[:0]
-				for _, it := range children {
-					if now.After(it.deadline) {
-						expired = append(expired, it)
-					} else {
-						kept = append(kept, it)
-					}
-				}
-				if len(kept) == 0 {
-					delete(bb.waiting, parent)
-				} else {
-					bb.waiting[parent] = kept
-				}
-			}
-			bb.depMu.Unlock()
-			if len(expired) > 0 {
-				bb.logger.WarnContext(bb.ctx, "parent-wait deadline reached, force-posting children", "count", len(expired))
-			}
-			bb.requeue(expired)
+			bb.sweep(time.Now())
 		}
+	}
+}
+
+func (bb *BackgroundBroadcaster) sweep(now time.Time) {
+	bb.depMu.Lock()
+	expired := bb.takeExpiredLocked(now)
+	bb.prunePostedLocked(now)
+	bb.depMu.Unlock()
+
+	if len(expired) == 0 {
+		return
+	}
+	bb.logger.WarnContext(bb.ctx, "parent-wait deadline reached, force-posting children", "count", len(expired))
+	bb.requeue(expired)
+}
+
+// takeExpiredLocked removes and returns the parked items whose parent-wait
+// deadline has passed, flagged to skip gating on their next attempt. Caller must
+// hold depMu.
+func (bb *BackgroundBroadcaster) takeExpiredLocked(now time.Time) []broadcastItem {
+	var expired []broadcastItem
+	for parent, children := range bb.waiting {
+		kept := children[:0]
+		for _, item := range children {
+			if now.After(item.deadline) {
+				item.force = true
+				expired = append(expired, item)
+				continue
+			}
+			kept = append(kept, item)
+		}
+		if len(kept) == 0 {
+			delete(bb.waiting, parent)
+		} else {
+			bb.waiting[parent] = kept
+		}
+	}
+	return expired
+}
+
+// prunePostedLocked drops posted txids older than the retention window.
+// postedOrder is in ascending time order, so pruning stops at the first entry
+// still inside the window and costs only what it removes. Caller must hold depMu.
+func (bb *BackgroundBroadcaster) prunePostedLocked(now time.Time) {
+	cutoff := now.Add(-bb.sizing.postedRetention())
+
+	pruned := 0
+	for ; pruned < len(bb.postedOrder); pruned++ {
+		entry := bb.postedOrder[pruned]
+		if entry.at.After(cutoff) {
+			break
+		}
+		// A re-posted txid has a newer map timestamp and a later order entry; drop
+		// it only when this entry is the newest one for that txid.
+		if at, ok := bb.posted[entry.txID]; ok && !at.After(entry.at) {
+			delete(bb.posted, entry.txID)
+		}
+	}
+	if pruned > 0 {
+		bb.postedOrder = append(bb.postedOrder[:0], bb.postedOrder[pruned:]...)
 	}
 }
 

--- a/pkg/storage/internal/service/background_broadcaster_ordering_test.go
+++ b/pkg/storage/internal/service/background_broadcaster_ordering_test.go
@@ -1,0 +1,92 @@
+package service_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	testvectors "github.com/bsv-blockchain/universal-test-vectors/pkg/testabilities"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/storage/internal/service"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+)
+
+// orderRecordingBroadcaster records the order in which txIDs are posted, with an
+// optional per-call delay to widen the race window.
+type orderRecordingBroadcaster struct {
+	mu    sync.Mutex
+	order []string
+	delay time.Duration
+}
+
+func (o *orderRecordingBroadcaster) BackgroundBroadcast(ctx context.Context, _ *transaction.Beef, txIDs []string) ([]wdk.ReviewActionResult, error) {
+	if o.delay > 0 {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(o.delay):
+		}
+	}
+	o.mu.Lock()
+	o.order = append(o.order, txIDs...)
+	o.mu.Unlock()
+	return nil, nil
+}
+
+func (o *orderRecordingBroadcaster) snapshot() []string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]string(nil), o.order...)
+}
+
+func (o *orderRecordingBroadcaster) waitFor(t testing.TB, n int) {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		o.mu.Lock()
+		got := len(o.order)
+		o.mu.Unlock()
+		if got >= n {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("expected %d posts, got %d", n, got)
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}
+
+// A child transaction spending an unconfirmed parent must be broadcast to Arcade
+// AFTER its parent, even when it was enqueued first — so Arcade's receive-order
+// contract forwards the parent to Teranode first.
+func TestBackgroundBroadcaster_PostsUnconfirmedParentBeforeChild(t *testing.T) {
+	t.Parallel()
+
+	rec := &orderRecordingBroadcaster{delay: 10 * time.Millisecond}
+	logger, _ := loggerForTestBroadcaster()
+	bb := service.NewBackgroundBroadcaster(t.Context(), logger, rec, nil, service.Sizing{Workers: 1})
+	bb.Start()
+	defer bb.Stop()
+
+	parent := testvectors.GivenTX().WithInput(100).WithP2PKHOutput(99)
+	child := testvectors.GivenTX().WithInputFromUTXO(parent.TX(), 0).WithP2PKHOutput(50)
+	parentID := parent.ID().String()
+	childID := child.ID().String()
+
+	childBeef, err := transaction.NewBeefFromTransaction(child.TX())
+	require.NoError(t, err)
+	parentBeef, err := transaction.NewBeefFromTransaction(parent.TX())
+	require.NoError(t, err)
+
+	// Worst case: enqueue the child BEFORE the parent.
+	require.True(t, bb.Add(childBeef, []string{childID}))
+	require.True(t, bb.Add(parentBeef, []string{parentID}))
+
+	rec.waitFor(t, 2)
+	require.Equal(t, []string{parentID, childID}, rec.snapshot(),
+		"parent must be posted to Arcade before its child")
+}

--- a/pkg/storage/internal/service/background_broadcaster_ordering_test.go
+++ b/pkg/storage/internal/service/background_broadcaster_ordering_test.go
@@ -129,12 +129,20 @@ func TestBackgroundBroadcaster_PostsParentAndChildOfSameBatchWithoutWaiting(t *t
 func TestBackgroundBroadcaster_ParentWaitDoesNotExpireWhileQueued(t *testing.T) {
 	t.Parallel()
 
-	const postDuration = 100 * time.Millisecond
+	const (
+		postDuration  = 100 * time.Millisecond
+		maxParentWait = 30 * time.Millisecond
+	)
 
 	rec := &orderRecordingBroadcaster{delay: postDuration}
 	logger, _ := loggerForTestBroadcaster()
-	bb := service.NewBackgroundBroadcaster(t.Context(), logger, rec, nil,
-		service.Sizing{Workers: 1, MaxParentWait: 30 * time.Millisecond})
+	// The sweeper is parked out of the way: this test is about the wait not being
+	// consumed while queued, not about what happens once it runs out.
+	bb := service.NewBackgroundBroadcaster(t.Context(), logger, rec, nil, service.Sizing{
+		Workers:       1,
+		MaxParentWait: maxParentWait,
+		SweepInterval: time.Minute,
+	})
 	bb.Start()
 	defer bb.Stop()
 
@@ -156,7 +164,7 @@ func TestBackgroundBroadcaster_ParentWaitDoesNotExpireWhileQueued(t *testing.T) 
 	require.True(t, bb.Add(parentBeef, []string{parent.ID().String()}))
 
 	// Queue for longer than MaxParentWait before the worker gets to the child.
-	time.Sleep(2 * 30 * time.Millisecond)
+	time.Sleep(2 * maxParentWait)
 
 	rec.waitFor(t, 3)
 	require.Equal(t,
@@ -165,18 +173,53 @@ func TestBackgroundBroadcaster_ParentWaitDoesNotExpireWhileQueued(t *testing.T) 
 		"a queued child must still wait for its parent")
 }
 
-// Posted txids are pruned after their retention window, so the set cannot grow
-// with lifetime volume. A child of a forgotten parent is then held only until its
-// parent-wait deadline and force-posted.
-func TestBackgroundBroadcaster_ForcePostsChildOfForgottenParent(t *testing.T) {
+// A child whose unconfirmed parent was never handed to this pool — posted by the
+// non-delayed path, by the cron fallback, or by another wallet — must not stall
+// waiting for a POST that is never going to happen here.
+func TestBackgroundBroadcaster_DoesNotStallOnParentItWillNeverPost(t *testing.T) {
+	t.Parallel()
+
+	rec := &orderRecordingBroadcaster{}
+	logger, _ := loggerForTestBroadcaster()
+	// A MaxParentWait far beyond the test's patience: reaching the assertion proves
+	// the child was held under the unknown-parent grace instead.
+	bb := service.NewBackgroundBroadcaster(t.Context(), logger, rec, nil, service.Sizing{
+		Workers:           1,
+		MaxParentWait:     time.Minute,
+		UnknownParentWait: 20 * time.Millisecond,
+		SweepInterval:     10 * time.Millisecond,
+	})
+	bb.Start()
+	defer bb.Stop()
+
+	parent := testvectors.GivenTX().WithInput(100).WithP2PKHOutput(99)
+	child := testvectors.GivenTX().WithInputFromUTXO(parent.TX(), 0).WithP2PKHOutput(50)
+	childID := child.ID().String()
+
+	// The beef carries the unconfirmed parent, but only the child is broadcast here.
+	childBeef, err := transaction.NewBeefFromTransaction(child.TX())
+	require.NoError(t, err)
+
+	require.True(t, bb.Add(childBeef, []string{childID}))
+
+	rec.waitFor(t, 1)
+	require.Equal(t, []string{childID}, rec.snapshot())
+}
+
+// Remembered txids are pruned after their retention window, so they cannot grow
+// with lifetime volume. A child of a forgotten parent is then held only for the
+// unknown-parent grace and posted.
+func TestBackgroundBroadcaster_PostsChildOfForgottenParent(t *testing.T) {
 	t.Parallel()
 
 	rec := &orderRecordingBroadcaster{}
 	logger, _ := loggerForTestBroadcaster()
 	bb := service.NewBackgroundBroadcaster(t.Context(), logger, rec, nil, service.Sizing{
-		Workers:         1,
-		MaxParentWait:   50 * time.Millisecond,
-		PostedRetention: time.Millisecond,
+		Workers:           1,
+		MaxParentWait:     time.Minute,
+		UnknownParentWait: 20 * time.Millisecond,
+		PostedRetention:   time.Millisecond,
+		SweepInterval:     10 * time.Millisecond,
 	})
 	bb.Start()
 	defer bb.Stop()
@@ -191,8 +234,8 @@ func TestBackgroundBroadcaster_ForcePostsChildOfForgottenParent(t *testing.T) {
 	require.True(t, bb.Add(parentBeef, []string{parent.ID().String()}))
 	rec.waitFor(t, 1)
 
-	// Give the sweeper a tick to forget the posted parent.
-	time.Sleep(2 * parentWaitSweepIntervalForTest)
+	// Let the sweeper forget the parent.
+	time.Sleep(100 * time.Millisecond)
 
 	require.True(t, bb.Add(childBeef, []string{child.ID().String()}))
 	rec.waitFor(t, 2)
@@ -201,7 +244,3 @@ func TestBackgroundBroadcaster_ForcePostsChildOfForgottenParent(t *testing.T) {
 		rec.snapshot(),
 		"the child of a forgotten parent must still be posted")
 }
-
-// parentWaitSweepIntervalForTest mirrors the broadcaster's unexported sweep
-// interval so timing-dependent tests do not hard-code it in several places.
-const parentWaitSweepIntervalForTest = time.Second

--- a/pkg/storage/internal/service/background_broadcaster_ordering_test.go
+++ b/pkg/storage/internal/service/background_broadcaster_ordering_test.go
@@ -90,3 +90,118 @@ func TestBackgroundBroadcaster_PostsUnconfirmedParentBeforeChild(t *testing.T) {
 	require.Equal(t, []string{parentID, childID}, rec.snapshot(),
 		"parent must be posted to Arcade before its child")
 }
+
+// A batch that carries both an unconfirmed parent and the child spending it goes
+// upstream in one request, parent first — it must not park waiting for a parent it
+// is itself responsible for posting.
+func TestBackgroundBroadcaster_PostsParentAndChildOfSameBatchWithoutWaiting(t *testing.T) {
+	t.Parallel()
+
+	rec := &orderRecordingBroadcaster{}
+	logger, _ := loggerForTestBroadcaster()
+	// A long parent wait would dominate the test if the batch parked, so reaching
+	// the assertion at all proves the batch was posted without waiting.
+	bb := service.NewBackgroundBroadcaster(t.Context(), logger, rec, nil,
+		service.Sizing{Workers: 1, MaxParentWait: time.Minute})
+	bb.Start()
+	defer bb.Stop()
+
+	parent := testvectors.GivenTX().WithInput(100).WithP2PKHOutput(99)
+	child := testvectors.GivenTX().WithInputFromUTXO(parent.TX(), 0).WithP2PKHOutput(50)
+	parentID := parent.ID().String()
+	childID := child.ID().String()
+
+	// The child's beef carries its unconfirmed parent as a raw transaction.
+	beef, err := transaction.NewBeefFromTransaction(child.TX())
+	require.NoError(t, err)
+
+	// Worst case: the child is named before its parent in the same batch.
+	require.True(t, bb.Add(beef, []string{childID, parentID}))
+
+	rec.waitFor(t, 2)
+	require.Equal(t, []string{parentID, childID}, rec.snapshot(),
+		"a same-batch parent must be posted first, not waited for")
+}
+
+// The parent wait must measure time spent waiting for a parent, not time spent
+// queued: a child that sat in the channel behind other work for longer than
+// MaxParentWait must still be posted after its parent.
+func TestBackgroundBroadcaster_ParentWaitDoesNotExpireWhileQueued(t *testing.T) {
+	t.Parallel()
+
+	const postDuration = 100 * time.Millisecond
+
+	rec := &orderRecordingBroadcaster{delay: postDuration}
+	logger, _ := loggerForTestBroadcaster()
+	bb := service.NewBackgroundBroadcaster(t.Context(), logger, rec, nil,
+		service.Sizing{Workers: 1, MaxParentWait: 30 * time.Millisecond})
+	bb.Start()
+	defer bb.Stop()
+
+	// An unrelated transaction occupies the single worker while parent and child
+	// queue up behind it.
+	filler := testvectors.GivenTX().WithInput(100).WithP2PKHOutput(99)
+	fillerBeef, err := transaction.NewBeefFromTransaction(filler.TX())
+	require.NoError(t, err)
+
+	parent := testvectors.GivenTX().WithInput(200).WithP2PKHOutput(199)
+	child := testvectors.GivenTX().WithInputFromUTXO(parent.TX(), 0).WithP2PKHOutput(150)
+	childBeef, err := transaction.NewBeefFromTransaction(child.TX())
+	require.NoError(t, err)
+	parentBeef, err := transaction.NewBeefFromTransaction(parent.TX())
+	require.NoError(t, err)
+
+	require.True(t, bb.Add(fillerBeef, []string{filler.ID().String()}))
+	require.True(t, bb.Add(childBeef, []string{child.ID().String()}))
+	require.True(t, bb.Add(parentBeef, []string{parent.ID().String()}))
+
+	// Queue for longer than MaxParentWait before the worker gets to the child.
+	time.Sleep(2 * 30 * time.Millisecond)
+
+	rec.waitFor(t, 3)
+	require.Equal(t,
+		[]string{filler.ID().String(), parent.ID().String(), child.ID().String()},
+		rec.snapshot(),
+		"a queued child must still wait for its parent")
+}
+
+// Posted txids are pruned after their retention window, so the set cannot grow
+// with lifetime volume. A child of a forgotten parent is then held only until its
+// parent-wait deadline and force-posted.
+func TestBackgroundBroadcaster_ForcePostsChildOfForgottenParent(t *testing.T) {
+	t.Parallel()
+
+	rec := &orderRecordingBroadcaster{}
+	logger, _ := loggerForTestBroadcaster()
+	bb := service.NewBackgroundBroadcaster(t.Context(), logger, rec, nil, service.Sizing{
+		Workers:         1,
+		MaxParentWait:   50 * time.Millisecond,
+		PostedRetention: time.Millisecond,
+	})
+	bb.Start()
+	defer bb.Stop()
+
+	parent := testvectors.GivenTX().WithInput(100).WithP2PKHOutput(99)
+	child := testvectors.GivenTX().WithInputFromUTXO(parent.TX(), 0).WithP2PKHOutput(50)
+	parentBeef, err := transaction.NewBeefFromTransaction(parent.TX())
+	require.NoError(t, err)
+	childBeef, err := transaction.NewBeefFromTransaction(child.TX())
+	require.NoError(t, err)
+
+	require.True(t, bb.Add(parentBeef, []string{parent.ID().String()}))
+	rec.waitFor(t, 1)
+
+	// Give the sweeper a tick to forget the posted parent.
+	time.Sleep(2 * parentWaitSweepIntervalForTest)
+
+	require.True(t, bb.Add(childBeef, []string{child.ID().String()}))
+	rec.waitFor(t, 2)
+	require.Equal(t,
+		[]string{parent.ID().String(), child.ID().String()},
+		rec.snapshot(),
+		"the child of a forgotten parent must still be posted")
+}
+
+// parentWaitSweepIntervalForTest mirrors the broadcaster's unexported sweep
+// interval so timing-dependent tests do not hard-code it in several places.
+const parentWaitSweepIntervalForTest = time.Second


### PR DESCRIPTION
## Problem

The storage delayed-broadcast pool (`pkg/storage/internal/service/background_broadcaster.go`)
drained one channel with N concurrent workers (up to 256 for the throughput strategy) and **no
dependency ordering**. A transaction and the child that spends its still-unconfirmed output are
queued by separate, concurrent `createAction`/`processAction` calls, so a child was frequently
POSTed upstream **before its parent**.

Arcade forwards transactions to Teranode in the order it receives them, so an out-of-order child
reached Teranode before the parent's output was in the UTXO set and was rejected
(`failed to validate transaction`), cascading to every descendant. Observed on the tstn scaling
stack: ~half of fan-out/stream transactions rejected, fuel starvation, and a storage view that
optimistically recorded them `unproven` while the network had rejected them.

## Fix

Make the broadcaster dependency-aware. Before posting an item it inspects the item's beef; if the
tx spends an **unconfirmed** direct parent (present as `transaction.RawTx`, i.e. no merkle proof)
that has not been posted yet, the child is **parked** (keyed by the parent txid) instead of posted.
When a parent's POST succeeds, its parked children are released and re-queued. A configurable
`Sizing.MaxParentWait` deadline + sweeper force-posts a child if its parent never arrives, so a
never-posted parent cannot hold children forever.

Gating only fires on `RawTx` parents, so mined (`RawTxAndBumpIndex`), txid-only, and
confirmed/external sources are untouched — independent transactions still broadcast fully
concurrently. `NewBackgroundBroadcaster`'s signature is unchanged; `Sizing` gains an optional
`MaxParentWait` (default 30s).

## Verification

- New `TestBackgroundBroadcaster_PostsUnconfirmedParentBeforeChild`: a child enqueued before its
  unconfirmed parent is posted after it. Existing broadcaster tests pass; race detector clean.
- Live on the tstn scaling stack: Arcade rejections drop from ~50% to **0** at both 100 and 1000
  TPS, and the fuel pool builds instead of starving.
