### PR TITLE
feat: fix double-spend revert tx

### DIFF
--- a/pkg/internal/storage/repo/known_tx.go
+++ b/pkg/internal/storage/repo/known_tx.go
@@ -153,21 +153,11 @@ func (p *KnownTx) FailKnownTxAsDoubleSpend(ctx context.Context, txID string, ski
 			return fmt.Errorf("failed to update transaction status as failed: %w", txErr)
 		}
 
-		// NOTE: There can be multiple transactions with the same tx_id, so we need to restore all of them.
-		var transactionIDs []uint
-		txErr = tx.Model(&models.Transaction{}).
-			Where(p.query.Transaction.TxID.Eq(txID)).
-			Pluck(p.query.Transaction.ID.ColumnName().String(), &transactionIDs).Error
-		if txErr != nil {
-			return fmt.Errorf("failed to find transaction IDs: %w", txErr)
-		}
-
-		query := genquery.Use(tx)
-		for _, transactionID := range transactionIDs {
-			if txErr = recreateSpentOutputs(ctx, query, transactionID); txErr != nil {
-				return fmt.Errorf("failed to restore spent outputs for transaction %d: %w", transactionID, txErr)
-			}
-		}
+		// Spent inputs are intentionally NOT restored to spendable here: a confirmed
+		// double spend only proves a conflicting tx exists, not that this tx's original
+		// spend is invalid. Restoring the input risks the wallet re-spending it and
+		// creating a real double spend on top of the reported one, so the input is left
+		// claimed (and effectively lost) rather than resurrected.
 
 		return nil
 	})

--- a/pkg/storage/internal/actions/process.go
+++ b/pkg/storage/internal/actions/process.go
@@ -768,9 +768,10 @@ func (p *process) updateSingleTx(
 				return fmt.Errorf("failed to find transaction IDs for failed tx %s: %w", txID, uowErr)
 			}
 			for _, id := range transactionIDs {
-				if uowErr = repos.OutputRepo().RecreateSpentOutputs(txCtx, id); uowErr != nil {
-					return fmt.Errorf("failed to restore spent outputs for failed tx %s: %w", txID, uowErr)
-				}
+				// Spent inputs are intentionally NOT restored to spendable here: a
+				// missing-inputs/double-spend verdict can be a false positive, and
+				// re-spending an input that's actually still valid risks a real double
+				// spend. Losing access to the input is safer than that.
 				if uowErr = repos.OutputRepo().MarkCreatedOutputsAsNotSpendable(txCtx, id); uowErr != nil {
 					return fmt.Errorf("failed to mark created outputs as not spendable for failed tx %s: %w", txID, uowErr)
 				}

--- a/pkg/storage/internal/actions/synchronize_tx_statuses.go
+++ b/pkg/storage/internal/actions/synchronize_tx_statuses.go
@@ -499,10 +499,10 @@ func (s *synchronizeTxStatuses) reviewKnownTxStatuses(ctx context.Context) error
 						return fmt.Errorf("failed to set failed transaction status for tx %s: %w", failedTx.TxID, uowErr)
 					}
 
-					if uowErr := repos.OutputRepo().RecreateSpentOutputs(txCtx, transactionID); uowErr != nil {
-						return fmt.Errorf("failed to restore spent outputs for terminal failed tx %s: %w", failedTx.TxID, uowErr)
-					}
-
+					// Spent inputs are intentionally NOT restored to spendable here: a
+					// terminal invalid/double-spend verdict can be a false positive, and
+					// re-spending an input that's actually still valid risks a real double
+					// spend. Losing access to the input is safer than that.
 					if uowErr := repos.OutputRepo().MarkCreatedOutputsAsNotSpendable(txCtx, transactionID); uowErr != nil {
 						return fmt.Errorf("failed to mark created outputs as not spendable for terminal failed tx %s: %w", failedTx.TxID, uowErr)
 					}

--- a/pkg/storage/provider_broadcast_double_spend_test.go
+++ b/pkg/storage/provider_broadcast_double_spend_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
@@ -134,4 +135,26 @@ func TestBroadcastConflict_MempoolConflict_TxUnknown_StaysFailed(t *testing.T) {
 	thenDBState := testabilities.ThenDBState(t, activeStorage)
 	thenDBState.HasKnownTX(txID).WithStatus(wdk.ProvenTxStatusDoubleSpend)
 	thenDBState.HasUserTransactionByTxID(testusers.Alice, txID).WithStatus(wdk.TxStatusFailed)
+
+	// and: the failed tx's spent inputs are NOT released back to spendable.
+	// A confirmed double spend here does not prove the ORIGINAL spend is invalid - only
+	// that a conflicting tx exists. Restoring the input to spendable risks the wallet
+	// respending it and creating a real double spend on top of the reported one, so the
+	// safer outcome is to leave the input claimed (and thus effectively lost) rather than
+	// resurrect it.
+	txRows, err := activeStorage.TransactionEntity().Read().
+		TxID().Equals(txID).
+		Find(t.Context())
+	require.NoError(t, err)
+	require.Len(t, txRows, 1)
+
+	spentOutputs, err := activeStorage.OutputsEntity().Read().
+		SpentBy().Equals(txRows[0].ID).
+		Find(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, spentOutputs, "expected the failed tx's inputs to still be claimed (spent_by unchanged)")
+	for _, output := range spentOutputs {
+		assert.False(t, output.Spendable,
+			"input vout=%d spent by the double-spend-failed tx must not be restored to spendable", output.Vout)
+	}
 }

--- a/pkg/storage/provider_list_failed_actions_test.go
+++ b/pkg/storage/provider_list_failed_actions_test.go
@@ -53,8 +53,12 @@ func TestListFailedActionsWithUnfail_ToleratesTransactionWithoutKnownTxRow(t *te
 	require.NoError(t, err)
 
 	// and: a second failed tx whose tx_id has NO matching KnownTx row (orphan) - proven
-	// possible in production per the abort sweep's own COALESCE-based filter
-	orphanCreateResult, orphanSignedTx := given.Action(activeStorage).Created()
+	// possible in production per the abort sweep's own COALESCE-based filter.
+	// Funded with a distinct amount so its internalized parent tx (and thus its
+	// funding input) doesn't collide with the first tx's - which, following the fix
+	// that stops restoring a double-spend-failed tx's inputs to spendable, remains
+	// permanently claimed rather than being freed for reuse.
+	orphanCreateResult, orphanSignedTx := given.Action(activeStorage).WithSatoshisToInternalize(43000).Created()
 	orphanTxID := orphanSignedTx.TxID().String()
 	orphanCompetingTxID := testvectors.GivenTX().WithInput(2).WithP2PKHOutput(1).ID().String()
 	provider.ARC().WhenQueryingTx(orphanTxID).WillReturnDoubleSpending(orphanCompetingTxID)
@@ -132,7 +136,11 @@ func TestListFailedActions_IncludesAbortedWithDistinctStatus(t *testing.T) {
 	// the pre-existing empty-TxID skip. Without this, the aborted fixture would
 	// have TxID=="" and no KnownTx row, and the test would pass identically even
 	// if the new guard were deleted - it would not actually pin the guard.
-	abortedCreate, abortedSignedTx := given.Action(activeStorage).Created()
+	// Funded with a distinct amount so its internalized parent tx (and thus its
+	// funding input) doesn't collide with the first tx's - which, following the fix
+	// that stops restoring a double-spend-failed tx's inputs to spendable, remains
+	// permanently claimed rather than being freed for reuse.
+	abortedCreate, abortedSignedTx := given.Action(activeStorage).WithSatoshisToInternalize(43000).Created()
 	abortedTxID := abortedSignedTx.TxID().String()
 	_, err = activeStorage.ProcessAction(t.Context(), testusers.Alice.AuthID(), wdk.ProcessActionArgs{
 		IsNewTx:   true,


### PR DESCRIPTION
## What Changed

- Stopped restoring a transaction's spent inputs back to spendable when it is terminally failed as a double-spend or invalid tx. The three places that did this (process.updateSingleTx on broadcast failure, KnownTx.FailKnownTxAsDoubleSpend on externally-rejected txs, and synchronizeTxStatuses.reviewKnownTxStatuses on terminal review) now leave the spent inputs claimed instead of calling RecreateSpentOutputs/recreateSpentOutputs.
- Outputs created by the failed tx are still marked non-spendable, since those never existed on-chain if the tx failed - only the restoration of the spent inputs was removed.
- Added a regression assertion to TestBroadcastConflict_MempoolConflict_TxUnknown_StaysFailed proving a double-spend-failed tx's inputs stay claimed and non-spendable.
- Updated two ListFailedActions tests that had been (unintentionally) relying on the old revert-to-spendable behavior to fund a second test action with the same input; they now fund independently.

## Why It Was Necessary

- WhatsOnChain reports "missing inputs" far more often than genuine double-spends occur (e.g. a parent tx in a chain hasn't reached its mempool yet), and the toolbox's broadcast aggregation folds "missing inputs" into the same DoubleSpend=true signal as a real txn-mempool-conflict.
- A "confirmed" double-spend verdict only proves a competing tx exists - it does not prove the original spend is invalid. Restoring the input to spendable let the wallet re-spend it while the original tx was potentially still valid/pending, producing a real double-spend on top of the reported one and corrupting the wallet's UTXO state.
- Better to lose access to some valid inputs than to risk generating a real double-spend by resurrecting one that was only ever a false-positive rejection.

## Testing Performed

- go build ./..., go vet ./..., gofmt -l on all changed files - clean.
- go test ./... - full suite passes.
- Added regression test in pkg/storage/provider_broadcast_double_spend_test.go (confirmed RED before the fix, GREEN after).
- Verified TestListFailedActionsWithUnfail_ToleratesTransactionWithoutKnownTxRow and TestListFailedActions_IncludesAbortedWithDistinctStatus pass after decoupling their test fixtures from the old behavior.

## Impact / Risk

- Behavior change: inputs spent by a tx that ends up double-spend/invalid-failed are no longer released back to the wallet's spendable UTXO set - they remain permanently claimed (effectively lost) rather than resurrected. This trades occasional loss of a genuinely-valid input (on a false-positive rejection) for eliminating a class of real double-spend/wallet-corruption bugs.
- No API or schema changes; scope is limited to the three internal terminal-failure code paths in the storage layer.
- Pre-broadcast abort and the unfail/merkle-path-timeout cascade were intentionally left unchanged (different risk profile - see code comments); worth revisiting separately if the same false-positive pattern turns up there.

## Notifications
- @username
