### PR TITLE
docs: document required replace directives for library consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,22 @@ go get -u github.com/bsv-blockchain/go-wallet-toolbox
 
 <br/>
 
+### Consuming as a library
+
+This module's `go.mod` pins three transitive dependencies via `replace` directives:
+
+```
+replace github.com/libp2p/go-libp2p => github.com/libp2p/go-libp2p v0.48.1-0.20260709142922-ec408fcc60c9
+replace github.com/quic-go/webtransport-go => github.com/quic-go/webtransport-go v0.11.1
+replace github.com/quic-go/quic-go => github.com/quic-go/quic-go v0.60.0
+```
+
+They exist because the latest `go-libp2p` release doesn't build against the latest `quic-go`/`webtransport-go` releases (an upstream API break), and other dependencies in the graph pull in those newer, incompatible versions.
+
+Go only applies `replace` directives from the **main module** being built — they are ignored when this module is imported as a dependency. If you import `go-wallet-toolbox` from your own module, `go build` may fail with an error such as `undefined: webtransport.Dialer` unless you copy the same three `replace` lines above into your own `go.mod`.
+
+<br/>
+
 ### Quick Start: Storage Server
 
 Run a local storage server for development/testing.

--- a/go.mod
+++ b/go.mod
@@ -287,6 +287,14 @@ require (
 
 tool go.uber.org/mock/mockgen
 
+// The go-libp2p / quic-go / webtransport-go trio below is pinned because the
+// latest go-libp2p (v0.49.0) does not compile against the latest
+// quic-go/webtransport-go (v0.12.0): it references a webtransport.Dialer type
+// that v0.12.0 removed. These replaces only apply when this module is built
+// standalone — Go ignores replace directives from dependencies, so consumers
+// importing this module as a library must copy the same three replace lines
+// into their own go.mod. See README.md "Consuming as a library" and
+// https://github.com/bsv-blockchain/go-wallet-toolbox/issues/983.
 replace github.com/libp2p/go-libp2p => github.com/libp2p/go-libp2p v0.48.1-0.20260709142922-ec408fcc60c9
 
 replace github.com/quic-go/webtransport-go => github.com/quic-go/webtransport-go v0.11.1


### PR DESCRIPTION
## What Changed
- Added a "Consuming as a library" section to `README.md` documenting the three `replace` directives (`go-libp2p`, `quic-go/webtransport-go`, `quic-go/quic-go`) that this module's `go.mod` relies on.
- Added a comment in `go.mod` above the `replace` block explaining why the pins exist and that they must be copied by downstream consumers.

## Why It Was Necessary
Reported in #983: `go.mod` pins `go-libp2p`, `webtransport-go`, and `quic-go` to specific compatible versions via `replace` directives. Go only applies `replace` directives declared by the **main module** being built, so any project that imports `go-wallet-toolbox` as a library does not get these replaces and instead resolves the raw, MVS-selected versions.

I confirmed the underlying incompatibility is real and not just a version-selection quirk: with the replaces removed, `go build ./...` picks `go-libp2p v0.49.0` + `quic-go/webtransport-go v0.12.0` (the latest releases of each) and fails with:
```
p2p/transport/webtransport/transport.go:217:25: undefined: webtransport.Dialer
```
`go-libp2p v0.49.0` references a `webtransport.Dialer` type that was removed in `webtransport-go v0.12.0` — an upstream API break between the two latest releases, not something fixable by choosing different versions within this module's own dependency graph. Since `replace` is the only way to force a compatible combination, and `replace` directives from a dependency are invisible to consumers, the fix is to clearly document the three lines that any importer must copy into their own `go.mod`.

## Testing Performed
- `go build ./...` — passes with the existing replaces in place.
- Reproduced the reported failure in an isolated worktree by removing the replace lines and running `go mod tidy && go build ./...`, confirming the exact upstream incompatibility.
- `go vet ./...` — passes.
- `go list -m all` — succeeds, `go.mod` is well-formed.

## Impact / Risk
Documentation-only change plus a `go.mod` comment; no dependency versions, build tags, or code changed. No risk of behavior change.

## Notifications
- @sirdeggen @kuba-4chain

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5F4YPqWxPJp4f5veuLv4T)_