### PR TITLE
feat: use chaintrack as a first service in OneByOne calls

### DIFF
--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -235,7 +235,7 @@ func New(logger *slog.Logger, config defs.WalletServices, opts ...func(*Options)
 
 	// Register chaintracks implementation if adapter is available
 	if chaintracksAdapter != nil {
-		predefined = append(predefined, Named[Implementation]{
+		predefined = append([]Named[Implementation]{{
 			Name: defs.ChaintracksServiceName,
 			Item: Implementation{
 				CurrentHeight:        chaintracksAdapter.CurrentHeight,
@@ -244,7 +244,7 @@ func New(logger *slog.Logger, config defs.WalletServices, opts ...func(*Options)
 				FindChainTipHeader:   chaintracksAdapter.GetTip,
 				IsValidRootForHeight: chaintracksAdapter.IsValidRootForHeight,
 			},
-		})
+		}}, predefined...)
 	}
 
 	allImplementations := append(options.customImplementations, predefined...)


### PR DESCRIPTION
## What Changed
- Prioritized the `Chaintracks` service in `pkg/services/services.go`. When the `chaintracksAdapter` is enabled, its implementation is now prepended to the `predefined` slice rather than appended.

## Why It Was Necessary
- `Chaintracks` needs to act as the primary, preferred service (particularly for methods like `FindChainTipHeader`), with other services like `WhatsOnChain` and `BHS` acting as fallbacks. The `servicequeue.OneByOne` method iterates over services sequentially in the order they are defined. By prepending `Chaintracks` to the slice, it becomes the first responder, fulfilling the required priority structure without needing a major refactor of the service setup flow. 

## Testing Performed
- [ ] Code successfully builds locally
- [ ] Verified that `Chaintracks` is injected at the front of the queue by inspecting active services

## Impact / Risk
- **Impact**: Positive. Faster and more reliable tip resolution utilizing the native `Chaintracks` implementation first, gracefully falling back to external indexers/services on error.
- **Risk**: Low. The fallback mechanisms (e.g. `WhatsOnChain`, `Bitails`) will remain intact in their original capacity to catch any outages or failures from `Chaintracks`.
