### PR TITLE
docs: correct the monitor comparison in the UTXO lifecycle page

### DIFF
--- a/docs/utxo-lifecycle.md
+++ b/docs/utxo-lifecycle.md
@@ -262,9 +262,25 @@ Four tasks are registered in `pkg/monitor/all_tasks.go`:
 | `fail_abandoned` | `AbortAbandoned` — sweeps aged non-terminal transactions to `aborted` |
 | `un_fail` | `UnFail` — retries operator-flagged failures |
 
-The TypeScript implementation ships nineteen tasks. Statuses that only its
-review-status cascade, double-spend review, reorg handling, `nosend` settlement, or UTXO
-review advance do not advance here.
+Scheduled tasks are only part of the picture here, and comparing their count against the
+TypeScript implementation's nineteen is misleading. Two other mechanisms carry work that
+TypeScript schedules:
+
+- **Event consumers.** `pkg/monitor` runs an SSE broadcast-event pipeline with a persisted
+  replay cursor (`arcade_sse_last_event_id`), plus reorg and new-tip consumers
+  (`monitor.go` `handleReorgEvents` / `handleNewTipEvents`). Reorg handling is real —
+  `Provider.HandleReorg` invalidates merkle proofs for transactions in orphaned blocks —
+  it is event-driven rather than polled.
+- **Inline verification.** `confirmDoubleSpends`
+  (`pkg/storage/internal/actions/process_confirm_double_spends.go`) re-verifies every
+  aggregated double-spend verdict before it becomes terminal, downgrading false positives
+  to `serviceError` for retry. TypeScript does the equivalent in a scheduled
+  `TaskReviewDoubleSpends`.
+
+What is genuinely not reproduced here is the TypeScript `reviewStatus` cascade, which
+reconciles transaction rows against their proof requests; statuses that only that cascade
+advances do not advance here. Purge and action-batch cleanup also have no counterpart, the
+latter because there is no action batching in this implementation.
 
 ### Known parity gaps
 


### PR DESCRIPTION
## What Changed

Corrects a factual error in `docs/utxo-lifecycle.md`, added in #990.

The page compared this implementation's four registered monitor tasks against the TypeScript implementation's nineteen and presented the difference as missing behavior — naming **reorg handling** and **double-spend review** among the things that "do not advance here". Both statements are wrong.

The section now describes the mechanisms that actually carry that work, and narrows the genuine gap.

## Why It Was Necessary

Counting scheduled tasks was the wrong comparison. This implementation moves most of that work off the scheduler:

- **Reorg handling is real and event-driven.** `pkg/monitor` runs an SSE broadcast-event pipeline with a persisted replay cursor (`arcade_sse_last_event_id`) plus reorg and new-tip consumers (`monitor.go` → `handleReorgEvents` / `handleNewTipEvents`). `Provider.HandleReorg` invalidates merkle proofs for transactions in orphaned blocks. It is not polled, so it does not appear in `all_tasks.go` — which is exactly how the original text got it wrong.
- **Double-spend review is real and inline.** `confirmDoubleSpends` (`pkg/storage/internal/actions/process_confirm_double_spends.go`) re-verifies every aggregated double-spend verdict before it becomes terminal, downgrading false positives to `serviceError` for retry. Its own comment explains the reasoning: failing a transaction releases its inputs, and doing that on a false positive lets the wallet build real double spends afterwards. TypeScript does the equivalent in a scheduled `TaskReviewDoubleSpends`.

What is genuinely not reproduced here is the TypeScript `reviewStatus` cascade, plus purge and action-batch cleanup — the last because there is no action batching in this implementation. That is what the section now says.

## Testing Performed

Documentation only; no Go code changed, so no build, vet, or lint delta. Every claim in the replacement text was read at the source line rather than inferred — `pkg/monitor/monitor.go:322` and `:147`, `pkg/monitor/broadcast_events.go`, `pkg/storage/provider.go:1187`, and `pkg/storage/internal/actions/process_confirm_double_spends.go:17-30`.

## Impact / Risk

No runtime impact. This removes an inaccuracy that understated the implementation's background-convergence coverage — a reader of the merged page would reasonably have concluded that reorgs and double-spend false positives go unhandled here, and acted on it.

The equivalent correction to the cross-implementation page is on [ts-stack#474](https://github.com/bsv-blockchain/ts-stack/pull/474).

## Notifications

-

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lug8S7eE3uxTFRtr5pU9kw)_