### PR TITLE
fix: arcade rejected tx retry

### DIFF
--- a/pkg/storage/internal/actions/process_external_status.go
+++ b/pkg/storage/internal/actions/process_external_status.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/entity"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/history"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/repo"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/tracing"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 )
@@ -315,7 +317,7 @@ func (p *process) advanceToBroadcastedFromExternalEvent(ctx context.Context, ev 
 // verification machinery (network re-check) before any terminal failure:
 //   - the network knows the tx -> false positive -> treat as a successful broadcast,
 //   - no positive evidence (no competing txs) or the network state is inconclusive ->
-//     keep the tx retryable (the polling safety net keeps it alive),
+//     make the tx retryable again (see retryExternallyRejectedTx),
 //   - confirmed double spend -> existing terminal failure path.
 func (p *process) applyExternalRejected(ctx context.Context, ev *wdk.BroadcastStatusEvent, current wdk.ProvenTxReqStatus) ([]wdk.TxSynchronizedStatus, error) {
 	aggregated := synthesizeRejectedVerdict(ev)
@@ -327,12 +329,7 @@ func (p *process) applyExternalRejected(ctx context.Context, ev *wdk.BroadcastSt
 		// False positive - the network knows the tx; make sure it's recorded as broadcast.
 		return p.advanceToBroadcastedFromExternalEvent(ctx, ev, current)
 	case wdk.AggregatedPostedTxIDServiceError:
-		p.logger.InfoContext(
-			ctx, "External REJECTED event could not be confirmed - keeping the tx retryable",
-			slog.String("txID", ev.TxID),
-			slog.String("storedStatus", string(current)),
-		)
-		return nil, nil
+		return p.retryExternallyRejectedTx(ctx, ev, current)
 	case wdk.AggregatedPostedTxIDDoubleSpend:
 		return p.failExternallyRejectedTx(ctx, ev, verdict)
 	case wdk.AggregatedPostedTxIDInvalidTx:
@@ -340,6 +337,56 @@ func (p *process) applyExternalRejected(ctx context.Context, ev *wdk.BroadcastSt
 	default:
 		return nil, fmt.Errorf("unexpected verdict status %s while processing external REJECTED event for tx %s", verdict.Status, ev.TxID)
 	}
+}
+
+// retryExternallyRejectedTx handles a REJECTED event that confirmDoubleSpends could not
+// confirm as a real double spend (no positive evidence - e.g. a bare "missing inputs"
+// hint, or Arcade's ancestor-count limit rejecting a chained tx). The tx must not be left
+// at a beyond-broadcast status (e.g. unmined): SendWaitingTransactions only rebroadcasts
+// Unsent/Sending (process_send_waiting.go), so a tx parked anywhere else has no path back
+// to a retry and is stuck forever while local state still claims it's in flight.
+//
+// Unsent/Sending transactions are already retryable and left untouched. Anything further
+// along is pulled back to Sending - the same status the normal broadcast flow assigns for
+// a ServiceError verdict (see singleTxBroadcastResult) - so the next SendWaitingTransactions
+// sweep rebroadcasts it. A tx that concurrently reached a genuinely terminal status
+// (completed/invalid/doubleSpend) is left untouched.
+func (p *process) retryExternallyRejectedTx(ctx context.Context, ev *wdk.BroadcastStatusEvent, current wdk.ProvenTxReqStatus) ([]wdk.TxSynchronizedStatus, error) {
+	logger := p.logger.With(
+		slog.String("txID", ev.TxID),
+		slog.String("storedStatus", string(current)),
+	)
+
+	if current == wdk.ProvenTxStatusUnsent || current == wdk.ProvenTxStatusSending {
+		logger.InfoContext(ctx, "External REJECTED event could not be confirmed - tx is already retryable")
+		return nil, nil
+	}
+
+	notes := []history.Builder{externalStatusNote(ev).WithNewStatus(string(wdk.ProvenTxStatusSending))}
+	skipStatuses := []wdk.ProvenTxReqStatus{wdk.ProvenTxStatusCompleted, wdk.ProvenTxStatusInvalid, wdk.ProvenTxStatusDoubleSpend}
+
+	err := p.knownTxRepo.UpdateKnownTxStatus(ctx, ev.TxID, wdk.ProvenTxStatusSending, skipStatuses, notes)
+	if errors.Is(err, repo.ErrStatusUpdateSkipped) {
+		logger.InfoContext(ctx, "Externally rejected tx reached a terminal status concurrently - leaving the stored state untouched")
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to make externally rejected tx %s retryable: %w", ev.TxID, err)
+	}
+
+	logger.InfoContext(ctx, "External REJECTED event could not be confirmed - made the tx retryable again")
+
+	reference, labels, err := p.referenceAndLabelsForTxID(ctx, ev.TxID)
+	if err != nil {
+		return nil, err
+	}
+
+	return []wdk.TxSynchronizedStatus{{
+		TxID:      ev.TxID,
+		Status:    wdk.ProvenTxStatusSending,
+		Reference: reference,
+		Labels:    labels,
+	}}, nil
 }
 
 // failExternallyRejectedTx applies the confirmed double spend through the same terminal

--- a/pkg/storage/provider_external_status_test.go
+++ b/pkg/storage/provider_external_status_test.go
@@ -26,6 +26,7 @@ const (
 	externalEventBlockHeight = 2000
 	externalEventBlockHash   = "000000000000000001885e0c6c302cbbacf927e1b5cf7884588973e72f8b1234"
 	externalNoteWhat         = "externalBroadcastStatus"
+	minedStatus              = "MINED"
 )
 
 // A MINED event carrying a valid merkle path must complete the transaction
@@ -52,7 +53,7 @@ func TestExternalStatusMinedWithMerklePathInEvent(t *testing.T) {
 	results, err := activeStorage.ProcessExternalTxStatusUpdate(t.Context(), wdk.BroadcastStatusEvent{
 		EventID:     "1000",
 		TxID:        txID,
-		Status:      "MINED",
+		Status:      minedStatus,
 		BlockHash:   externalEventBlockHash,
 		BlockHeight: externalEventBlockHeight,
 		MerklePath:  merklePath.Hex(),
@@ -100,7 +101,7 @@ func TestExternalStatusMinedWithInvalidMerkleRootIsRejected(t *testing.T) {
 	// when:
 	results, err := activeStorage.ProcessExternalTxStatusUpdate(t.Context(), wdk.BroadcastStatusEvent{
 		TxID:        txID,
-		Status:      "MINED",
+		Status:      minedStatus,
 		BlockHash:   externalEventBlockHash,
 		BlockHeight: externalEventBlockHeight,
 		MerklePath:  merklePath.Hex(),
@@ -137,7 +138,7 @@ func TestExternalStatusMinedWithoutPathFallsBackToServices(t *testing.T) {
 	// when:
 	results, err := activeStorage.ProcessExternalTxStatusUpdate(t.Context(), wdk.BroadcastStatusEvent{
 		TxID:   txID,
-		Status: "MINED",
+		Status: minedStatus,
 	})
 
 	// then:
@@ -269,7 +270,7 @@ func TestExternalStatusMinedSSEFrameWithBUMPCompletesTx(t *testing.T) {
 	results, err := activeStorage.ProcessExternalTxStatusUpdate(t.Context(), wdk.BroadcastStatusEvent{
 		EventID:     "1745870512987654321",
 		TxID:        txID,
-		Status:      "MINED",
+		Status:      minedStatus,
 		BlockHash:   externalEventBlockHash,
 		BlockHeight: externalEventBlockHeight,
 		MerklePath:  merklePath.Hex(),
@@ -376,7 +377,7 @@ func TestExternalStatusMinedWithoutPathAndNoProofIsLeftToPolling(t *testing.T) {
 	// when:
 	results, err := activeStorage.ProcessExternalTxStatusUpdate(t.Context(), wdk.BroadcastStatusEvent{
 		TxID:   txID,
-		Status: "MINED",
+		Status: minedStatus,
 	})
 
 	// then: no error and no result - nothing was applied:
@@ -413,7 +414,7 @@ func TestExternalStatusMinedWithPathButNoBlockHashFallsBackToServices(t *testing
 	merklePath := testutils.MockValidMerklePath(t, txID, externalEventBlockHeight)
 	results, err := activeStorage.ProcessExternalTxStatusUpdate(t.Context(), wdk.BroadcastStatusEvent{
 		TxID:        txID,
-		Status:      "MINED",
+		Status:      minedStatus,
 		BlockHeight: externalEventBlockHeight,
 		MerklePath:  merklePath.Hex(),
 	})
@@ -582,7 +583,7 @@ func TestExternalStatusUnknownTxIDIsNoOp(t *testing.T) {
 	// when:
 	results, err := activeStorage.ProcessExternalTxStatusUpdate(t.Context(), wdk.BroadcastStatusEvent{
 		TxID:   "27a53423aa3e5d5c46bf30be53a9998dd247daf758847f244f82d430be71de6e",
-		Status: "MINED",
+		Status: minedStatus,
 	})
 
 	// then:
@@ -610,7 +611,7 @@ func TestExternalStatusTerminalStatusIsNoOp(t *testing.T) {
 
 	_, err = activeStorage.ProcessExternalTxStatusUpdate(t.Context(), wdk.BroadcastStatusEvent{
 		TxID:        txID,
-		Status:      "MINED",
+		Status:      minedStatus,
 		BlockHash:   externalEventBlockHash,
 		BlockHeight: externalEventBlockHeight,
 		MerklePath:  merklePath.Hex(),
@@ -667,7 +668,7 @@ func TestExternalStatusRejectedRacingCompletionLeavesCompletedTxUntouched(t *tes
 				completedConcurrently = true
 				_, minedErr := activeStorage.ProcessExternalTxStatusUpdate(t.Context(), wdk.BroadcastStatusEvent{
 					TxID:        txID,
-					Status:      "MINED",
+					Status:      minedStatus,
 					BlockHash:   externalEventBlockHash,
 					BlockHeight: externalEventBlockHeight,
 					MerklePath:  merklePath.Hex(),
@@ -742,7 +743,7 @@ func TestExternalStatusRejectedWithoutEvidenceRacingCompletionLeavesCompletedTxU
 				completedConcurrently = true
 				_, minedErr := activeStorage.ProcessExternalTxStatusUpdate(t.Context(), wdk.BroadcastStatusEvent{
 					TxID:        txID,
-					Status:      "MINED",
+					Status:      minedStatus,
 					BlockHash:   externalEventBlockHash,
 					BlockHeight: externalEventBlockHeight,
 					MerklePath:  merklePath.Hex(),

--- a/pkg/storage/provider_external_status_test.go
+++ b/pkg/storage/provider_external_status_test.go
@@ -532,9 +532,12 @@ func TestExternalStatusRejectedWithCompetingTxsConfirmedIsFailed(t *testing.T) {
 }
 
 // A REJECTED event without competing transactions carries no positive evidence of a
-// double spend - even when the network does not (yet) know the tx, it must stay
-// retryable rather than be terminally failed (polling safety net keeps it alive).
-func TestExternalStatusRejectedWithoutEvidenceStaysRetryable(t *testing.T) {
+// double spend - even when the network does not (yet) know the tx, it must not be
+// terminally failed. Since the tx had already advanced past Sending (to unmined), it
+// must also be pulled back to Sending: SendWaitingTransactions only rebroadcasts
+// Unsent/Sending, so a tx left at "unmined" would be retryable in name only, with no
+// path back to a retry.
+func TestExternalStatusRejectedWithoutEvidenceIsMadeRetryableAgain(t *testing.T) {
 	// given:
 	given, cleanup := testabilities.Given(t)
 	defer cleanup()
@@ -550,17 +553,19 @@ func TestExternalStatusRejectedWithoutEvidenceStaysRetryable(t *testing.T) {
 	given.Provider().WhatsOnChain().WillRespondOnTxStatusNotFound()
 
 	// when:
-	_, err := activeStorage.ProcessExternalTxStatusUpdate(t.Context(), wdk.BroadcastStatusEvent{
+	results, err := activeStorage.ProcessExternalTxStatusUpdate(t.Context(), wdk.BroadcastStatusEvent{
 		TxID:   txID,
 		Status: "REJECTED",
 	})
 
 	// then:
 	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, wdk.ProvenTxStatusSending, results[0].Status)
 
-	// and: the tx is NOT failed:
+	// and: the tx is NOT failed, but pulled back to Sending so the retry sweep can reach it:
 	thenDBState := testabilities.ThenDBState(t, activeStorage)
-	thenDBState.HasKnownTX(txID).WithStatus(wdk.ProvenTxStatusUnmined)
+	thenDBState.HasKnownTX(txID).WithStatus(wdk.ProvenTxStatusSending)
 	thenDBState.HasUserTransactionByTxID(testusers.Alice, txID).WithStatus(wdk.TxStatusUnproven)
 }
 
@@ -692,6 +697,79 @@ func TestExternalStatusRejectedRacingCompletionLeavesCompletedTxUntouched(t *tes
 		Status:       "REJECTED",
 		ExtraInfo:    "double spend attempted",
 		CompetingTxs: []string{"27a53423aa3e5d5c46bf30be53a9998dd247daf758847f244f82d430be71de6e"},
+	})
+
+	// then: the race actually happened and the rejection was swallowed without changes:
+	require.True(t, completedConcurrently)
+	require.NoError(t, err)
+	require.Empty(t, results)
+
+	// and: the completed tx and its UTXO state are untouched:
+	thenDBState := testabilities.ThenDBState(t, activeStorage)
+	thenDBState.HasKnownTX(txID).WithStatus(wdk.ProvenTxStatusCompleted).IsMined()
+	thenDBState.HasUserTransactionByTxID(testusers.Alice, txID).WithStatus(wdk.TxStatusCompleted)
+}
+
+// Same race as TestExternalStatusRejectedRacingCompletionLeavesCompletedTxUntouched, but
+// for a REJECTED event with no double-spend evidence: the tx completes (MINED) WHILE the
+// ServiceError re-check is in flight. The guarded UpdateKnownTxStatus (skip-list) must then
+// write NOTHING - pulling a completed tx back to Sending would resurrect it as broadcastable.
+func TestExternalStatusRejectedWithoutEvidenceRacingCompletionLeavesCompletedTxUntouched(t *testing.T) {
+	// given:
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+	activeStorage := given.Provider().
+		WithRandomizer(randomizer.NewTestRandomizer()).
+		GORM()
+
+	// and: a successfully broadcast transaction (status unmined):
+	_, signedTx := given.Action(activeStorage).Processed()
+	txID := signedTx.TxID().String()
+
+	// and: a valid merkle path the racing MINED event will carry:
+	merklePath := testutils.MockValidMerklePath(t, txID, externalEventBlockHeight)
+	merkleRoot, err := merklePath.ComputeRootHex(&txID)
+	require.NoError(t, err)
+	given.Provider().BHS().OnMerkleRootVerifyResponse(externalEventBlockHeight, merkleRoot, testabilities.BHSMerkleRootConfirmed)
+
+	// and: the network re-check (confirmDoubleSpends) reports the tx as unknown, and the
+	// tx completes concurrently while that re-check is in flight (the responder applies a
+	// MINED event before answering - after the REJECTED handler's terminal check passed):
+	completedConcurrently := false
+	given.Provider().WhatsOnChain().Transport().RegisterResponder(http.MethodPost, `=~txs/status\z`,
+		func(req *http.Request) (*http.Response, error) {
+			if !completedConcurrently {
+				completedConcurrently = true
+				_, minedErr := activeStorage.ProcessExternalTxStatusUpdate(t.Context(), wdk.BroadcastStatusEvent{
+					TxID:        txID,
+					Status:      "MINED",
+					BlockHash:   externalEventBlockHash,
+					BlockHeight: externalEventBlockHeight,
+					MerklePath:  merklePath.Hex(),
+				})
+				require.NoError(t, minedErr)
+			}
+
+			var body struct {
+				Txids []string `json:"txids"`
+			}
+			if json.NewDecoder(req.Body).Decode(&body) != nil {
+				return httpmock.NewStringResponse(http.StatusBadRequest, "bad request"), nil
+			}
+			respItems := []map[string]any{}
+			for _, txid := range body.Txids {
+				respItems = append(respItems, map[string]any{"txid": txid, "error": "unknown"})
+			}
+			respBytes, _ := json.Marshal(respItems)
+			resp := httpmock.NewStringResponse(http.StatusOK, string(respBytes))
+			resp.Header.Set("Content-Type", "application/json")
+			return resp, nil
+		})
+
+	// when: the REJECTED event (without double-spend evidence) finishes its verification:
+	results, err := activeStorage.ProcessExternalTxStatusUpdate(t.Context(), wdk.BroadcastStatusEvent{
+		TxID:   txID,
+		Status: "REJECTED",
 	})
 
 	// then: the race actually happened and the rejection was swallowed without changes:


### PR DESCRIPTION
## What Changed
- applyExternalRejected's ServiceError branch (no double-spend evidence on an Arcade REJECTED/DOUBLE_SPEND_ATTEMPTED event) no longer no-ops. It now guardedly transitions the KnownTx back to Sending via UpdateKnownTxStatus, skipping the write if the tx concurrently reached a genuinely terminal status (Completed/Invalid/DoubleSpend).
- Added retryExternallyRejectedTx (pkg/storage/internal/actions/process_external_status.go) implementing this, and wired it into applyExternalRejected in place of the old log-and-return no-op.
- Updated TestExternalStatusRejectedWithoutEvidenceStaysRetryable → TestExternalStatusRejectedWithoutEvidenceIsMadeRetryableAgain to assert the tx moves to Sending and a TxSynchronizedStatus is emitted.
- Added TestExternalStatusRejectedWithoutEvidenceRacingCompletionLeavesCompletedTxUntouched, mirroring the existing double-spend race test, to cover the concurrent-completion guard.

## Why It Was Necessary

Once a tx advances past Sending (e.g. to unmined via a SENT_TO_NETWORK/ACCEPTED_BY_NETWORK event), an Arcade REJECTED with no double-spend evidence was logged as "keeping the tx retryable" but left the stored status untouched at unmined. SendWaitingTransactions (process_send_waiting.go) only rescans Unsent/Sending — unmined is unreachable by any retry path, so the tx was silently dead while local state still claimed it was in-flight. We hit this in practice via Arcade's 300-ancestor limit rejecting chained txs after they'd already advanced past Sending. The fix reuses the exact status transition (Sending) that the normal broadcast flow already uses for its own ServiceError verdict, so the tx re-enters the existing retry sweep instead of inventing new state. Confirmed double spends still go through the pre-existing terminal failExternallyRejectedTx path — unchanged.

## Testing Performed

- go build ./..., go vet ./pkg/storage/... ./pkg/monitor/... — clean.
- go test ./pkg/storage/... (full suite) and go test ./pkg/monitor/... — all pass.

## Impact / Risk

- Scoped to the ServiceError branch of applyExternalRejected; the Success (false positive) and DoubleSpend (confirmed) branches are untouched.
- Low risk: reuses an existing, already-tested status transition (Sending) and an existing guarded-update pattern (skip-list on terminal statuses) rather than introducing new state or altering the Transaction-row status.
- Txs previously stuck at unmined with no evidence will now be picked up by the next SendWaitingTransactions sweep and rebroadcast.
