### PR TITLE
fix: avoid db deadlock, add retry

### DIFF
--- a/pkg/internal/storage/database/database.go
+++ b/pkg/internal/storage/database/database.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/genquery"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/dbretry"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/funder"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/repo"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/logging"
@@ -62,11 +63,17 @@ func NewWithGorm(database *gorm.DB, baseLogger *slog.Logger) *Database {
 }
 
 func (d *Database) CreateRepositories() *repo.Repositories {
-	return repo.NewSQLRepositories(d.DB)
+	return repo.NewSQLRepositories(d.DB, d.retryPolicy())
+}
+
+// retryPolicy is the policy for repositories built over this connection: it owns the
+// transactions it opens, so it may re-run one the engine rolled back.
+func (d *Database) retryPolicy() *dbretry.Policy {
+	return dbretry.Retrying(d.logger, nil)
 }
 
 func (d *Database) CreateFunder(feeModel defs.FeeModel, maxChangeOutputsPerTx uint64) *funder.SQL {
-	utxoRepo := repo.NewUTXOs(d.DB, genquery.Use(d.DB))
+	utxoRepo := repo.NewUTXOs(d.DB, genquery.Use(d.DB), d.retryPolicy())
 	return funder.NewSQL(d.baseLogger, utxoRepo, feeModel, maxChangeOutputsPerTx)
 }
 

--- a/pkg/internal/storage/dbretry/dbretry.go
+++ b/pkg/internal/storage/dbretry/dbretry.go
@@ -1,0 +1,120 @@
+// Package dbretry re-runs a database transaction the engine rolled back to break a conflict
+// between concurrent sessions. Such a rollback is not an application error - the same work run
+// again normally commits. Everything else is returned to the caller untouched.
+package dbretry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/logging"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/randomizer"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+)
+
+// Postgres class-40 (transaction rollback) SQLSTATEs: the server aborted the transaction to
+// resolve a conflict with a concurrent session, and expects the client to retry.
+const (
+	deadlockDetected     = "40P01"
+	serializationFailure = "40001"
+)
+
+// MaxAttempts bounds the re-runs before the error is returned. The victim's rollback frees the
+// locks immediately, so one retry almost always suffices; beyond three, the cause is a
+// systematic lock-order problem that should be seen rather than hidden.
+const MaxAttempts = 3
+
+// baseBackoff is the delay before the first retry. A var, not a const, so tests can shrink it.
+var baseBackoff = 20 * time.Millisecond
+
+// Retryable reports whether err is - or wraps - a Postgres class-40 transaction rollback.
+// Deliberately narrow: an application error, a constraint violation or a failed CAS re-runs to
+// the same outcome, so retrying it only holds a connection open.
+func Retryable(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+
+	return pgErr.Code == deadlockDetected || pgErr.Code == serializationFailure
+}
+
+// Do runs fn while it returns a Retryable error, up to MaxAttempts times, waiting a jittered
+// backoff in between and returning early if ctx is canceled. A conflict that survives every
+// attempt surfaces with its original SQLSTATE.
+//
+// fn MUST be safe to run more than once: the engine rolled the failed attempt back before Do
+// saw the error, so a caller that only writes to the database qualifies.
+func Do(ctx context.Context, logger *slog.Logger, random wdk.Randomizer, fn func() error) error {
+	for attempt := 1; ; attempt++ {
+		err := fn()
+		if err == nil || !Retryable(err) || attempt == MaxAttempts {
+			return err
+		}
+
+		logger.WarnContext(ctx, "retrying database transaction after a transient rollback",
+			slog.Int("attempt", attempt), slog.Int("maxAttempts", MaxAttempts), logging.Error(err))
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("database retry aborted: %w", ctx.Err())
+		case <-time.After(backoffWithJitter(attempt, random)):
+		}
+	}
+}
+
+// backoffWithJitter returns baseBackoff*attempt with +/-50% jitter, so transactions that just
+// deadlocked do not line up to collide again.
+func backoffWithJitter(attempt int, random wdk.Randomizer) time.Duration {
+	base := baseBackoff * time.Duration(attempt)
+	if base <= 0 {
+		return 0
+	}
+
+	jitter := random.Uint64(uint64(base))
+
+	return base/2 + time.Duration(jitter) //nolint:gosec // jitter < base <= MaxInt64, conversion cannot overflow
+}
+
+// Policy is a pre-bound decision about whether a database handle may retry the transactions it
+// opens. The same repository code runs against two kinds of handle, and only one may retry.
+type Policy struct {
+	logger *slog.Logger
+	random wdk.Randomizer
+}
+
+// Retrying returns a Policy for a handle that owns the transactions it opens - the top-level
+// connection. A nil random selects a default one; pass your own to make the jitter deterministic.
+func Retrying(logger *slog.Logger, random wdk.Randomizer) *Policy {
+	if random == nil {
+		random = randomizer.New()
+	}
+
+	return &Policy{logger: logger, random: random}
+}
+
+// NoRetry returns a Policy that runs the work exactly once.
+//
+// Required for a handle bound to an outer transaction: gorm makes that a SAVEPOINT, and rolling
+// back to it frees only the locks taken since it opened, not the outer ones the deadlock cycle
+// runs through. Only the owner of the outer transaction can resolve it, and it retries.
+//
+// Also the honest choice where there is no concurrency to retry against, such as a test.
+func NoRetry() *Policy {
+	return &Policy{}
+}
+
+// Do runs fn under the policy. The zero Policy and a nil *Policy both run fn once: a handle
+// never told it owns its transactions must not assume it does.
+func (p *Policy) Do(ctx context.Context, fn func() error) error {
+	if p == nil || p.logger == nil {
+		return fn()
+	}
+
+	return Do(ctx, p.logger, p.random, fn)
+}

--- a/pkg/internal/storage/dbretry/dbretry_test.go
+++ b/pkg/internal/storage/dbretry/dbretry_test.go
@@ -1,0 +1,176 @@
+package dbretry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/logging"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/randomizer"
+)
+
+// deadlock mimics what reaches Do in production: the pgconn error wrapped by the repository and
+// then by the action layer.
+func deadlock() error {
+	return fmt.Errorf("failed to update single tx after background broadcast: %w",
+		fmt.Errorf("failed to update known tx status: %w",
+			&pgconn.PgError{Code: deadlockDetected, Message: "deadlock detected"}))
+}
+
+func TestRetryable(t *testing.T) {
+	tests := map[string]struct {
+		err  error
+		want bool
+	}{
+		"nil":                              {err: nil, want: false},
+		"wrapped deadlock (40P01)":         {err: deadlock(), want: true},
+		"serialization failure (40001)":    {err: &pgconn.PgError{Code: serializationFailure}, want: true},
+		"unique violation is not retried":  {err: &pgconn.PgError{Code: "23505"}, want: false},
+		"plain application error":          {err: errors.New("status update skipped"), want: false},
+		"non-postgres engine never counts": {err: errors.New("database is locked"), want: false},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.want, Retryable(test.err))
+		})
+	}
+}
+
+func TestDo(t *testing.T) {
+	original := baseBackoff
+	baseBackoff = time.Millisecond
+	t.Cleanup(func() { baseBackoff = original })
+
+	random := randomizer.New()
+
+	t.Run("returns immediately on success without retrying", func(t *testing.T) {
+		calls := 0
+		err := Do(context.Background(), logging.NewTestLogger(t), random, func() error {
+			calls++
+			return nil
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("re-runs the unit of work after a deadlock and succeeds", func(t *testing.T) {
+		calls := 0
+		err := Do(context.Background(), logging.NewTestLogger(t), random, func() error {
+			calls++
+			if calls == 1 {
+				return deadlock()
+			}
+			return nil
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 2, calls)
+	})
+
+	t.Run("gives up after MaxAttempts and surfaces the original error", func(t *testing.T) {
+		calls := 0
+		err := Do(context.Background(), logging.NewTestLogger(t), random, func() error {
+			calls++
+			return deadlock()
+		})
+
+		require.Error(t, err)
+		assert.Equal(t, MaxAttempts, calls)
+		assert.True(t, Retryable(err))
+
+		var pgErr *pgconn.PgError
+		require.ErrorAs(t, err, &pgErr)
+		assert.Equal(t, deadlockDetected, pgErr.Code)
+	})
+
+	t.Run("does not retry an application error", func(t *testing.T) {
+		calls := 0
+		sentinel := errors.New("status update skipped")
+		err := Do(context.Background(), logging.NewTestLogger(t), random, func() error {
+			calls++
+			return sentinel
+		})
+
+		require.ErrorIs(t, err, sentinel)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("stops retrying when the context is canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		err := Do(ctx, logging.NewTestLogger(t), random, func() error {
+			calls++
+			cancel()
+			return deadlock()
+		})
+
+		require.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, 1, calls, "must not start another attempt once the context is done")
+	})
+}
+
+func TestPolicy(t *testing.T) {
+	original := baseBackoff
+	baseBackoff = time.Millisecond
+	t.Cleanup(func() { baseBackoff = original })
+
+	t.Run("Retrying re-runs a rolled-back transaction", func(t *testing.T) {
+		calls := 0
+		err := Retrying(logging.NewTestLogger(t), randomizer.New()).Do(context.Background(), func() error {
+			calls++
+			if calls == 1 {
+				return deadlock()
+			}
+			return nil
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 2, calls)
+	})
+
+	// The Database handle passes no randomizer of its own and must still get jittered backoff.
+	t.Run("Retrying falls back to a default randomizer", func(t *testing.T) {
+		calls := 0
+		err := Retrying(logging.NewTestLogger(t), nil).Do(context.Background(), func() error {
+			calls++
+			if calls == 1 {
+				return deadlock()
+			}
+			return nil
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 2, calls)
+	})
+
+	t.Run("NoRetry runs the work exactly once", func(t *testing.T) {
+		calls := 0
+		err := NoRetry().Do(context.Background(), func() error {
+			calls++
+			return deadlock()
+		})
+
+		require.Error(t, err)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("the nil policy runs the work exactly once", func(t *testing.T) {
+		var policy *Policy
+		calls := 0
+		err := policy.Do(context.Background(), func() error {
+			calls++
+			return deadlock()
+		})
+
+		require.Error(t, err)
+		assert.Equal(t, 1, calls)
+	})
+}

--- a/pkg/internal/storage/repo/all.go
+++ b/pkg/internal/storage/repo/all.go
@@ -4,6 +4,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/genquery"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/dbretry"
 )
 
 type Repositories struct {
@@ -26,18 +27,22 @@ type Repositories struct {
 	DB *gorm.DB
 }
 
-func NewSQLRepositories(db *gorm.DB) *Repositories {
+// NewSQLRepositories builds every repository over db, with retry the policy each of them
+// applies to the transactions it opens. Pass dbretry.Retrying for the top-level connection,
+// which owns its transactions, and dbretry.Disabled for a handle already bound to an outer
+// transaction (see runInTransaction).
+func NewSQLRepositories(db *gorm.DB, retry *dbretry.Policy) *Repositories {
 	query := genquery.Use(db)
 	repositories := &Repositories{
 		DB:            db,
 		Migrator:      NewMigrator(db),
 		Settings:      NewSettings(db),
-		OutputBaskets: NewOutputBaskets(db, query),
+		OutputBaskets: NewOutputBaskets(db, query, retry),
 		Certificates:  NewCertificates(db, query),
-		UTXOs:         NewUTXOs(db, query),
-		Transactions:  NewTransactions(db, query),
-		Outputs:       NewOutputs(db, query),
-		KnownTx:       NewKnownTxRepo(db, query),
+		UTXOs:         NewUTXOs(db, query, retry),
+		Transactions:  NewTransactions(db, query, retry),
+		Outputs:       NewOutputs(db, query, retry),
+		KnownTx:       NewKnownTxRepo(db, query, retry),
 		Sync:          NewSync(db, query),
 		SyncState:     NewSyncState(db),
 		KeyValue:      NewKeyValue(db),

--- a/pkg/internal/storage/repo/known_tx.go
+++ b/pkg/internal/storage/repo/known_tx.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/genquery"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/scopes"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/dbretry"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/entity"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/history"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/queryopts"
@@ -35,10 +36,11 @@ const (
 type KnownTx struct {
 	db    *gorm.DB
 	query *genquery.Query
+	retry *dbretry.Policy
 }
 
-func NewKnownTxRepo(db *gorm.DB, query *genquery.Query) *KnownTx {
-	return &KnownTx{db: db, query: query}
+func NewKnownTxRepo(db *gorm.DB, query *genquery.Query, retry *dbretry.Policy) *KnownTx {
+	return &KnownTx{db: db, query: query, retry: retry}
 }
 
 func (p *KnownTx) UpsertKnownTx(ctx context.Context, req *entity.UpsertKnownTx, txNote history.Builder) error {
@@ -48,7 +50,7 @@ func (p *KnownTx) UpsertKnownTx(ctx context.Context, req *entity.UpsertKnownTx, 
 		tracing.EndTracing(span, err)
 	}()
 
-	err = p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err = runInTransaction(ctx, p.db, p.retry, func(tx *gorm.DB) error {
 		return upsertKnownTx(tx, req, txNote)
 	})
 	if err != nil {
@@ -91,7 +93,7 @@ func (p *KnownTx) ParkUnbroadcastKnownTx(ctx context.Context, txID string, txNot
 	}()
 
 	applied := false
-	err = p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err = runInTransaction(ctx, p.db, p.retry, func(tx *gorm.DB) error {
 		result := tx.Model(&models.KnownTx{}).
 			Where("tx_id = ?", txID).
 			Where("status IN ?", KnownTxNeverPostedStatuses).
@@ -155,7 +157,7 @@ func (p *KnownTx) ClaimKnownTxsForBroadcast(ctx context.Context, txIDs []string)
 	}
 
 	var claimed []string
-	err = p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err = runInTransaction(ctx, p.db, p.retry, func(tx *gorm.DB) error {
 		var rows []*models.KnownTx
 		if findErr := tx.Model(&models.KnownTx{}).
 			Select("tx_id").
@@ -236,7 +238,7 @@ func (p *KnownTx) FailKnownTxAsDoubleSpend(ctx context.Context, txID string, ski
 		tracing.EndTracing(span, err)
 	}()
 
-	err = p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err = runInTransaction(ctx, p.db, p.retry, func(tx *gorm.DB) error {
 		var txErr error
 		applied, txErr = applyKnownTxStatusGuarded(tx, txID, wdk.ProvenTxStatusDoubleSpend, skipForStatuses, txNotes)
 		if txErr != nil || !applied {
@@ -278,7 +280,7 @@ func (p *KnownTx) AdvanceKnownTxToBroadcasted(ctx context.Context, txID string, 
 		tracing.EndTracing(span, err)
 	}()
 
-	err = p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err = runInTransaction(ctx, p.db, p.retry, func(tx *gorm.DB) error {
 		var txErr error
 		applied, txErr = applyKnownTxStatusGuarded(tx, txID, wdk.ProvenTxStatusUnmined, skipForStatuses, txNotes)
 		if txErr != nil || !applied {
@@ -613,7 +615,7 @@ func (p *KnownTx) UpdateKnownTxAsMined(ctx context.Context, knownTxAsMined *enti
 		tracing.EndTracing(span, err)
 	}()
 
-	err = p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err = runInTransaction(ctx, p.db, p.retry, func(tx *gorm.DB) error {
 		err = tx.Model(&models.KnownTx{}).
 			Where(p.query.KnownTx.TxID.Eq(knownTxAsMined.TxID)).
 			Updates(&models.KnownTx{
@@ -707,7 +709,7 @@ func (p *KnownTx) ApplyProofTimeouts(ctx context.Context, attempts, maxRebroadca
 		return nil, nil
 	}
 
-	err = p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err = runInTransaction(ctx, p.db, p.retry, func(tx *gorm.DB) error {
 		var timedOut []*models.KnownTx
 		query := tx.Model(&models.KnownTx{}).
 			Where("attempts >= ?", attempts)
@@ -759,7 +761,7 @@ func (p *KnownTx) RequeueKnownTxForRebroadcast(ctx context.Context, txID string,
 		tracing.EndTracing(span, err)
 	}()
 
-	err = p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err = runInTransaction(ctx, p.db, p.retry, func(tx *gorm.DB) error {
 		var candidates []*models.KnownTx
 		if findErr := tx.Model(&models.KnownTx{}).
 			Where("tx_id = ? AND status IN ?", txID, fromStatuses).
@@ -941,7 +943,7 @@ func (p *KnownTx) InvalidateMerkleProofsByBlockHash(ctx context.Context, blockHa
 
 	var affected int64
 
-	err = p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err = runInTransaction(ctx, p.db, p.retry, func(tx *gorm.DB) error {
 		var affectedTxs []struct {
 			TxID      string
 			BlockHash string

--- a/pkg/internal/storage/repo/known_tx_get_beef_direct_sources_test.go
+++ b/pkg/internal/storage/repo/known_tx_get_beef_direct_sources_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/dbretry"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/entity"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/repo"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/dbfixtures"
@@ -70,7 +71,7 @@ func TestGetBEEFForTxIDs_DirectSourcesOnly_StorageKnownParents(t *testing.T) {
 	storeKnownTx(t, db, parent, nil)
 	storeKnownTx(t, db, subject, ancestryBytes)
 
-	repos := repo.NewSQLRepositories(db.DB)
+	repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 
 	// when:
 	beef, err := repos.GetBEEFForTxIDs(
@@ -106,7 +107,7 @@ func TestGetBEEFForTxIDs_DirectSourcesOnly_CallerSuppliedParent(t *testing.T) {
 
 	storeKnownTx(t, db, subject, ancestryBytes)
 
-	repos := repo.NewSQLRepositories(db.DB)
+	repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 
 	// when:
 	beef, err := repos.GetBEEFForTxIDs(

--- a/pkg/internal/storage/repo/output_baskets.go
+++ b/pkg/internal/storage/repo/output_baskets.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/genquery"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/scopes"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/dbretry"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/queryopts"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/tracing"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
@@ -22,10 +23,11 @@ import (
 type OutputBaskets struct {
 	db    *gorm.DB
 	query *genquery.Query
+	retry *dbretry.Policy
 }
 
-func NewOutputBaskets(db *gorm.DB, query *genquery.Query) *OutputBaskets {
-	return &OutputBaskets{db: db, query: query}
+func NewOutputBaskets(db *gorm.DB, query *genquery.Query, retry *dbretry.Policy) *OutputBaskets {
+	return &OutputBaskets{db: db, query: query, retry: retry}
 }
 
 func (o *OutputBaskets) FindBasketByName(ctx context.Context, userID int, name string) (*entity.OutputBasket, error) {
@@ -63,7 +65,7 @@ func (o *OutputBaskets) UpsertOutputBasket(ctx context.Context, userID int, bask
 		MinimumDesiredUTXOValue: basket.MinimumDesiredUTXOValue,
 	}
 
-	err = o.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err = runInTransaction(ctx, o.db, o.retry, func(tx *gorm.DB) error {
 		updateTx := tx.Model(&models.OutputBasket{}).
 			Scopes(scopes.UserID(userID)).
 			Where("name = ?", basket.Name).

--- a/pkg/internal/storage/repo/outputs.go
+++ b/pkg/internal/storage/repo/outputs.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/genquery"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/scopes"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/dbretry"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/entity"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/queryopts"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/txutils"
@@ -31,10 +32,11 @@ import (
 type Outputs struct {
 	db    *gorm.DB
 	query *genquery.Query
+	retry *dbretry.Policy
 }
 
-func NewOutputs(db *gorm.DB, query *genquery.Query) *Outputs {
-	return &Outputs{db: db, query: query}
+func NewOutputs(db *gorm.DB, query *genquery.Query, retry *dbretry.Policy) *Outputs {
+	return &Outputs{db: db, query: query, retry: retry}
 }
 
 type txIDsReadModel struct {
@@ -243,7 +245,7 @@ func (o *Outputs) UnlinkOutputFromBasketByOutpoint(ctx context.Context, userID i
 		tracing.EndTracing(span, err)
 	}()
 
-	err = o.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err = runInTransaction(ctx, o.db, o.retry, func(tx *gorm.DB) error {
 		query := tx.Model(&models.Output{}).
 			Select("id").
 			Scopes(scopes.UserID(userID)).
@@ -628,7 +630,7 @@ func (o *Outputs) SaveOutputs(ctx context.Context, outputs []*pkgentity.Output) 
 		return res
 	})
 
-	err = o.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err = runInTransaction(ctx, o.db, o.retry, func(tx *gorm.DB) error {
 		for _, model := range modelsToStore {
 			err = tx.Save(&model.Output).Error
 			if err != nil {
@@ -660,7 +662,7 @@ func (o *Outputs) RecreateSpentOutputs(ctx context.Context, spendingTransactionI
 		tracing.EndTracing(span, err)
 	}()
 
-	err = o.query.DBTransaction(func(query *genquery.Query) error {
+	err = runInQueryTransaction(ctx, o.query, o.retry, func(query *genquery.Query) error {
 		return recreateSpentOutputs(ctx, query, spendingTransactionID)
 	})
 	if err != nil {

--- a/pkg/internal/storage/repo/park_unbroadcast_known_tx_test.go
+++ b/pkg/internal/storage/repo/park_unbroadcast_known_tx_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/dbretry"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/history"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/repo"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/dbfixtures"
@@ -32,7 +33,7 @@ func TestParkUnbroadcastKnownTx_NeverPosted_Parks(t *testing.T) {
 			db, cleanup := dbfixtures.TestDatabase(t)
 			defer cleanup()
 
-			repos := repo.NewSQLRepositories(db.DB)
+			repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 			txID := "1111111111111111111111111111111111111111111111111111111111111111"
 			require.NoError(t, db.DB.Create(&models.KnownTx{
 				TxID:         txID,
@@ -88,7 +89,7 @@ func TestParkUnbroadcastKnownTx_PostedOrPosting_IsRefused(t *testing.T) {
 			db, cleanup := dbfixtures.TestDatabase(t)
 			defer cleanup()
 
-			repos := repo.NewSQLRepositories(db.DB)
+			repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 			txID := "2222222222222222222222222222222222222222222222222222222222222222"
 			knownTx.TxID = txID
 			require.NoError(t, db.DB.Create(&knownTx).Error)
@@ -118,7 +119,7 @@ func TestParkUnbroadcastKnownTx_MissingRow_IsRefused(t *testing.T) {
 	db, cleanup := dbfixtures.TestDatabase(t)
 	defer cleanup()
 
-	repos := repo.NewSQLRepositories(db.DB)
+	repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 
 	// when:
 	applied, err := repos.ParkUnbroadcastKnownTx(t.Context(), "3333333333333333333333333333333333333333333333333333333333333333", nil)
@@ -137,7 +138,7 @@ func TestClaimKnownTxsForBroadcast_ClaimsOnlyClaimableStatuses(t *testing.T) {
 	db, cleanup := dbfixtures.TestDatabase(t)
 	defer cleanup()
 
-	repos := repo.NewSQLRepositories(db.DB)
+	repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 
 	claimable := map[string]wdk.ProvenTxReqStatus{
 		"1111111111111111111111111111111111111111111111111111111111111111": wdk.ProvenTxStatusUnprocessed,
@@ -191,7 +192,7 @@ func TestClaimKnownTxsForBroadcast_ParkedTxIsNeverClaimed(t *testing.T) {
 	db, cleanup := dbfixtures.TestDatabase(t)
 	defer cleanup()
 
-	repos := repo.NewSQLRepositories(db.DB)
+	repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 	txID := "abababababababababababababababababababababababababababababababab"
 	require.NoError(t, db.DB.Create(&models.KnownTx{TxID: txID, Status: wdk.ProvenTxStatusUnsent}).Error)
 

--- a/pkg/internal/storage/repo/status_writers_test.go
+++ b/pkg/internal/storage/repo/status_writers_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/dbretry"
 	storageentity "github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/entity"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/history"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/repo"
@@ -24,7 +25,7 @@ func TestUpdateKnownTxStatus_ZeroRows_ReturnsSkipped(t *testing.T) {
 	db, cleanup := dbfixtures.TestDatabase(t)
 	defer cleanup()
 
-	repos := repo.NewSQLRepositories(db.DB)
+	repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 	ctx := t.Context()
 
 	txID := "1111111111111111111111111111111111111111111111111111111111111111"
@@ -41,7 +42,7 @@ func TestUpdateKnownTxStatus_SkipListExcludes_ReturnsSkippedAndWritesNoNotes(t *
 	db, cleanup := dbfixtures.TestDatabase(t)
 	defer cleanup()
 
-	repos := repo.NewSQLRepositories(db.DB)
+	repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 	ctx := t.Context()
 
 	txID := "2222222222222222222222222222222222222222222222222222222222222222"
@@ -79,7 +80,7 @@ func TestUpdateTransactionStatusByTxID_ExpectedMismatch_Skipped(t *testing.T) {
 	db, cleanup := dbfixtures.TestDatabase(t)
 	defer cleanup()
 
-	repos := repo.NewSQLRepositories(db.DB)
+	repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 	ctx := t.Context()
 
 	user, err := repos.CreateUser(ctx, "status-writer-mismatch", "test-storage")
@@ -113,7 +114,7 @@ func TestUpdateTransactionStatusByTxID_ExpectedMatch_Updates(t *testing.T) {
 	db, cleanup := dbfixtures.TestDatabase(t)
 	defer cleanup()
 
-	repos := repo.NewSQLRepositories(db.DB)
+	repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 	ctx := t.Context()
 
 	user, err := repos.CreateUser(ctx, "status-writer-match", "test-storage")
@@ -147,7 +148,7 @@ func TestUpdateTransactionStatusByID_ZeroRows_Skipped(t *testing.T) {
 	db, cleanup := dbfixtures.TestDatabase(t)
 	defer cleanup()
 
-	repos := repo.NewSQLRepositories(db.DB)
+	repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 	ctx := t.Context()
 
 	// when:
@@ -165,7 +166,7 @@ func TestInvalidateMerkleProofs_HappyPath_ReturnsCount(t *testing.T) {
 	db, cleanup := dbfixtures.TestDatabase(t)
 	defer cleanup()
 
-	repos := repo.NewSQLRepositories(db.DB)
+	repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 	ctx := t.Context()
 
 	blockHash := "000000000000000000000000000000000000000000000000000000000000dead"

--- a/pkg/internal/storage/repo/transaction_runner.go
+++ b/pkg/internal/storage/repo/transaction_runner.go
@@ -1,0 +1,32 @@
+package repo
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/genquery"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/dbretry"
+)
+
+// runInTransaction runs fn in a single database transaction, re-running it when the engine
+// rolls it back to break a conflict with a concurrent session. Whether that retry happens is
+// decided by the policy the repository was built with, not here: the top-level connection owns
+// its transactions and retries, a unit-of-work handle opens a savepoint and must not.
+//
+// fn must be safe to run more than once, which rules out a closure that accumulates into a
+// captured map or slice. Read-only queries do not use this helper: plain SELECTs take no row
+// locks and so have nothing to retry.
+func runInTransaction(ctx context.Context, db *gorm.DB, retry *dbretry.Policy, fn func(tx *gorm.DB) error) error {
+	return retry.Do(ctx, func() error {
+		return db.WithContext(ctx).Transaction(fn)
+	})
+}
+
+// runInQueryTransaction is runInTransaction for the generated-query API, which owns its own
+// transaction helper. Same policy, same re-run contract.
+func runInQueryTransaction(ctx context.Context, query *genquery.Query, retry *dbretry.Policy, fn func(query *genquery.Query) error) error {
+	return retry.Do(ctx, func() error {
+		return query.DBTransaction(fn)
+	})
+}

--- a/pkg/internal/storage/repo/transactions.go
+++ b/pkg/internal/storage/repo/transactions.go
@@ -19,6 +19,7 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/genquery"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/scopes"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/dbretry"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/entity"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/history"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/queryopts"
@@ -62,10 +63,11 @@ func (e *StaleUTXOIndexError) Unwrap() error { return ErrUTXOContention }
 type Transactions struct {
 	query *genquery.Query
 	db    *gorm.DB
+	retry *dbretry.Policy
 }
 
-func NewTransactions(db *gorm.DB, query *genquery.Query) *Transactions {
-	return &Transactions{db: db, query: query}
+func NewTransactions(db *gorm.DB, query *genquery.Query, retry *dbretry.Policy) *Transactions {
+	return &Transactions{db: db, query: query, retry: retry}
 }
 
 func (txs *Transactions) CreateTransaction(ctx context.Context, newTx *entity.NewTx) error {
@@ -75,7 +77,7 @@ func (txs *Transactions) CreateTransaction(ctx context.Context, newTx *entity.Ne
 		tracing.EndTracing(span, err)
 	}()
 
-	err = txs.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err = runInTransaction(ctx, txs.db, txs.retry, func(tx *gorm.DB) error {
 		return txs.createTransactionInTx(tx, newTx)
 	})
 	if err != nil {
@@ -413,7 +415,7 @@ func (txs *Transactions) SpendTransaction(ctx context.Context, updatedTx entity.
 		tracing.EndTracing(span, err)
 	}()
 
-	err = txs.db.WithContext(ctx).Transaction(func(tx *gorm.DB) (err error) {
+	err = runInTransaction(ctx, txs.db, txs.retry, func(tx *gorm.DB) (err error) {
 		err = tx.Model(models.Transaction{}).
 			Scopes(scopes.UserID(updatedTx.UserID)).
 			Where("id = ?", updatedTx.TransactionID).
@@ -761,7 +763,7 @@ func (txs *Transactions) AddLabels(ctx context.Context, userID int, transactionI
 
 	transactionModel := models.Transaction{}
 
-	err = txs.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	err = runInTransaction(ctx, txs.db, txs.retry, func(tx *gorm.DB) error {
 		err = tx.Model(models.Transaction{}).
 			Select("*").
 			Where("id = ?", transactionID).

--- a/pkg/internal/storage/repo/transactions_claim_test.go
+++ b/pkg/internal/storage/repo/transactions_claim_test.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/dbretry"
 	storageentity "github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/entity"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/repo"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/dbfixtures"
@@ -28,7 +29,7 @@ func TestMarkReservedOutputsAsNotSpendable_RejectsAlreadyClaimedOutput(t *testin
 	db, cleanup := dbfixtures.TestDatabase(t)
 	defer cleanup()
 
-	repos := repo.NewSQLRepositories(db.DB)
+	repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 	ctx := t.Context()
 
 	user, err := repos.CreateUser(ctx, "claim-contention-user", "test-storage")

--- a/pkg/internal/storage/repo/transactions_reserve_test.go
+++ b/pkg/internal/storage/repo/transactions_reserve_test.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/dbretry"
 	storageentity "github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/entity"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/repo"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/dbfixtures"
@@ -29,7 +30,7 @@ func TestReserveUTXOs_RejectsAlreadyReservedUTXO(t *testing.T) {
 	db, cleanup := dbfixtures.TestDatabase(t)
 	defer cleanup()
 
-	repos := repo.NewSQLRepositories(db.DB)
+	repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 	ctx := t.Context()
 
 	user, err := repos.CreateUser(ctx, "reserve-contention-user", "test-storage", wdk.DefaultBasketConfiguration())

--- a/pkg/internal/storage/repo/user_utxo_update_test.go
+++ b/pkg/internal/storage/repo/user_utxo_update_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/entity"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/dbretry"
 	storageentity "github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/entity"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/repo"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/dbfixtures"
@@ -31,7 +32,7 @@ func TestUserUTXOsUpdate_RejectsReservingAlreadyReservedUTXO(t *testing.T) {
 	db, cleanup := dbfixtures.TestDatabase(t)
 	defer cleanup()
 
-	repos := repo.NewSQLRepositories(db.DB)
+	repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 	ctx := t.Context()
 
 	user, err := repos.CreateUser(ctx, "utxo-cas-a-user", "test-storage", wdk.DefaultBasketConfiguration())
@@ -83,7 +84,7 @@ func TestUserUTXOsUpdate_ReservesUnreservedUTXO(t *testing.T) {
 	db, cleanup := dbfixtures.TestDatabase(t)
 	defer cleanup()
 
-	repos := repo.NewSQLRepositories(db.DB)
+	repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 	ctx := t.Context()
 
 	user, err := repos.CreateUser(ctx, "utxo-cas-b-user", "test-storage", wdk.DefaultBasketConfiguration())
@@ -134,7 +135,7 @@ func TestUserUTXOsUpdate_OtherFieldsUnaffectedByGuard(t *testing.T) {
 	db, cleanup := dbfixtures.TestDatabase(t)
 	defer cleanup()
 
-	repos := repo.NewSQLRepositories(db.DB)
+	repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 	ctx := t.Context()
 
 	user, err := repos.CreateUser(ctx, "utxo-cas-c-user", "test-storage", wdk.DefaultBasketConfiguration())
@@ -187,7 +188,7 @@ func TestUserUTXOsUpdate_MissingOutputReturnsNotFound(t *testing.T) {
 	db, cleanup := dbfixtures.TestDatabase(t)
 	defer cleanup()
 
-	repos := repo.NewSQLRepositories(db.DB)
+	repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 	ctx := t.Context()
 
 	user, err := repos.CreateUser(ctx, "utxo-notfound-user", "test-storage", wdk.DefaultBasketConfiguration())

--- a/pkg/internal/storage/repo/utxos.go
+++ b/pkg/internal/storage/repo/utxos.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/genquery"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/scopes"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/dbretry"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/queryopts"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/tracing"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
@@ -21,12 +22,14 @@ import (
 type UTXOs struct {
 	db    *gorm.DB
 	query *genquery.Query
+	retry *dbretry.Policy
 }
 
-func NewUTXOs(db *gorm.DB, query *genquery.Query) *UTXOs {
+func NewUTXOs(db *gorm.DB, query *genquery.Query, retry *dbretry.Policy) *UTXOs {
 	return &UTXOs{
 		db:    db,
 		query: query,
+		retry: retry,
 	}
 }
 
@@ -270,7 +273,7 @@ func (u *UTXOs) MakeChangeSpendableAndIndexByTxID(ctx context.Context, txID stri
 		tracing.EndTracing(span, err)
 	}()
 
-	err = u.query.DBTransaction(func(query *genquery.Query) error {
+	err = runInQueryTransaction(ctx, u.query, u.retry, func(query *genquery.Query) error {
 		filterScope := func(dao gen.Dao) gen.Dao {
 			subquery := query.Transaction.
 				Select(query.Transaction.ID).
@@ -311,7 +314,7 @@ func (u *UTXOs) CreateUTXOForSpendableOutputsByTxID(ctx context.Context, txID st
 		tracing.EndTracing(span, err)
 	}()
 
-	err = u.query.DBTransaction(func(query *genquery.Query) error {
+	err = runInQueryTransaction(ctx, u.query, u.retry, func(query *genquery.Query) error {
 		return createUTXOsForSpendableOutputsByTxID(ctx, query, txID)
 	})
 	if err != nil {

--- a/pkg/internal/storage/repo/utxos_bounded_test.go
+++ b/pkg/internal/storage/repo/utxos_bounded_test.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/dbretry"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/repo"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/dbfixtures"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
@@ -34,7 +35,7 @@ func newBoundedUTXOsFixture(t *testing.T) (*boundedUTXOsFixture, func()) {
 	t.Helper()
 
 	db, cleanup := dbfixtures.TestDatabase(t)
-	repos := repo.NewSQLRepositories(db.DB)
+	repos := repo.NewSQLRepositories(db.DB, dbretry.NoRetry())
 	ctx := t.Context()
 
 	user, err := repos.CreateUser(ctx, "bounded-utxos-user", "test-storage", wdk.DefaultBasketConfiguration())

--- a/pkg/storage/internal/actions/process.go
+++ b/pkg/storage/internal/actions/process.go
@@ -807,6 +807,25 @@ func (p *process) processDelayedTransactions(ctx context.Context, txIDs []string
 	return sendWithResults, nil
 }
 
+// broadcastResultSkipStatuses are the KnownTx statuses a broadcast result must not transition:
+// everything beyond the broadcast stage, plus the terminal failures that only the unfail flow
+// may resurrect. It is wider than wdk.ProvenTxReqBeyondBroadcastStageStatuses because it guards
+// the first write of updateSingleTx - the terminal failures used to be covered by the
+// Transaction CAS that ran before it.
+var broadcastResultSkipStatuses = append(
+	slices.Clone(wdk.ProvenTxReqBeyondBroadcastStageStatuses),
+	wdk.ProvenTxStatusInvalid,
+	wdk.ProvenTxStatusDoubleSpend,
+)
+
+// updateSingleTx applies one transaction's broadcast result: KnownTx status and history notes,
+// the owners' Transaction rows, and the outputs that follow from them.
+//
+// The shared KnownTx is written before the per-user Transaction rows, matching every other
+// multi-table writer in the storage layer; the reverse order deadlocked against the status-sync
+// cron, which picks a transaction up while its POST is still in flight. KnownTx is also the
+// storage-wide authority on how far a transaction has got, so it carries the guard that makes a
+// late or raced result a no-op.
 func (p *process) updateSingleTx(
 	ctx context.Context,
 	txID string,
@@ -836,18 +855,21 @@ func (p *process) updateSingleTx(
 
 	err = p.uow.Do(ctx, func(txCtx context.Context, repos Providers) error {
 		var uowErr error
-		// Guarded Transaction write FIRST. A broadcast result may only transition a tx that is
-		// still in a broadcast-eligible state: unprocessed (initial), sending (in-flight),
-		// nosend (broadcast via SendWith), or unproven (re-broadcast while awaiting proof, e.g.
-		// SendWaitingTransactions). If it matches zero rows the tx is already proven/mined
-		// (completed) or terminal (failed) — a late/raced result. Warn and no-op BEFORE the
-		// failure cascade or the KnownTx downgrade, so we never downgrade a proven tx or
-		// re-release inputs the proof already proved.
+		uowErr = repos.KnownTxRepo().UpdateKnownTxStatus(txCtx, txID, newReqStatus, broadcastResultSkipStatuses, notes)
+		if uowErr != nil {
+			if errors.Is(uowErr, repo.ErrStatusUpdateSkipped) {
+				p.logger.WarnContext(txCtx, "ignoring late broadcast result for transaction beyond broadcast stage",
+					slog.String("txID", txID), slog.String("attemptedStatus", string(newReqStatus)), logging.Error(uowErr))
+				return nil
+			}
+			return fmt.Errorf("failed to update known tx status after broadcast: %w", uowErr)
+		}
+
 		uowErr = repos.TransactionsRepo().UpdateTransactionStatusByTxID(txCtx, txID, newTxStatus,
 			wdk.TxStatusUnprocessed, wdk.TxStatusSending, wdk.TxStatusNoSend, wdk.TxStatusUnproven)
 		if uowErr != nil {
 			if errors.Is(uowErr, repo.ErrStatusUpdateSkipped) {
-				p.logger.WarnContext(txCtx, "ignoring late broadcast result for transaction beyond broadcast stage",
+				p.logger.WarnContext(txCtx, "broadcast result not applied to user transactions (no row in the expected pre-proof state)",
 					slog.String("txID", txID), slog.String("attemptedStatus", string(newTxStatus)), logging.Error(uowErr))
 				return nil
 			}
@@ -868,17 +890,6 @@ func (p *process) updateSingleTx(
 				if uowErr = repos.OutputRepo().MarkCreatedOutputsAsNotSpendable(txCtx, id); uowErr != nil {
 					return fmt.Errorf("failed to mark created outputs as not spendable for failed tx %s: %w", txID, uowErr)
 				}
-			}
-		}
-
-		uowErr = repos.KnownTxRepo().UpdateKnownTxStatus(txCtx, txID, newReqStatus, wdk.ProvenTxReqBeyondBroadcastStageStatuses, notes)
-		if uowErr != nil {
-			if errors.Is(uowErr, repo.ErrStatusUpdateSkipped) {
-				// The shared KnownTx is already beyond the broadcast stage; leaving it as-is
-				// is legitimate. The Transaction write above already matched, so continue.
-				p.logger.DebugContext(txCtx, "known tx status update skipped (beyond broadcast stage)", slog.String("txID", txID), logging.Error(uowErr))
-			} else {
-				return fmt.Errorf("failed to update known tx status after broadcast: %w", uowErr)
 			}
 		}
 

--- a/pkg/storage/internal/actions/process_background_broadcast_test.go
+++ b/pkg/storage/internal/actions/process_background_broadcast_test.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/history"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/repo"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/logging"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 )
@@ -179,5 +181,130 @@ func TestBackgroundBroadcast_BumpsAttemptsAfterPost(t *testing.T) {
 		require.Error(t, err)
 		assert.Zero(t, rec.count("bump"), "attempts must not be bumped when the post failed")
 		assert.Empty(t, spy.attemptsCalls)
+	})
+}
+
+// --- Lock-order regression cover for updateSingleTx's unit of work ---
+
+// bgOrderUowKnownTxRepo / bgOrderUowTxRepo record which table is written first and let a test
+// drive either guard into ErrStatusUpdateSkipped.
+type bgOrderUowKnownTxRepo struct {
+	KnownTxRepo
+
+	rec              *callRecorder
+	skipStatusesSeen []wdk.ProvenTxReqStatus
+	skip             bool
+}
+
+func (s *bgOrderUowKnownTxRepo) UpdateKnownTxStatus(_ context.Context, txID string, status wdk.ProvenTxReqStatus, skipForStatuses []wdk.ProvenTxReqStatus, _ []history.Builder) error {
+	s.rec.record("known_tx")
+	s.skipStatusesSeen = skipForStatuses
+	if s.skip {
+		return fmt.Errorf("%w: known tx %s -> %s", repo.ErrStatusUpdateSkipped, txID, status)
+	}
+	return nil
+}
+
+type bgOrderUowTxRepo struct {
+	TransactionsRepo
+
+	rec  *callRecorder
+	skip bool
+}
+
+func (s *bgOrderUowTxRepo) UpdateTransactionStatusByTxID(_ context.Context, txID string, status wdk.TxStatus, _ ...wdk.TxStatus) error {
+	s.rec.record("transactions")
+	if s.skip {
+		return fmt.Errorf("%w: transaction(s) with txID %s -> %s", repo.ErrStatusUpdateSkipped, txID, status)
+	}
+	return nil
+}
+
+type bgOrderUowUTXORepo struct {
+	UTXORepo
+
+	rec *callRecorder
+}
+
+func (s *bgOrderUowUTXORepo) CreateUTXOForSpendableOutputsByTxID(_ context.Context, _ string) error {
+	s.rec.record("utxo")
+	return nil
+}
+
+type bgOrderUowProviders struct {
+	Providers
+
+	knownTx *bgOrderUowKnownTxRepo
+	txs     *bgOrderUowTxRepo
+	utxo    *bgOrderUowUTXORepo
+}
+
+func (p bgOrderUowProviders) TransactionsRepo() TransactionsRepo { return p.txs }
+func (p bgOrderUowProviders) KnownTxRepo() KnownTxRepo           { return p.knownTx }
+func (p bgOrderUowProviders) UTXORepo() UTXORepo                 { return p.utxo }
+
+type bgOrderUow struct{ providers bgOrderUowProviders }
+
+func (u bgOrderUow) Do(ctx context.Context, fn func(ctx context.Context, p Providers) error) error {
+	return fn(ctx, u.providers)
+}
+
+// TestUpdateSingleTx_WritesKnownTxBeforeTransactions pins the lock order of the post-broadcast
+// apply - shared KnownTx before the per-user Transaction rows - and the guard semantics that
+// ride on it. The reverse order deadlocked against the status-sync cron.
+func TestUpdateSingleTx_WritesKnownTxBeforeTransactions(t *testing.T) {
+	const txID = "deadbeef"
+
+	newProcess := func(knownTx *bgOrderUowKnownTxRepo, txs *bgOrderUowTxRepo, utxo *bgOrderUowUTXORepo) *process {
+		return &process{
+			logger: logging.NewTestLogger(t),
+			uow:    bgOrderUow{providers: bgOrderUowProviders{knownTx: knownTx, txs: txs, utxo: utxo}},
+		}
+	}
+
+	successResult := &wdk.AggregatedPostedTxID{Status: wdk.AggregatedPostedTxIDSuccess}
+
+	t.Run("known_tx is written before transactions", func(t *testing.T) {
+		rec := &callRecorder{}
+		knownTx := &bgOrderUowKnownTxRepo{rec: rec}
+		p := newProcess(knownTx, &bgOrderUowTxRepo{rec: rec}, &bgOrderUowUTXORepo{rec: rec})
+
+		_, _, err := p.updateSingleTx(context.Background(), txID, successResult, nil, nil, []string{txID}, "", nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"known_tx", "transactions", "utxo"}, rec.snapshot())
+	})
+
+	t.Run("the known_tx guard covers terminal failures, not just the beyond-broadcast statuses", func(t *testing.T) {
+		rec := &callRecorder{}
+		knownTx := &bgOrderUowKnownTxRepo{rec: rec}
+		p := newProcess(knownTx, &bgOrderUowTxRepo{rec: rec}, &bgOrderUowUTXORepo{rec: rec})
+
+		_, _, err := p.updateSingleTx(context.Background(), txID, successResult, nil, nil, []string{txID}, "", nil)
+		require.NoError(t, err)
+
+		assert.Subset(t, knownTx.skipStatusesSeen, wdk.ProvenTxReqBeyondBroadcastStageStatuses)
+		assert.Contains(t, knownTx.skipStatusesSeen, wdk.ProvenTxStatusInvalid)
+		assert.Contains(t, knownTx.skipStatusesSeen, wdk.ProvenTxStatusDoubleSpend)
+	})
+
+	t.Run("a skipped known_tx guard makes the whole unit of work a no-op", func(t *testing.T) {
+		rec := &callRecorder{}
+		p := newProcess(&bgOrderUowKnownTxRepo{rec: rec, skip: true}, &bgOrderUowTxRepo{rec: rec}, &bgOrderUowUTXORepo{rec: rec})
+
+		_, _, err := p.updateSingleTx(context.Background(), txID, successResult, nil, nil, []string{txID}, "", nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"known_tx"}, rec.snapshot())
+	})
+
+	t.Run("a skipped transaction CAS keeps the known_tx transition and skips the rest", func(t *testing.T) {
+		rec := &callRecorder{}
+		p := newProcess(&bgOrderUowKnownTxRepo{rec: rec}, &bgOrderUowTxRepo{rec: rec, skip: true}, &bgOrderUowUTXORepo{rec: rec})
+
+		_, _, err := p.updateSingleTx(context.Background(), txID, successResult, nil, nil, []string{txID}, "", nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"known_tx", "transactions"}, rec.snapshot())
 	})
 }

--- a/pkg/storage/provider.go
+++ b/pkg/storage/provider.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/specops"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/database/models"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/dbretry"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/funder"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/repo"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/validate"
@@ -72,13 +73,24 @@ func (p *providersWrapper) CommissionRepo() actions.CommissionRepo     { return 
 func (p *providersWrapper) KeyValueRepo() actions.KeyValueRepo         { return p.r.KeyValue }
 
 type uow struct {
-	db *gorm.DB
+	db     *gorm.DB
+	logger *slog.Logger
+	random wdk.Randomizer
 }
 
+// Do runs fn inside a single database transaction, re-running the whole transaction when the
+// engine rolls it back to break a conflict with a concurrent session. The repositories fn
+// receives are bound to that transaction and therefore do not retry on their own; this is the
+// only layer that can, because only it can release every lock and start over.
+//
+// fn is re-run from the top, so its CAS guards re-evaluate against current state. Every closure
+// passed here writes only to the database, which is what makes re-running it safe.
 func (u *uow) Do(ctx context.Context, fn func(ctx context.Context, p actions.Providers) error) error {
-	return u.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		txRepos := repo.NewSQLRepositories(tx)
-		return fn(ctx, &providersWrapper{txRepos})
+	return dbretry.Do(ctx, u.logger, u.random, func() error {
+		return u.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			txRepos := repo.NewSQLRepositories(tx, dbretry.NoRetry())
+			return fn(ctx, &providersWrapper{txRepos})
+		})
 	})
 }
 
@@ -137,7 +149,7 @@ func NewGORMProvider(chain defs.BSVNetwork, services wdk.Services, opts ...Provi
 			tunableFunder,
 			options.Commission,
 			repos,
-			&uow{db.DB},
+			&uow{db: db.DB, logger: log, random: options.Randomizer},
 			options.Randomizer,
 			services,
 			options.SynchronizeTxStatusesConfig,


### PR DESCRIPTION
## What Changed
- Fixed a lock-order inversion in updateSingleTx (process.go). The post-broadcast apply now writes the shared known_tx row before the per-user transactions rows, matching every other multi-table writer in the storage layer (UpdateKnownTxAsMined, AdvanceKnownTxToBroadcasted, FailKnownTxAsDoubleSpend, the unfail cascades). It was the only writer taking them in the reverse order.
- Widened the KnownTx guard into broadcastResultSkipStatuses — ProvenTxReqBeyondBroadcastStageStatuses plus invalid and doubleSpend. Since KnownTx now leads, its skip list is what stops a late broadcast result from resurrecting a terminal failure; that used to be covered transitively by the Transaction CAS.
- Added pkg/internal/storage/dbretry — bounded retry (3 attempts, jittered backoff) on Postgres class-40 rollbacks: 40P01 deadlock_detected and 40001 serialization_failure. Nothing else is retried.
- Wired the retry into uow.Do (provider.go), covering all six units of work: updateSingleTx, abortTx, internalizeAction, markAsInvalid, markAsUnminedAndUnproven, reviewKnownTxStatuses.
- Wired it into 18 repository transactions via a dbretry.Policy threaded through NewSQLRepositories. The top-level connection owns its transactions and retries; repositories bound to a unit of work get NoRetry(), because a savepoint rollback frees only its own locks, not the outer ones the deadlock cycle runs through.
- Read-only repository transactions (ListAndCountActions, GetLabelsForSelectedActions, ListAndCountOutputs, FindInputsAndOutputsForSelectedActions) deliberately do not retry — plain SELECTs take no row locks, and two of them accumulate into captured maps, so a re-run would duplicate results.

## Why It Was Necessary
- Production hit deadlock detected (SQLSTATE 40P01) under a 1000-settlement load test (5000 transactions). The background broadcaster held transactions(X) and waited on known_tx(X); the status-sync cron held known_tx(X) and waited on transactions(X).
- The window is wide enough to hit regularly: ClaimKnownTxsForBroadcast flips the tx to sending before the POST, sending is in statusesReadyToSync, and confirmDoubleSpends can add several seconds between the claim and the status write.
- The transaction that lost the deadlock had already been accepted by the network, but its status was never recorded: known_tx and transactions stuck at sending, attempts left at 0 (so the proof-timeout machinery stayed blind to it), and no event emitted on txBroadcastedChannel. The loop returns on first error, so the rest of the batch was lost too.
- No retry on class-40 existed anywhere in the storage layer — the only retry was retryOnContention for UTXO contention, which does not match this error.

## Testing Performed
-go test ./... — full suite green.
- golangci-lint run ./pkg/internal/storage/... ./pkg/storage/... — clean (the one gosec G118 in background_broadcaster.go:230 pre-dates this branch, verified against a stashed tree).
- New TestUpdateSingleTx_WritesKnownTxBeforeTransactions — 4 subtests pinning the write order, the widened skip list, and both skip paths.
- New dbretry tests — 15 cases: error unwrapping through the real production wrap chain, non-retryable codes, retry-then-succeed, exhausting MaxAttempts with the SQLSTATE intact, context cancellation mid-backoff, and Retrying / NoRetry / nil-policy behaviour.
- Verified the gorm postgres driver's TranslateError does not remap 40P01 (its errCodes map covers only 23505/23503/42703/23514), so *pgconn.PgError survives to errors.As.

## Impact / Risk
- Two cases in updateSingleTx now no-op that previously wrote. Both were latent bugs: a terminal invalid/doubleSpend KnownTx being downgraded to unmined (leaving known_tx = unmined / transactions = failed permanently divergent and invisible to reviewKnownTxStatuses), and a per-user Transaction being downgraded after the tx had already advanced past the broadcast stage.
- No behaviour change when there is no contention — the retry only fires on class-40 rollbacks, which never occur on SQLite.
- NewSQLRepositories gained a required parameter. Both production call sites and 20 test call sites updated; no external callers.
- Worth watching after deploy: "retrying database transaction after a transient rollback" at WARN. A steady stream of these would mean another lock-order inversion remains rather than a transient conflict.