### PR TITLE
feat: add background broadcaster config, sort tx before broadcast, fallback for beef party

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@ manual_tests/*.sqlite-journal
 manual_tests/*.sqlite-wal
 manual_tests/*.sqlite-shm
 
+# Runtime / container log dumps (e.g. `docker compose logs > token-wallet.log`)
+*.log
+
 # Fuzz Tests
 testdata
 

--- a/.golangci.json
+++ b/.golangci.json
@@ -285,7 +285,8 @@
         ],
         "concurrency": 8,
         "issues-exit-code": 1,
-        "tests": true
+        "tests": true,
+        "timeout": "10m"
     },
     "severity": {
         "default": "warning",

--- a/infra-config-docker.yaml
+++ b/infra-config-docker.yaml
@@ -105,6 +105,18 @@ monitor:
       interval_seconds: 600
       start_immediately: false
 
+# --- Delayed broadcast queue ---
+# createAction hands transactions to this queue; the send_waiting cron is only a
+# fallback for whatever does not fit, and it drains far more slowly.
+#   workers      0 = derive from utxo_management.throughput.target_tps, else 10.
+#                    Throughput is roughly workers / (time of one post).
+#   channel_size 0 = 1000. This buffers bursts; it does not raise sustained
+#                    throughput. 5000 absorbs a burst of a few thousand
+#                    transactions without spilling to the cron.
+background_broadcaster:
+  workers: 0
+  channel_size: 5000
+
 # --- Change Basket Defaults ---
 change_basket:
   max_change_outputs_per_tx: 8

--- a/infra-config.example.yaml
+++ b/infra-config.example.yaml
@@ -1,3 +1,6 @@
+background_broadcaster:
+  channel_size: 0
+  workers: 0
 bsv_network: main
 change_basket:
   max_change_outputs_per_tx: 8

--- a/pkg/defs/background_broadcaster.go
+++ b/pkg/defs/background_broadcaster.go
@@ -1,0 +1,52 @@
+package defs
+
+import "fmt"
+
+const (
+	// MaxBroadcasterWorkers bounds the delayed-broadcast worker pool. Past this
+	// point the database connection pool and the broadcast service, not the
+	// number of goroutines, decide throughput.
+	MaxBroadcasterWorkers = 1024
+
+	// MaxBroadcasterChannelSize bounds the delayed-broadcast queue. Every queued
+	// item holds a parsed BEEF - a structure, not raw bytes - so an oversized
+	// queue is an out-of-memory risk rather than a harmless buffer. The cap is
+	// here to make a typo cost a config error instead of a dead process.
+	MaxBroadcasterChannelSize = 100_000
+)
+
+// BackgroundBroadcaster sizes the delayed-broadcast queue that createAction
+// hands its transactions to.
+//
+// Both fields are optional and a zero means "not configured": the sizing is then
+// derived from the throughput strategy when it is enabled, and otherwise falls
+// back to the package defaults. Because the fields resolve independently, an
+// operator can widen the queue for bursty traffic without touching the worker
+// count, or the other way round.
+type BackgroundBroadcaster struct {
+	// Workers is the number of concurrent posts. Throughput is roughly
+	// Workers / (time of one post), so this is the ceiling on how fast queued
+	// transactions reach the network.
+	Workers uint `mapstructure:"workers"`
+	// ChannelSize is how many transactions may wait for a worker. It absorbs
+	// bursts; it does not raise sustained throughput. Whatever does not fit is
+	// deferred to the send_waiting cron, which drains far more slowly.
+	ChannelSize uint `mapstructure:"channel_size"`
+}
+
+// DefaultBackgroundBroadcaster returns the unconfigured value, which preserves
+// the sizing every existing deployment gets today.
+func DefaultBackgroundBroadcaster() BackgroundBroadcaster {
+	return BackgroundBroadcaster{}
+}
+
+// Validate verifies the background broadcaster configuration.
+func (b *BackgroundBroadcaster) Validate() error {
+	if b.Workers > MaxBroadcasterWorkers {
+		return fmt.Errorf("workers must not exceed %d, got %d", MaxBroadcasterWorkers, b.Workers)
+	}
+	if b.ChannelSize > MaxBroadcasterChannelSize {
+		return fmt.Errorf("channel_size must not exceed %d, got %d", MaxBroadcasterChannelSize, b.ChannelSize)
+	}
+	return nil
+}

--- a/pkg/defs/background_broadcaster_test.go
+++ b/pkg/defs/background_broadcaster_test.go
@@ -1,0 +1,65 @@
+package defs_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+)
+
+// TestDefaultBackgroundBroadcasterIsUnconfigured pins the contract every existing
+// deployment relies on: with nothing in the config file the sizing is still the one
+// derived from the strategy, not something this struct imposes.
+func TestDefaultBackgroundBroadcasterIsUnconfigured(t *testing.T) {
+	cfg := defs.DefaultBackgroundBroadcaster()
+
+	assert.Zero(t, cfg.Workers)
+	assert.Zero(t, cfg.ChannelSize)
+	require.NoError(t, cfg.Validate())
+}
+
+func TestBackgroundBroadcasterValidate(t *testing.T) {
+	tests := map[string]struct {
+		cfg     defs.BackgroundBroadcaster
+		wantErr bool
+	}{
+		"zero values are the unconfigured default": {
+			cfg: defs.BackgroundBroadcaster{},
+		},
+		"only the queue widened": {
+			cfg: defs.BackgroundBroadcaster{ChannelSize: 5000},
+		},
+		"only the pool widened": {
+			cfg: defs.BackgroundBroadcaster{Workers: 50},
+		},
+		"both at their upper bound": {
+			cfg: defs.BackgroundBroadcaster{
+				Workers:     defs.MaxBroadcasterWorkers,
+				ChannelSize: defs.MaxBroadcasterChannelSize,
+			},
+		},
+		"too many workers": {
+			cfg:     defs.BackgroundBroadcaster{Workers: defs.MaxBroadcasterWorkers + 1},
+			wantErr: true,
+		},
+		// A queue is sized in parsed BEEFs, not bytes, so a typo here costs memory
+		// rather than a harmless over-allocation.
+		"queue beyond the memory guard": {
+			cfg:     defs.BackgroundBroadcaster{ChannelSize: defs.MaxBroadcasterChannelSize + 1},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/infra/config.go
+++ b/pkg/infra/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	TracingConfig         defs.TracingConfig         `mapstructure:"tracing"`
 	ChangeBasket          defs.ChangeBasket          `mapstructure:"change_basket"`
 	UTXOManagement        defs.UTXOManagement        `mapstructure:"utxo_management"`
+	BackgroundBroadcaster defs.BackgroundBroadcaster `mapstructure:"background_broadcaster"`
 	Observability         defs.Observability         `mapstructure:"observability"`
 }
 
@@ -93,6 +94,7 @@ func Defaults() Config {
 		TracingConfig:         defs.DefaultTracingConfig(),
 		ChangeBasket:          defs.DefaultChangeBasket(),
 		UTXOManagement:        defs.DefaultUTXOManagement(),
+		BackgroundBroadcaster: defs.DefaultBackgroundBroadcaster(),
 		Observability:         defs.DefaultObservability(),
 	}
 }
@@ -215,6 +217,10 @@ func (c *Config) Validate() (err error) {
 
 	if err = c.UTXOManagement.Validate(c.FeeModel, c.Commission); err != nil {
 		return fmt.Errorf("invalid utxo management config: %w", err)
+	}
+
+	if err = c.BackgroundBroadcaster.Validate(); err != nil {
+		return fmt.Errorf("invalid background broadcaster config: %w", err)
 	}
 
 	if err = c.Observability.Validate(); err != nil {

--- a/pkg/infra/gorm_provider_options.go
+++ b/pkg/infra/gorm_provider_options.go
@@ -12,5 +12,6 @@ func GORMProviderOptionsFromConfig(cfg *Config) []storage.ProviderOption {
 		storage.WithFailAbandoned(cfg.FailAbandoned),
 		storage.WithChangeBasket(cfg.ChangeBasket),
 		storage.WithUTXOManagement(cfg.UTXOManagement),
+		storage.WithBackgroundBroadcaster(cfg.BackgroundBroadcaster),
 	}
 }

--- a/pkg/infra/server.go
+++ b/pkg/infra/server.go
@@ -108,6 +108,7 @@ func NewServer(ctx context.Context, opts ...InitOption) (*Server, error) {
 		GORMProviderOptionsFromConfig(&cfg),
 		storage.WithLogger(logger),
 		storage.WithBackgroundBroadcasterContext(ctx),
+		storage.WithBackgroundBroadcaster(defs.BackgroundBroadcaster{Workers: cfg.BackgroundBroadcaster.Workers, ChannelSize: cfg.BackgroundBroadcaster.ChannelSize}),
 	)
 
 	activeStorage, err := storage.NewGORMProvider(cfg.BSVNetwork, activeServices, providerOptions...)

--- a/pkg/internal/storage/database/scopes/for_gorm_gen.go
+++ b/pkg/internal/storage/database/scopes/for_gorm_gen.go
@@ -20,8 +20,18 @@ func PaginateForGen(getter genTableGetter, page *queryopts.Paging) func(gen.Dao)
 		}
 
 		sortByExpr := to.If(page.IsDesc(), sortBy.Desc).Else(sortBy.Asc)
+		dao = dao.Order(sortByExpr)
 
-		return dao.Order(sortByExpr).Offset(page.Offset).Limit(page.Limit)
+		if page.ThenBy != "" {
+			thenBy, thenOk := getter.GetFieldByName(page.ThenBy)
+			if !thenOk {
+				_ = dao.AddError(fmt.Errorf("field %s not found", page.ThenBy))
+				return dao
+			}
+			dao = dao.Order(to.If(page.IsDesc(), thenBy.Desc).Else(thenBy.Asc))
+		}
+
+		return dao.Offset(page.Offset).Limit(page.Limit)
 	}
 }
 

--- a/pkg/internal/storage/database/scopes/scopes.go
+++ b/pkg/internal/storage/database/scopes/scopes.go
@@ -11,11 +11,17 @@ import (
 func Paginate(page *queryopts.Paging) func(db *gorm.DB) *gorm.DB {
 	page.ApplyDefaults()
 	return func(db *gorm.DB) *gorm.DB {
-		orderClause := clause.OrderByColumn{
+		db = db.Order(clause.OrderByColumn{
 			Column: clause.Column{Name: page.SortBy},
 			Desc:   page.IsDesc(),
+		})
+		if page.ThenBy != "" {
+			db = db.Order(clause.OrderByColumn{
+				Column: clause.Column{Name: page.ThenBy},
+				Desc:   page.IsDesc(),
+			})
 		}
-		return db.Order(orderClause).Offset(page.Offset).Limit(page.Limit)
+		return db.Offset(page.Offset).Limit(page.Limit)
 	}
 }
 

--- a/pkg/internal/storage/queryopts/paging.go
+++ b/pkg/internal/storage/queryopts/paging.go
@@ -7,6 +7,11 @@ type Paging struct {
 	Offset int
 	Sort   string
 	SortBy string
+	// ThenBy breaks ties on SortBy. Rows that compare equal on SortBy otherwise come back in
+	// whatever order the engine happens to pick, which is unstable between queries: under
+	// OFFSET paging that can drop a row from one page and repeat it on the next. Empty leaves
+	// the ordering as it was.
+	ThenBy string
 }
 
 // ApplyDefaults sets default values for a Paging object (in place).
@@ -19,6 +24,8 @@ func (p *Paging) ApplyDefaults() {
 	if p.SortBy == "" {
 		p.SortBy = "created_at"
 	}
+
+	p.ThenBy = strings.ToLower(p.ThenBy)
 
 	if strings.ToLower(p.Sort) == "asc" {
 		p.Sort = "ASC"

--- a/pkg/internal/testabilities/testservices/fixture_arc.go
+++ b/pkg/internal/testabilities/testservices/fixture_arc.go
@@ -44,6 +44,10 @@ type ARCFixture interface {
 	OnBroadcast() ArcBroadcastFixture
 	HoldBroadcasting() ARCFixture
 	ReleaseBroadcasting() ARCFixture
+	// PostedTxIDs returns the txids of every broadcast POST this fixture received, in the
+	// order they arrived. Arcade forwards to Teranode in that order, so this is what an
+	// assertion about broadcast order has to look at.
+	PostedTxIDs() []string
 }
 
 type ARCQueryFixture interface {
@@ -75,6 +79,9 @@ type arcFixture struct {
 	url                          string
 	token                        string
 	holdBroadcastExecution       sync.RWMutex
+
+	postedMu    sync.Mutex
+	postedTxIDs []string
 }
 
 func NewARCFixture(t testing.TB, opts ...Option) ARCFixture {
@@ -141,6 +148,7 @@ func (f *arcFixture) IsUpAndRunning() {
 			return httpmock.NewJsonResponse(errorResponseForStatusWithExtraInfo(arcHttpStatusCumulativeFeeValidationFailed, message))
 		}
 
+		f.recordPostedTx(tx.TxID().String())
 		f.storeEFTx(tx)
 
 		if f.broadcastWithoutResponseBody {
@@ -154,6 +162,18 @@ func (f *arcFixture) IsUpAndRunning() {
 		txid := req.URL.String()[len(f.url+"/v1/tx/"):]
 		return f.getKnownTransaction(txid).toResponse()
 	})
+}
+
+func (f *arcFixture) recordPostedTx(txID string) {
+	f.postedMu.Lock()
+	defer f.postedMu.Unlock()
+	f.postedTxIDs = append(f.postedTxIDs, txID)
+}
+
+func (f *arcFixture) PostedTxIDs() []string {
+	f.postedMu.Lock()
+	defer f.postedMu.Unlock()
+	return append([]string(nil), f.postedTxIDs...)
 }
 
 func (f *arcFixture) TxInfoJSON(id string) string {

--- a/pkg/internal/txutils/parents_first.go
+++ b/pkg/internal/txutils/parents_first.go
@@ -1,0 +1,73 @@
+package txutils
+
+import (
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+)
+
+// ParentsFirst returns txIDs reordered so that a transaction spending another
+// transaction of the same batch comes after it, preserving the input order
+// otherwise. PostFromBEEF posts a batch in slice order and Arcade forwards
+// upstream in receive order, so an unordered batch could post a child before the
+// parent it shares a request with. The input slice is not modified.
+//
+// The reordering is stable: transactions with no dependency on each other keep
+// their relative order, so an input already sorted by creation time stays sorted.
+func ParentsFirst(beef *transaction.Beef, txIDs []string) []string {
+	if beef == nil || len(txIDs) < 2 {
+		return append([]string(nil), txIDs...)
+	}
+
+	batch := make(map[string]struct{}, len(txIDs))
+	for _, txID := range txIDs {
+		batch[txID] = struct{}{}
+	}
+
+	ordered := make([]string, 0, len(txIDs))
+	visited := make(map[string]struct{}, len(txIDs))
+
+	var visit func(txID string)
+	visit = func(txID string) {
+		if _, seen := visited[txID]; seen {
+			return
+		}
+		visited[txID] = struct{}{} // marked before recursing, so a cycle cannot loop forever
+		for _, parentID := range batchParents(beef, txID, batch) {
+			visit(parentID)
+		}
+		ordered = append(ordered, txID)
+	}
+	for _, txID := range txIDs {
+		visit(txID)
+	}
+	return ordered
+}
+
+// batchParents returns the txids spent by txID that are also subjects of the same
+// batch.
+func batchParents(beef *transaction.Beef, txID string, batch map[string]struct{}) []string {
+	tx := BeefTx(beef, txID)
+	if tx == nil {
+		return nil
+	}
+	var parents []string
+	for _, in := range tx.Inputs {
+		if in.SourceTXID == nil {
+			continue
+		}
+		parentID := in.SourceTXID.String()
+		if _, ok := batch[parentID]; ok {
+			parents = append(parents, parentID)
+		}
+	}
+	return parents
+}
+
+// BeefTx looks a subject transaction up in a beef by its hex txid.
+func BeefTx(beef *transaction.Beef, txID string) *transaction.Transaction {
+	hash, err := chainhash.NewHashFromHex(txID)
+	if err != nil {
+		return nil
+	}
+	return beef.FindTransactionByHash(hash)
+}

--- a/pkg/internal/txutils/parents_first_test.go
+++ b/pkg/internal/txutils/parents_first_test.go
@@ -1,0 +1,84 @@
+package txutils_test
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	txtestabilities "github.com/bsv-blockchain/universal-test-vectors/pkg/testabilities"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/txutils"
+)
+
+// beefWith merges the given transactions into one BEEF, in the order they are handed over.
+func beefWith(t *testing.T, txs ...*transaction.Transaction) *transaction.Beef {
+	t.Helper()
+	beef := transaction.NewBeefV2()
+	for _, tx := range txs {
+		_, err := beef.MergeRawTx(tx.Bytes(), nil)
+		require.NoError(t, err)
+	}
+	return beef
+}
+
+// TestParentsFirst covers the contract both broadcast paths depend on: PostFromBEEF posts a
+// slice in order and Arcade forwards upstream in receive order, so a child spending another
+// subject of the same post has to come after it - while everything else stays where it was,
+// because that input order carries the transactions' creation order.
+func TestParentsFirst(t *testing.T) {
+	parentSpec := txtestabilities.GivenTX().WithInput(200_000).WithP2PKHOutput(150_000)
+	childSpec := txtestabilities.GivenTX().
+		WithSender(txtestabilities.Bob).
+		WithInputFromUTXO(parentSpec.TX(), 0).
+		WithP2PKHOutput(100_000)
+	grandchildSpec := txtestabilities.GivenTX().
+		WithSender(txtestabilities.Bob).
+		WithInputFromUTXO(childSpec.TX(), 0).
+		WithP2PKHOutput(50_000)
+
+	parent, child, grandchild := parentSpec.ID().String(), childSpec.ID().String(), grandchildSpec.ID().String()
+	beef := beefWith(t, parentSpec.TX(), childSpec.TX(), grandchildSpec.TX())
+
+	t.Run("moves a child behind the parent it spends", func(t *testing.T) {
+		assert.Equal(t, []string{parent, child}, txutils.ParentsFirst(beef, []string{child, parent}))
+	})
+
+	t.Run("resolves a chain, not just a pair", func(t *testing.T) {
+		assert.Equal(t, []string{parent, child, grandchild}, txutils.ParentsFirst(beef, []string{grandchild, child, parent}))
+	})
+
+	t.Run("leaves an order that already respects the dependencies alone", func(t *testing.T) {
+		ordered := []string{parent, child, grandchild}
+		assert.Equal(t, ordered, txutils.ParentsFirst(beef, ordered))
+	})
+
+	t.Run("does not modify the input slice", func(t *testing.T) {
+		input := []string{child, parent}
+		txutils.ParentsFirst(beef, input)
+		assert.Equal(t, []string{child, parent}, input)
+	})
+
+	t.Run("keeps unrelated transactions in the order they were given", func(t *testing.T) {
+		// Only the child has to move; the parent's position relative to an unrelated
+		// transaction must survive, otherwise the creation order would not.
+		unrelatedSpec := txtestabilities.GivenTX().WithInput(90_000).WithP2PKHOutput(80_000)
+		unrelated := unrelatedSpec.ID().String()
+		withUnrelated := beefWith(t, parentSpec.TX(), childSpec.TX(), unrelatedSpec.TX())
+
+		assert.Equal(t,
+			[]string{parent, child, unrelated},
+			txutils.ParentsFirst(withUnrelated, []string{parent, child, unrelated}),
+		)
+		assert.Equal(t,
+			[]string{parent, unrelated, child},
+			txutils.ParentsFirst(withUnrelated, []string{parent, unrelated, child}),
+		)
+	})
+
+	t.Run("passes through what it cannot reorder", func(t *testing.T) {
+		assert.Equal(t, []string{child}, txutils.ParentsFirst(beef, []string{child}))
+		assert.Equal(t, []string{child, parent}, txutils.ParentsFirst(nil, []string{child, parent}))
+		assert.Empty(t, txutils.ParentsFirst(beef, nil))
+	})
+}

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -61,6 +61,9 @@ type ActiveTask struct {
 	Instance tasks.TaskInterface
 	Cronjob  gocron.Job
 	TaskName defs.MonitorTask
+	// Interval is the configured period of the job, and the authority on how long
+	// one run may take. The scheduler's own NextRun() is not: see contextWithTimeout.
+	Interval time.Duration
 }
 
 // NewDaemonWithGORMLocker creates a new Daemon instance with a GORM-based distributed lock.
@@ -216,6 +219,7 @@ func (d *Daemon) initializeTask(taskInstance tasks.TaskInterface, taskName defs.
 	task := &ActiveTask{
 		Instance: taskInstance,
 		TaskName: taskName,
+		Interval: taskConfig.Interval(),
 		// NOTE: Cronjob (gocron.Job) is not set here, as it will be set when the job is created.
 	}
 
@@ -238,7 +242,7 @@ func (d *Daemon) initializeTask(taskInstance tasks.TaskInterface, taskName defs.
 		opts = append(opts, gocron.WithStartAt(gocron.WithStartImmediately()))
 	}
 
-	interval := taskConfig.Interval()
+	interval := task.Interval
 
 	// Wire the lease TTL for this job before it can run. The lock key gocron
 	// uses is jobName, so the TTL must be registered under jobName. A TTL of
@@ -290,32 +294,34 @@ func (d *Daemon) singleTaskRunner(activeTask *ActiveTask) func(ctx context.Conte
 			d.logger.InfoContext(ctx, "Finish task", slog.Any("task", activeTask.TaskName), slog.Any("next_run", nextRun))
 		}()
 
-		nextRun, err := activeTask.Cronjob.NextRun()
-		if err != nil {
-			d.logger.ErrorContext(ctx, "Failed to get next run for task", slog.Any("task", activeTask.TaskName), slog.Any("error", err))
-			return
-		}
-
-		ctx, cancel := d.contextWithTimeout(ctx, nextRun)
+		ctx, cancel := d.contextWithTimeout(ctx, activeTask.Interval)
 		defer cancel()
 
 		err = activeTask.Instance.Run(ctx)
 	}
 }
 
-func (d *Daemon) contextWithTimeout(ctx context.Context, nextRun time.Time) (context.Context, context.CancelFunc) {
-	if nextRun.IsZero() {
+// contextWithTimeout budgets one run of a task: its interval, less a safety margin,
+// so a run normally finishes before the next one is due.
+//
+// The budget is deliberately derived from the configured interval and NOT from the
+// scheduler's NextRun(). gocron can start a run a few milliseconds BEFORE its
+// scheduled instant, and NextRun() then still reports that instant rather than the
+// following one. Subtracting it from "now" yielded single-digit milliseconds instead
+// of the interval, and every batch in the run failed instantly on an already-expired
+// context - observed in production as hundreds of identical errors from a sweep that
+// lasted 34ms in total.
+//
+// Overrunning the slot is already tolerated elsewhere: gocron runs these jobs in
+// singleton mode with LimitModeReschedule, so an overlapping tick is rescheduled
+// rather than run concurrently, and the distributed lease TTL is max(2*interval, 5m)
+// precisely so a slow run is not stolen by a peer.
+func (d *Daemon) contextWithTimeout(ctx context.Context, interval time.Duration) (context.Context, context.CancelFunc) {
+	if interval <= 0 {
 		return ctx, func() {}
 	}
 
-	now := time.Now()
-	untilNext := nextRun.Sub(now)
-
-	if untilNext <= 0 {
-		return ctx, func() {}
-	}
-
-	timeout := time.Duration(float64(untilNext) * safetyMargin)
+	timeout := time.Duration(float64(interval) * safetyMargin)
 	return context.WithTimeout(ctx, timeout)
 }
 

--- a/pkg/monitor/task_budget_test.go
+++ b/pkg/monitor/task_budget_test.go
@@ -1,0 +1,120 @@
+package monitor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/logging"
+)
+
+// budgetCapturingTask records the deadline its run was given.
+type budgetCapturingTask struct {
+	ran         bool
+	deadline    time.Time
+	hasDeadline bool
+	err         error
+}
+
+func (c *budgetCapturingTask) Run(ctx context.Context) error {
+	c.ran = true
+	c.deadline, c.hasDeadline = ctx.Deadline()
+	return c.err
+}
+
+func TestContextWithTimeout(t *testing.T) {
+	d := &Daemon{logger: logging.NewTestLogger(t)}
+
+	t.Run("budgets the interval less the safety margin", func(t *testing.T) {
+		ctx, cancel := d.contextWithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok)
+		assert.InDelta(t, float64(285*time.Second), float64(time.Until(deadline)), float64(time.Second))
+	})
+
+	t.Run("an unset interval leaves the context alone", func(t *testing.T) {
+		for _, interval := range []time.Duration{0, -time.Second} {
+			ctx, cancel := d.contextWithTimeout(context.Background(), interval)
+			cancel()
+
+			_, ok := ctx.Deadline()
+			assert.False(t, ok, "interval %s must not produce a deadline", interval)
+		}
+	})
+
+	t.Run("an earlier parent deadline still wins", func(t *testing.T) {
+		parent, cancelParent := context.WithTimeout(context.Background(), time.Second)
+		defer cancelParent()
+
+		ctx, cancel := d.contextWithTimeout(parent, time.Hour)
+		defer cancel()
+
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok)
+		assert.Less(t, time.Until(deadline), 2*time.Second)
+	})
+}
+
+// TestSingleTaskRunner_BudgetsFromTheInterval is the regression guard for the
+// production incident: gocron started send_waiting 17.85ms BEFORE its scheduled
+// instant, NextRun() still reported that instant rather than the following one, and
+// the run was handed a ~17ms budget instead of 285s. Every one of the 197 batches it
+// had just discovered then failed on its first query, and the whole run lasted 34ms.
+//
+// Deriving the budget from the configured interval makes that impossible by
+// construction, whatever the scheduler reports.
+func TestSingleTaskRunner_BudgetsFromTheInterval(t *testing.T) {
+	d := &Daemon{logger: logging.NewTestLogger(t)}
+	task := &budgetCapturingTask{}
+
+	// Cronjob is deliberately nil: the budget must not depend on the scheduler being
+	// able to answer questions about the next run.
+	runner := d.singleTaskRunner(&ActiveTask{
+		Instance: task,
+		TaskName: defs.SendWaitingMonitorTask,
+		Interval: 5 * time.Minute,
+	})
+	runner(context.Background())
+
+	require.True(t, task.ran, "the task must run even when the scheduler cannot report a next run")
+	require.True(t, task.hasDeadline)
+	assert.InDelta(t, float64(285*time.Second), float64(time.Until(task.deadline)), float64(time.Second))
+}
+
+func TestSingleTaskRunner_ReportsTaskFailure(t *testing.T) {
+	d := &Daemon{logger: logging.NewTestLogger(t)}
+	task := &budgetCapturingTask{err: errors.New("boom: task failed")}
+
+	runner := d.singleTaskRunner(&ActiveTask{
+		Instance: task,
+		TaskName: defs.SendWaitingMonitorTask,
+		Interval: time.Minute,
+	})
+
+	assert.NotPanics(t, func() { runner(context.Background()) })
+	assert.True(t, task.ran)
+}
+
+// TestInitializeTaskRecordsTheInterval pins the wiring the budget depends on: an
+// ActiveTask built by the daemon must carry the configured interval.
+func TestInitializeTaskRecordsTheInterval(t *testing.T) {
+	d, err := NewDaemon(logging.NewTestLogger(t), nil, DefaultDaemonEventOptions())
+	require.NoError(t, err)
+
+	require.NoError(t, d.initializeTask(
+		&budgetCapturingTask{},
+		defs.SendWaitingMonitorTask,
+		defs.TaskConfig{Enabled: true, IntervalSeconds: 300},
+	))
+
+	active, ok := d.Get(defs.SendWaitingMonitorTask)
+	require.True(t, ok)
+	assert.Equal(t, 5*time.Minute, active.Interval)
+}

--- a/pkg/storage/internal/actions/actions.go
+++ b/pkg/storage/internal/actions/actions.go
@@ -65,10 +65,10 @@ func (t ThroughputConfig) broadcasterSizing() service.Sizing {
 func resolveBroadcasterSizing(explicit defs.BackgroundBroadcaster, throughput ThroughputConfig) service.Sizing {
 	sizing := throughput.broadcasterSizing()
 	if explicit.Workers > 0 {
-		sizing.Workers = int(explicit.Workers) //nolint:gosec // bounded by defs.MaxBroadcasterWorkers
+		sizing.Workers = int(explicit.Workers)
 	}
 	if explicit.ChannelSize > 0 {
-		sizing.ChannelSize = int(explicit.ChannelSize) //nolint:gosec // bounded by defs.MaxBroadcasterChannelSize
+		sizing.ChannelSize = int(explicit.ChannelSize)
 	}
 	return sizing
 }

--- a/pkg/storage/internal/actions/actions.go
+++ b/pkg/storage/internal/actions/actions.go
@@ -57,6 +57,29 @@ func (t ThroughputConfig) broadcasterSizing() service.Sizing {
 	}
 }
 
+// resolveBroadcasterSizing combines the operator's explicit sizing with the one
+// derived from the throughput strategy. Resolution is per field and an explicit
+// value wins, so a deployment that is not on the throughput strategy - where the
+// derivation yields nothing - can still widen just the queue for bursty traffic.
+// Fields left at zero fall through to the package defaults in service.Sizing.
+func resolveBroadcasterSizing(explicit defs.BackgroundBroadcaster, throughput ThroughputConfig) service.Sizing {
+	sizing := throughput.broadcasterSizing()
+	if explicit.Workers > 0 {
+		sizing.Workers = int(explicit.Workers) //nolint:gosec // bounded by defs.MaxBroadcasterWorkers
+	}
+	if explicit.ChannelSize > 0 {
+		sizing.ChannelSize = int(explicit.ChannelSize) //nolint:gosec // bounded by defs.MaxBroadcasterChannelSize
+	}
+	return sizing
+}
+
+// BroadcasterQueueStats reports the delayed-broadcast queue occupancy, so the
+// provider can expose it as a gauge. Depth is what predicts an overflow; the
+// overflow counter only reports one after it already happened.
+func (a *Actions) BroadcasterQueueStats() (depth, capacity int) {
+	return a.backgroundBroadcaster.QueueStats()
+}
+
 func New(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -71,6 +94,7 @@ func New(
 	scriptsVerifier wdk.ScriptsVerifier,
 	txBroadcastedChannel chan<- wdk.CurrentTxStatus,
 	throughput ThroughputConfig,
+	broadcasterCfg defs.BackgroundBroadcaster,
 ) *Actions {
 	abortAction := newAbortAction(logger, repos.Transactions, repos.Outputs, repos.UTXOs, repos.KnownTx, uow)
 
@@ -89,7 +113,7 @@ func New(
 		beefVerifier,
 		scriptsVerifier,
 		txBroadcastedChannel,
-		throughput.broadcasterSizing(),
+		resolveBroadcasterSizing(broadcasterCfg, throughput),
 		syncTxStatusesConfig.MaxRebroadcastAttempts,
 		abortAction,
 	)

--- a/pkg/storage/internal/actions/broadcaster_overflow_test.go
+++ b/pkg/storage/internal/actions/broadcaster_overflow_test.go
@@ -1,0 +1,133 @@
+package actions
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/storage/internal/service"
+)
+
+const overflowWarnMsg = "delayed broadcast queue is full; transactions deferred to the send_waiting cron"
+
+func newOverflowProcess(t *testing.T, queueSize int) (*process, *bytes.Buffer) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	return &process{
+		logger: logger,
+		backgroundBroadcaster: service.NewBackgroundBroadcaster(
+			t.Context(), logger, nil, nil, service.Sizing{Workers: 1, ChannelSize: queueSize},
+		),
+	}, &buf
+}
+
+// overflowWarning is the shape the warning is asserted on. Decoding into it rather
+// than a map keeps the counters integral, which is what they are.
+type overflowWarning struct {
+	Msg                      string `json:"msg"`
+	DeferredSinceLastWarning uint64 `json:"deferredSinceLastWarning"`
+	DeferredTotal            uint64 `json:"deferredTotal"`
+	QueueDepth               int    `json:"queueDepth"`
+	QueueCapacity            int    `json:"queueCapacity"`
+}
+
+func overflowWarnings(t *testing.T, buf *bytes.Buffer) []overflowWarning {
+	t.Helper()
+
+	var out []overflowWarning
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec overflowWarning
+		require.NoError(t, json.Unmarshal([]byte(line), &rec))
+		if rec.Msg == overflowWarnMsg {
+			out = append(out, rec)
+		}
+	}
+	return out
+}
+
+// TestRecordBroadcasterOverflow_ReportsTheBurstAsOneAccurateWarning is the point of
+// the whole change: the incident rejected 197 transactions inside two seconds, and
+// logged none of it above debug level. One line per rejection would bury the signal,
+// and a line reporting only the first would understate it by two orders of magnitude.
+func TestRecordBroadcasterOverflow_ReportsTheBurstAsOneAccurateWarning(t *testing.T) {
+	p, buf := newOverflowProcess(t, 1000)
+
+	const rejections = 197
+	for range rejections {
+		p.recordBroadcasterOverflow(context.Background(), 1)
+	}
+
+	// Nothing is emitted mid-burst: the first rejection arms the window rather than
+	// logging a count of one.
+	require.Empty(t, overflowWarnings(t, buf))
+
+	// The sweep - which is about to pick these very transactions up - flushes it.
+	p.flushBroadcasterOverflow(context.Background())
+
+	warnings := overflowWarnings(t, buf)
+	require.Len(t, warnings, 1, "a burst must collapse into one warning")
+
+	assert.Equal(t, uint64(rejections), warnings[0].DeferredSinceLastWarning)
+	assert.Equal(t, uint64(rejections), warnings[0].DeferredTotal)
+	assert.Equal(t, 1000, warnings[0].QueueCapacity)
+	assert.NotContains(t, buf.String(), "txIDs", "the warning must not carry per-transaction payload")
+	assert.Equal(t, uint64(rejections), p.overflowTotal.Load())
+}
+
+// TestFlushBroadcasterOverflow_IsANoopWithNothingPending keeps the sweep quiet on the
+// overwhelmingly common path where the queue never overflowed.
+func TestFlushBroadcasterOverflow_IsANoopWithNothingPending(t *testing.T) {
+	p, buf := newOverflowProcess(t, 10)
+
+	p.flushBroadcasterOverflow(context.Background())
+	p.recordBroadcasterOverflow(context.Background(), 4)
+	p.flushBroadcasterOverflow(context.Background())
+	p.flushBroadcasterOverflow(context.Background())
+
+	assert.Len(t, overflowWarnings(t, buf), 1, "only the flush that had something to report may log")
+}
+
+// TestRecordBroadcasterOverflow_WarnsAgainInTheNextWindow makes sure throttling delays
+// the warning rather than silencing it while an overflow is ongoing.
+func TestRecordBroadcasterOverflow_WarnsAgainInTheNextWindow(t *testing.T) {
+	p, buf := newOverflowProcess(t, 10)
+
+	p.recordBroadcasterOverflow(context.Background(), 5) // arms the window
+	require.Empty(t, overflowWarnings(t, buf))
+
+	// Age the window instead of sleeping through it.
+	p.overflowLoggedAt.Store(time.Now().Add(-2 * broadcasterOverflowLogInterval).UnixNano())
+	p.recordBroadcasterOverflow(context.Background(), 3)
+
+	p.overflowLoggedAt.Store(time.Now().Add(-2 * broadcasterOverflowLogInterval).UnixNano())
+	p.recordBroadcasterOverflow(context.Background(), 2)
+
+	warnings := overflowWarnings(t, buf)
+	require.Len(t, warnings, 2)
+
+	assert.Equal(t, uint64(8), warnings[0].DeferredSinceLastWarning, "the first line carries everything accrued so far")
+	assert.Equal(t, uint64(2), warnings[1].DeferredSinceLastWarning, "each later window reports only its own rejections")
+	assert.Equal(t, uint64(10), warnings[1].DeferredTotal, "the running total spans windows")
+}
+
+func TestRecordBroadcasterOverflow_IgnoresEmptyBatches(t *testing.T) {
+	p, buf := newOverflowProcess(t, 10)
+
+	p.recordBroadcasterOverflow(context.Background(), 0)
+
+	assert.Empty(t, overflowWarnings(t, buf))
+	assert.Zero(t, p.overflowTotal.Load())
+}

--- a/pkg/storage/internal/actions/broadcaster_sizing_test.go
+++ b/pkg/storage/internal/actions/broadcaster_sizing_test.go
@@ -1,0 +1,77 @@
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/defs"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/storage/internal/service"
+)
+
+// TestResolveBroadcasterSizing pins the precedence between the operator's explicit
+// sizing and the one derived from the throughput strategy. The case that matters
+// most is the last one: an untouched config must still produce exactly what every
+// deployment gets today.
+func TestResolveBroadcasterSizing(t *testing.T) {
+	throughputOn := ThroughputConfig{Enabled: true, TargetTPS: 1000}
+
+	tests := map[string]struct {
+		explicit        defs.BackgroundBroadcaster
+		throughput      ThroughputConfig
+		wantWorkers     int
+		wantChannelSize int
+	}{
+		"nothing configured, no throughput: package defaults apply": {
+			// Zero Sizing means service.Sizing falls back to its own constants.
+			wantWorkers:     0,
+			wantChannelSize: 0,
+		},
+		"throughput only: sizing is derived": {
+			throughput:      throughputOn,
+			wantWorkers:     256,
+			wantChannelSize: 256 * 400,
+		},
+		"queue widened on a non-throughput deployment": {
+			// The incident case: the queue is the lever, and it has to be reachable
+			// without switching the whole funding strategy on.
+			explicit:        defs.BackgroundBroadcaster{ChannelSize: 5000},
+			wantWorkers:     0,
+			wantChannelSize: 5000,
+		},
+		"pool widened, queue left derived": {
+			explicit:        defs.BackgroundBroadcaster{Workers: 50},
+			throughput:      throughputOn,
+			wantWorkers:     50,
+			wantChannelSize: 256 * 400,
+		},
+		"explicit values win over the derivation": {
+			explicit:        defs.BackgroundBroadcaster{Workers: 64, ChannelSize: 9000},
+			throughput:      throughputOn,
+			wantWorkers:     64,
+			wantChannelSize: 9000,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			sizing := resolveBroadcasterSizing(tc.explicit, tc.throughput)
+
+			assert.Equal(t, tc.wantWorkers, sizing.Workers)
+			assert.Equal(t, tc.wantChannelSize, sizing.ChannelSize)
+		})
+	}
+}
+
+// TestResolveBroadcasterSizingKeepsTodaysDefaults spells out what the zero value
+// resolves to once service.Sizing has applied its fallbacks, so a change to either
+// side of that contract fails here rather than silently in production.
+func TestResolveBroadcasterSizingKeepsTodaysDefaults(t *testing.T) {
+	sizing := resolveBroadcasterSizing(defs.BackgroundBroadcaster{}, ThroughputConfig{})
+
+	bb := service.NewBackgroundBroadcaster(t.Context(), nil, nil, nil, sizing)
+	depth, capacity := bb.QueueStats()
+
+	assert.Zero(t, depth)
+	assert.Equal(t, service.BackgroundBroadcasterChannelSize, capacity)
+}

--- a/pkg/storage/internal/actions/process.go
+++ b/pkg/storage/internal/actions/process.go
@@ -9,6 +9,8 @@ import (
 	"maps"
 	"slices"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/bsv-blockchain/go-sdk/transaction"
 	"github.com/go-softwarelab/common/pkg/must"
@@ -26,6 +28,7 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/repo"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/txutils"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/logging"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/storage/internal/metrics"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/storage/internal/service"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/tracing"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
@@ -53,6 +56,14 @@ type process struct {
 	// double-spend-confirmed) tx is requeued for rebroadcast; 0 means unlimited.
 	maxRebroadcastAttempts uint64
 	aborter                actionAborter
+
+	// overflow* throttle the queue-full warning. A burst rejects hundreds of
+	// transactions within a second or two, and one line per rejection would bury
+	// the very signal the line exists to carry. Add() sits on the synchronous
+	// createAction path, so the throttle must stay lock-free.
+	overflowTotal    atomic.Uint64
+	overflowSinceLog atomic.Uint64
+	overflowLoggedAt atomic.Int64 // unix nanos of the last emitted warning
 }
 
 func newProcessAction(
@@ -801,10 +812,87 @@ func (p *process) processDelayedTransactions(ctx context.Context, txIDs []string
 
 	added := p.backgroundBroadcaster.Add(beef, txIDs)
 	if !added {
-		p.logger.DebugContext(ctx, "Background broadcaster channel is full, will be added later by the CRON")
+		p.recordBroadcasterOverflow(ctx, len(txIDs))
 	}
 
 	return sendWithResults, nil
+}
+
+// broadcasterOverflowLogInterval bounds how often the queue-full warning is
+// emitted. The operator needs to know that it happened and how many
+// transactions it affected, not one line per transaction.
+const broadcasterOverflowLogInterval = 10 * time.Second
+
+// recordBroadcasterOverflow accounts for transactions the delayed-broadcast
+// queue refused. They are not lost - the send_waiting cron picks them up - but
+// that path drains far more slowly, so this has to be visible at INFO level
+// rather than buried in debug logs where nobody reads it.
+//
+// The count is exact in the metric immediately; the log line is throttled,
+// because a burst rejects hundreds of transactions inside a second or two.
+func (p *process) recordBroadcasterOverflow(ctx context.Context, txCount int) {
+	if txCount <= 0 {
+		return
+	}
+
+	metrics.RecordBroadcasterOverflow(ctx, txCount)
+
+	p.overflowTotal.Add(uint64(txCount))
+	p.overflowSinceLog.Add(uint64(txCount))
+
+	now := time.Now().UnixNano()
+	last := p.overflowLoggedAt.Load()
+	if last == 0 {
+		// First rejection: arm the window instead of logging. The useful line is the
+		// one that says how many transactions a burst displaced, not the one that
+		// reports the first of them.
+		if p.overflowLoggedAt.CompareAndSwap(0, now) {
+			return
+		}
+		last = p.overflowLoggedAt.Load()
+	}
+
+	if now-last < int64(broadcasterOverflowLogInterval) {
+		return
+	}
+	if !p.overflowLoggedAt.CompareAndSwap(last, now) {
+		// Another goroutine won this window; its line carries our count too, because
+		// the pending counter is only drained by the winner.
+		return
+	}
+
+	p.logBroadcasterOverflow(ctx)
+}
+
+// flushBroadcasterOverflow reports whatever the throttle is still holding back.
+//
+// The sweep calls it, because the sweep is where the consequence surfaces: a burst
+// that never recurs would otherwise leave its tail - everything rejected after the
+// last windowed warning - unreported, which is exactly the blind spot this whole
+// change exists to close. Reporting it next to the sweep also puts cause and effect
+// in the same place in the log.
+func (p *process) flushBroadcasterOverflow(ctx context.Context) {
+	if p.overflowSinceLog.Load() == 0 {
+		return
+	}
+	p.overflowLoggedAt.Store(time.Now().UnixNano())
+	p.logBroadcasterOverflow(ctx)
+}
+
+func (p *process) logBroadcasterOverflow(ctx context.Context) {
+	deferredSinceLastWarning := p.overflowSinceLog.Swap(0)
+	if deferredSinceLastWarning == 0 {
+		return
+	}
+
+	depth, capacity := p.backgroundBroadcaster.QueueStats()
+	p.logger.WarnContext(ctx,
+		"delayed broadcast queue is full; transactions deferred to the send_waiting cron",
+		slog.Uint64("deferredSinceLastWarning", deferredSinceLastWarning),
+		slog.Uint64("deferredTotal", p.overflowTotal.Load()),
+		slog.Int("queueDepth", depth),
+		slog.Int("queueCapacity", capacity),
+	)
 }
 
 // broadcastResultSkipStatuses are the KnownTx statuses a broadcast result must not transition:

--- a/pkg/storage/internal/actions/process.go
+++ b/pkg/storage/internal/actions/process.go
@@ -571,7 +571,15 @@ func (p *process) broadcastTxs(ctx context.Context, txIDs []string, isDelayed bo
 	if len(claimedTxIDs) == 0 {
 		return &wdk.ProcessActionResult{SendWithResults: sendWithResults}, nil
 	}
-	readyToSendTxIDs = claimedTxIDs
+	// Keep the caller's order rather than adopting the claim's: the sweep hands these over
+	// oldest-first, and the claim query returns whatever order the database happens to use.
+	readyToSendTxIDs = retainClaimed(readyToSendTxIDs, claimedTxIDs)
+
+	// Parents ahead of their children within this post. PostFromBEEF walks the slice in order
+	// and Arcade forwards upstream in receive order, so a child posted before the parent it
+	// spends is rejected by Teranode. The reordering is stable, so the creation order above
+	// survives everywhere there is no dependency to respect.
+	readyToSendTxIDs = txutils.ParentsFirst(beef, readyToSendTxIDs)
 
 	// Count the attempt only for the txs we are ACTUALLY posting now (readyToSendTxIDs), right
 	// before the post. Already-sent txs (which took the early return / sendWithResults branch) and
@@ -620,6 +628,27 @@ type postedBroadcast struct {
 	txLabelsLookup     map[string][]string
 	sendWithResults    []wdk.SendWithResult
 	notDelayedResults  []wdk.ReviewActionResult
+}
+
+// retainClaimed keeps the txIDs that the claim accepted, in the order they were asked for.
+// ClaimKnownTxsForBroadcast matches on `tx_id IN (...)` without an ORDER BY, so its result
+// carries the database's ordering - typically by txid hex, which says nothing about the order
+// these transactions have to reach the network in.
+func retainClaimed(txIDs, claimedTxIDs []string) []string {
+	if len(claimedTxIDs) == len(txIDs) {
+		return txIDs
+	}
+	claimed := make(map[string]struct{}, len(claimedTxIDs))
+	for _, txID := range claimedTxIDs {
+		claimed[txID] = struct{}{}
+	}
+	retained := make([]string, 0, len(claimedTxIDs))
+	for _, txID := range txIDs {
+		if _, ok := claimed[txID]; ok {
+			retained = append(retained, txID)
+		}
+	}
+	return retained
 }
 
 func (p *process) partitionBroadcastTxIDs(
@@ -1134,14 +1163,17 @@ func (p *process) BackgroundBroadcast(ctx context.Context, beef *transaction.Bee
 	// The queued BEEF was built earlier, so re-claim right before posting: a transaction that
 	// was aborted (and had its inputs released) while sitting in the queue is no longer
 	// claimable and must not reach the network.
-	txIDs, err := p.knownTxRepo.ClaimKnownTxsForBroadcast(ctx, txIDs)
+	claimedTxIDs, err := p.knownTxRepo.ClaimKnownTxsForBroadcast(ctx, txIDs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to claim txs for background broadcast: %w", err)
 	}
-	if len(txIDs) == 0 {
+	if len(claimedTxIDs) == 0 {
 		p.logger.InfoContext(ctx, "skipping background broadcast: no transaction is claimable anymore")
 		return nil, nil
 	}
+	// Filter rather than replace: Add() already ordered this item parents-first, and the claim
+	// query returns whatever order the database happens to use.
+	txIDs = retainClaimed(txIDs, claimedTxIDs)
 
 	results, err := p.services.PostFromBEEF(ctx, beef, txIDs)
 	if err != nil {

--- a/pkg/storage/internal/actions/process_background_broadcast_test.go
+++ b/pkg/storage/internal/actions/process_background_broadcast_test.go
@@ -49,7 +49,12 @@ func (r *callRecorder) count(name string) int {
 }
 
 // bgSpyKnownTxRepo is the process's knownTxRepo: it records each attempts bump (call + txIDs).
+// claimReturns stands in for the claim query's own ordering, which is the database's, not the
+// caller's - when set, it is returned instead of the txIDs that were asked for.
 func (s *bgSpyKnownTxRepo) ClaimKnownTxsForBroadcast(_ context.Context, txIDs []string) ([]string, error) {
+	if s.claimReturns != nil {
+		return s.claimReturns, nil
+	}
 	return txIDs, nil
 }
 
@@ -58,6 +63,7 @@ type bgSpyKnownTxRepo struct {
 
 	rec           *callRecorder
 	attemptsCalls [][]string
+	claimReturns  []string
 }
 
 func (s *bgSpyKnownTxRepo) IncreaseKnownTxAttemptsForTxIDs(_ context.Context, txIDs []string) error {
@@ -73,10 +79,13 @@ type bgStubServices struct {
 	rec     *callRecorder
 	result  wdk.PostFromBeefResult
 	postErr error
+
+	postedTxIDs []string
 }
 
-func (b *bgStubServices) PostFromBEEF(_ context.Context, _ *transaction.Beef, _ []string) (wdk.PostFromBeefResult, error) {
+func (b *bgStubServices) PostFromBEEF(_ context.Context, _ *transaction.Beef, txIDs []string) (wdk.PostFromBeefResult, error) {
 	b.rec.record("post")
+	b.postedTxIDs = txIDs
 	return b.result, b.postErr
 }
 
@@ -181,6 +190,53 @@ func TestBackgroundBroadcast_BumpsAttemptsAfterPost(t *testing.T) {
 		require.Error(t, err)
 		assert.Zero(t, rec.count("bump"), "attempts must not be bumped when the post failed")
 		assert.Empty(t, spy.attemptsCalls)
+	})
+}
+
+// TestBackgroundBroadcast_KeepsTheOrderItWasGiven pins the ordering contract of the re-claim.
+// Add() orders an item parents-first, and PostFromBEEF posts the slice in order, so the claim -
+// which matches on `tx_id IN (...)` and carries the database's ordering - must be used as a
+// filter, never as the new order. Adopting it used to send a child upstream ahead of its parent.
+func TestBackgroundBroadcast_KeepsTheOrderItWasGiven(t *testing.T) {
+	parent, child, gone := "aaa-parent", "bbb-child", "ccc-aborted"
+
+	t.Run("a reordered claim result does not reorder the post", func(t *testing.T) {
+		rec := &callRecorder{}
+		services := &bgStubServices{rec: rec, result: newSuccessPostResult(parent)}
+		p := &process{
+			logger:      logging.NewTestLogger(t),
+			knownTxRepo: &bgSpyKnownTxRepo{rec: rec, claimReturns: []string{child, parent}},
+			services:    services,
+			txRepo:      bgStubTxRepo{},
+			uow:         bgUow{},
+		}
+
+		_, err := p.BackgroundBroadcast(context.Background(), nil, []string{parent, child})
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{parent, child}, services.postedTxIDs)
+	})
+
+	t.Run("what the claim rejected is dropped, the rest keeps its order", func(t *testing.T) {
+		rec := &callRecorder{}
+		services := &bgStubServices{rec: rec, result: newSuccessPostResult(parent)}
+		spy := &bgSpyKnownTxRepo{rec: rec, claimReturns: []string{child, parent}}
+		p := &process{
+			logger:      logging.NewTestLogger(t),
+			knownTxRepo: spy,
+			services:    services,
+			txRepo:      bgStubTxRepo{},
+			uow:         bgUow{},
+		}
+
+		// gone was aborted while queued: it must not reach the network, and must not drag the
+		// others out of order on its way out.
+		_, err := p.BackgroundBroadcast(context.Background(), nil, []string{parent, gone, child})
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{parent, child}, services.postedTxIDs)
+		require.Len(t, spy.attemptsCalls, 1)
+		assert.Equal(t, []string{parent, child}, spy.attemptsCalls[0], "attempts are bumped for what is actually posted")
 	})
 }
 
@@ -306,5 +362,38 @@ func TestUpdateSingleTx_WritesKnownTxBeforeTransactions(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, []string{"known_tx", "transactions"}, rec.snapshot())
+	})
+}
+
+// TestRetainClaimed pins the filter both broadcast paths run the claim result through.
+// ClaimKnownTxsForBroadcast matches on `tx_id IN (...)` with no ORDER BY, so its result carries
+// the database's ordering - taking it as the new order is what used to send a child upstream
+// ahead of its parent.
+func TestRetainClaimed(t *testing.T) {
+	oldest, middle, newest := "aaa-oldest", "mmm-middle", "zzz-newest"
+
+	t.Run("keeps the caller's order when everything was claimed", func(t *testing.T) {
+		// The claim came back sorted by txid; the caller asked in creation order.
+		assert.Equal(t,
+			[]string{newest, oldest, middle},
+			retainClaimed([]string{newest, oldest, middle}, []string{oldest, middle, newest}),
+		)
+	})
+
+	t.Run("drops what was not claimed and keeps the rest in order", func(t *testing.T) {
+		assert.Equal(t,
+			[]string{newest, middle},
+			retainClaimed([]string{newest, oldest, middle}, []string{middle, newest}),
+		)
+	})
+
+	t.Run("an empty claim retains nothing", func(t *testing.T) {
+		assert.Empty(t, retainClaimed([]string{oldest, middle}, nil))
+	})
+
+	t.Run("does not modify the input slice", func(t *testing.T) {
+		input := []string{newest, oldest, middle}
+		retainClaimed(input, []string{oldest})
+		assert.Equal(t, []string{newest, oldest, middle}, input)
 	})
 }

--- a/pkg/storage/internal/actions/process_send_waiting.go
+++ b/pkg/storage/internal/actions/process_send_waiting.go
@@ -15,6 +15,15 @@ import (
 const (
 	sendWaitingMaxPages     = 10
 	sendWaitingItemsPerPage = 1000
+
+	// sweepBatchDurationSeed is the per-batch estimate used before any batch of
+	// this run has been timed.
+	sweepBatchDurationSeed = 1 * time.Second
+	// sweepMinReserve floors the reserve so a run of fast batches cannot shrink
+	// the estimate to a value that leaves no room for a slow outlier.
+	sweepMinReserve = 2 * time.Second
+	// sweepEWMAWeight is the weight of the newest sample in the running average.
+	sweepEWMAWeight = 0.3
 )
 
 var statusesOfWaitingTxs = []wdk.ProvenTxReqStatus{
@@ -39,14 +48,102 @@ func (p *process) SendWaitingTransactions(ctx context.Context, minTransactionAge
 	}
 	defer p.sendWaitingLock.Unlock()
 
-	paging := queryopts.Paging{Limit: sendWaitingItemsPerPage, Sort: "asc"}
+	// Report any queue overflow still held back by the throttle. These are the very
+	// transactions this sweep is about to pick up, so cause and effect land together.
+	p.flushBroadcasterOverflow(ctx)
+
 	until := queryopts.Until{
 		Time: time.Now().Add(-minTransactionAge),
 	}
 
+	batchesToBroadcast, collectErr := p.collectWaitingBatches(ctx, log, until)
+	if collectErr != nil {
+		err = collectErr
+		return nil, err
+	}
+
+	if len(batchesToBroadcast) == 0 {
+		log.InfoContext(ctx, "No transactions found to send")
+		return nil, nil
+	}
+
+	log.InfoContext(ctx, "Found transactions to send", "batchesCount", len(batchesToBroadcast))
+
+	results := &wdk.ProcessActionResult{}
+	var batchErrs []error
+	budget := newSweepBudget(ctx)
+	processed := 0
+
+	for batchName, txIDs := range batchesToBroadcast {
+		if !budget.allows(ctx) {
+			// The monitor budgets the whole sweep, not the individual batch. Stopping
+			// here defers the remainder to the next run as one summary line, instead of
+			// letting every remaining batch fail on its first query and emit an error.
+			log.WarnContext(
+				ctx, "send_waiting budget exhausted; deferring remaining batches to the next run",
+				slog.Int("processed", processed),
+				slog.Int("deferred", len(batchesToBroadcast)-processed),
+			)
+			break
+		}
+
+		log.InfoContext(ctx, "Processing batch", "batchName", batchName, "txIDs", txIDs)
+
+		batchStart := time.Now()
+		res, batchErr := p.broadcastDelayedTransaction(ctx, log, txIDs)
+		budget.observe(time.Since(batchStart))
+		processed++
+
+		if batchErr != nil {
+			// Continue-on-error: a single bad batch must not strand the rest. A context
+			// error is not a batch failure - it says the run ran out of budget - so it is
+			// reported as a deferral and kept out of the joined error, which the monitor
+			// turns into a "Task failed".
+			if isContextErr(batchErr) {
+				log.WarnContext(
+					ctx, "Waiting batch deferred to the next run: sweep is out of budget",
+					slog.String("batchName", batchName), slog.Int("txCount", len(txIDs)),
+				)
+				continue
+			}
+			log.ErrorContext(
+				ctx, "Failed to broadcast waiting batch",
+				slog.String("batchName", batchName), slog.Int("txCount", len(txIDs)), "error", batchErr,
+			)
+			batchErrs = append(batchErrs, batchErr)
+			continue
+		}
+		if res != nil {
+			results.SendWithResults = append(results.SendWithResults, res.SendWithResults...)
+			results.NotDelayedResults = append(results.NotDelayedResults, res.NotDelayedResults...)
+		}
+	}
+
+	// TODO: Keep in mind that the transactions above max attempts will be reviewed in another "reviewStatus" periodic task.
+
+	// Return the assembled result together with any hard batch errors (joined). Soft, per-tx
+	// failures (e.g. a service error that leaves a tx still "sending") are reported inside the
+	// result's per-tx entries, not as a returned error.
+	err = errors.Join(batchErrs...)
+	return results, err
+}
+
+// collectWaitingBatches pages through the waiting transactions and groups them the
+// way they were submitted: transactions sharing a batch go out together, and a
+// transaction without one becomes a single-member batch keyed by its own txID.
+//
+// A page that fails after earlier pages succeeded does not sink the whole sweep -
+// broadcasting what was already read makes progress, and the remainder is picked
+// up by the next run.
+func (p *process) collectWaitingBatches(ctx context.Context, log *slog.Logger, until queryopts.Until) (map[string][]string, error) {
+	paging := queryopts.Paging{Limit: sendWaitingItemsPerPage, Sort: "asc"}
 	batchesToBroadcast := make(map[string][]string)
 
 	for range sendWaitingMaxPages {
+		if ctx.Err() != nil {
+			break
+		}
+
 		txIDsPage, pageErr := p.knownTxRepo.FindKnownTxIDsByStatuses(
 			ctx,
 			statusesOfWaitingTxs,
@@ -54,8 +151,14 @@ func (p *process) SendWaitingTransactions(ctx context.Context, minTransactionAge
 			queryopts.WithPage(paging),
 		)
 		if pageErr != nil {
-			err = fmt.Errorf("failed to find known txs by statuses: %w", pageErr)
-			return nil, err
+			if isContextErr(pageErr) || len(batchesToBroadcast) > 0 {
+				log.WarnContext(
+					ctx, "Failed to read a page of waiting transactions; continuing with the pages already read",
+					slog.Int("batchesSoFar", len(batchesToBroadcast)), "error", pageErr,
+				)
+				break
+			}
+			return nil, fmt.Errorf("failed to find known txs by statuses: %w", pageErr)
 		}
 
 		for _, item := range txIDsPage {
@@ -73,39 +176,57 @@ func (p *process) SendWaitingTransactions(ctx context.Context, minTransactionAge
 		paging.Next()
 	}
 
-	if len(batchesToBroadcast) == 0 {
-		log.InfoContext(ctx, "No transactions found to send")
-		return nil, nil
+	return batchesToBroadcast, nil
+}
+
+// sweepBudget decides whether another batch still fits in the run's deadline.
+//
+// The monitor gives the entire sweep one budget, so a batch started too late dies
+// mid-flight - and a batch that dies after ClaimKnownTxsForBroadcast is left
+// marked sending/was_broadcast without ever having been posted. Keeping a reserve
+// shrinks that window.
+type sweepBudget struct {
+	deadline    time.Time
+	hasDeadline bool
+	// avgBatch is an EWMA of observed batch durations. A fixed reserve would be
+	// wrong at both ends: a single-tx batch runs in a fraction of a second, while
+	// a chained batch costs one HTTP post per member, because PostFromBEEF walks
+	// the batch transaction by transaction.
+	avgBatch time.Duration
+}
+
+func newSweepBudget(ctx context.Context) *sweepBudget {
+	deadline, hasDeadline := ctx.Deadline()
+	return &sweepBudget{
+		deadline:    deadline,
+		hasDeadline: hasDeadline,
+		avgBatch:    sweepBatchDurationSeed,
 	}
+}
 
-	log.InfoContext(ctx, "Found transactions to send", "batchesCount", len(batchesToBroadcast))
-
-	results := &wdk.ProcessActionResult{}
-	var batchErrs []error
-	for batchName, txIDs := range batchesToBroadcast {
-		log.InfoContext(ctx, "Processing batch", "batchName", batchName, "txIDs", txIDs)
-
-		res, batchErr := p.broadcastDelayedTransaction(ctx, log, txIDs)
-		if batchErr != nil {
-			// Continue-on-error: a single bad batch must not strand the rest. Record the error and
-			// keep going; the aggregated (joined) error is returned to the caller at the end.
-			log.ErrorContext(ctx, "Failed to broadcast waiting batch", "batchName", batchName, "txIDs", txIDs, "error", batchErr)
-			batchErrs = append(batchErrs, batchErr)
-			continue
-		}
-		if res != nil {
-			results.SendWithResults = append(results.SendWithResults, res.SendWithResults...)
-			results.NotDelayedResults = append(results.NotDelayedResults, res.NotDelayedResults...)
-		}
+// allows reports whether another batch should be started.
+func (b *sweepBudget) allows(ctx context.Context) bool {
+	if ctx.Err() != nil {
+		return false
 	}
+	if !b.hasDeadline {
+		return true
+	}
+	return time.Until(b.deadline) >= b.reserve()
+}
 
-	// TODO: Keep in mind that the transactions above max attempts will be reviewed in another "reviewStatus" periodic task.
+func (b *sweepBudget) reserve() time.Duration {
+	return max(2*b.avgBatch, sweepMinReserve)
+}
 
-	// Return the assembled result together with any hard batch errors (joined). Soft, per-tx
-	// failures (e.g. a service error that leaves a tx still "sending") are reported inside the
-	// result's per-tx entries, not as a returned error.
-	err = errors.Join(batchErrs...)
-	return results, err
+func (b *sweepBudget) observe(batchDuration time.Duration) {
+	b.avgBatch = time.Duration(sweepEWMAWeight*float64(batchDuration) + (1-sweepEWMAWeight)*float64(b.avgBatch))
+}
+
+// isContextErr reports whether err is the run running out of budget (or being
+// cancelled) rather than anything wrong with the work itself.
+func isContextErr(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 // broadcastDelayedTransaction broadcasts a single waiting batch and returns its result and error

--- a/pkg/storage/internal/actions/process_send_waiting.go
+++ b/pkg/storage/internal/actions/process_send_waiting.go
@@ -74,11 +74,15 @@ func (p *process) SendWaitingTransactions(ctx context.Context, minTransactionAge
 	budget := newSweepBudget(ctx)
 	processed := 0
 
-	for batchName, txIDs := range batchesToBroadcast {
+	for _, batch := range batchesToBroadcast {
+		batchName, txIDs := batch.name, batch.txIDs
+
 		if !budget.allows(ctx) {
 			// The monitor budgets the whole sweep, not the individual batch. Stopping
 			// here defers the remainder to the next run as one summary line, instead of
 			// letting every remaining batch fail on its first query and emit an error.
+			// Because the batches are ordered oldest-first, what is deferred is the
+			// newest tail - never a parent whose child has already gone out.
 			log.WarnContext(
 				ctx, "send_waiting budget exhausted; deferring remaining batches to the next run",
 				slog.Int("processed", processed),
@@ -128,16 +132,35 @@ func (p *process) SendWaitingTransactions(ctx context.Context, minTransactionAge
 	return results, err
 }
 
+// waitingBatch is one unit of broadcast work: the transactions of a single submitted
+// batch, or a lone transaction that was submitted without one.
+type waitingBatch struct {
+	name  string
+	txIDs []string
+}
+
 // collectWaitingBatches pages through the waiting transactions and groups them the
 // way they were submitted: transactions sharing a batch go out together, and a
 // transaction without one becomes a single-member batch keyed by its own txID.
 //
+// The result is ordered by creation time, and stays that way through broadcasting:
+// Arcade forwards to Teranode in receive order, so a child spending an unconfirmed
+// parent has to be posted after it. The query returns rows oldest-first, a batch takes
+// the position of its oldest member, and members keep their order within it. A batch
+// spanning a long stretch of time could in principle still straddle a lone transaction
+// that belongs in its middle, but a batch is created by a single processAction call,
+// so its members share a creation instant.
+//
 // A page that fails after earlier pages succeeded does not sink the whole sweep -
 // broadcasting what was already read makes progress, and the remainder is picked
 // up by the next run.
-func (p *process) collectWaitingBatches(ctx context.Context, log *slog.Logger, until queryopts.Until) (map[string][]string, error) {
-	paging := queryopts.Paging{Limit: sendWaitingItemsPerPage, Sort: "asc"}
-	batchesToBroadcast := make(map[string][]string)
+func (p *process) collectWaitingBatches(ctx context.Context, log *slog.Logger, until queryopts.Until) ([]waitingBatch, error) {
+	// Oldest first, with the primary key breaking ties: created_at ties for every member of a
+	// batch, because one processAction call writes them all, and an unstable order under OFFSET
+	// paging can drop a row from one page and repeat it on the next.
+	paging := queryopts.Paging{Limit: sendWaitingItemsPerPage, Sort: "asc", ThenBy: "tx_id"}
+	var batchesToBroadcast []waitingBatch
+	positionOf := make(map[string]int)
 
 	for range sendWaitingMaxPages {
 		if ctx.Err() != nil {
@@ -162,11 +185,18 @@ func (p *process) collectWaitingBatches(ctx context.Context, log *slog.Logger, u
 		}
 
 		for _, item := range txIDsPage {
+			name := item.TxID
 			if item.Batch != nil {
-				batchesToBroadcast[*item.Batch] = append(batchesToBroadcast[*item.Batch], item.TxID)
-			} else {
-				batchesToBroadcast[item.TxID] = []string{item.TxID}
+				name = *item.Batch
 			}
+
+			if position, seen := positionOf[name]; seen {
+				batchesToBroadcast[position].txIDs = append(batchesToBroadcast[position].txIDs, item.TxID)
+				continue
+			}
+
+			positionOf[name] = len(batchesToBroadcast)
+			batchesToBroadcast = append(batchesToBroadcast, waitingBatch{name: name, txIDs: []string{item.TxID}})
 		}
 
 		if len(txIDsPage) < sendWaitingItemsPerPage {

--- a/pkg/storage/internal/actions/process_send_waiting_budget_test.go
+++ b/pkg/storage/internal/actions/process_send_waiting_budget_test.go
@@ -137,8 +137,33 @@ func TestCollectWaitingBatches(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Len(t, batches, 2)
-		assert.ElementsMatch(t, []string{"aa", "bb"}, batches[batch])
-		assert.Equal(t, []string{"cc"}, batches["cc"], "an unbatched tx is keyed by its own txID")
+		assert.Equal(t, batch, batches[0].name)
+		assert.Equal(t, []string{"aa", "bb"}, batches[0].txIDs)
+		assert.Equal(t, waitingBatch{name: "cc", txIDs: []string{"cc"}}, batches[1], "an unbatched tx is keyed by its own txID")
+	})
+
+	// The repo returns rows oldest-first; the sweep has to broadcast them in that order,
+	// so a batch takes the position of its oldest member.
+	t.Run("keeps the order the rows were read in", func(t *testing.T) {
+		late := "late-batch"
+		repo := &swSpyKnownTxRepo{pages: [][]*entity.KnownTxForStatusSync{{
+			waitingTx("oldest", nil),
+			waitingTx("second", &batch),
+			waitingTx("third", nil),
+			waitingTx("fourth", &batch),
+			waitingTx("fifth", &late),
+		}}}
+		p := newSweepProcess(t, repo)
+
+		batches, err := p.collectWaitingBatches(context.Background(), p.logger, queryopts.Until{Time: time.Now()})
+
+		require.NoError(t, err)
+		assert.Equal(t, []waitingBatch{
+			{name: "oldest", txIDs: []string{"oldest"}},
+			{name: batch, txIDs: []string{"second", "fourth"}},
+			{name: "third", txIDs: []string{"third"}},
+			{name: late, txIDs: []string{"fifth"}},
+		}, batches)
 	})
 
 	t.Run("a failing first page is a hard error when nothing was read", func(t *testing.T) {

--- a/pkg/storage/internal/actions/process_send_waiting_budget_test.go
+++ b/pkg/storage/internal/actions/process_send_waiting_budget_test.go
@@ -1,0 +1,236 @@
+package actions
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/entity"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/storage/queryopts"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/logging"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+)
+
+// swSpyKnownTxRepo serves the two calls the sweep makes before it reaches anything
+// heavier: the page query that discovers waiting transactions, and the status
+// lookup that opens broadcastTxs.
+type swSpyKnownTxRepo struct {
+	KnownTxRepo // embed interface; unimplemented methods panic if unexpectedly called
+
+	pages     [][]*entity.KnownTxForStatusSync
+	pageErrs  []error
+	pageCalls int
+
+	statusErr    error
+	statusCalls  int
+	statusesSeen [][]string
+}
+
+func (s *swSpyKnownTxRepo) FindKnownTxIDsByStatuses(_ context.Context, _ []wdk.ProvenTxReqStatus, _ ...queryopts.Options) ([]*entity.KnownTxForStatusSync, error) {
+	i := s.pageCalls
+	s.pageCalls++
+	if i < len(s.pageErrs) && s.pageErrs[i] != nil {
+		return nil, s.pageErrs[i]
+	}
+	if i < len(s.pages) {
+		return s.pages[i], nil
+	}
+	return nil, nil
+}
+
+func (s *swSpyKnownTxRepo) FindKnownTxStatuses(_ context.Context, txIDs ...string) (map[string]wdk.ProvenTxReqStatus, error) {
+	s.statusCalls++
+	s.statusesSeen = append(s.statusesSeen, txIDs)
+	return nil, s.statusErr
+}
+
+func waitingTx(txID string, batch *string) *entity.KnownTxForStatusSync {
+	return &entity.KnownTxForStatusSync{TxID: txID, Status: wdk.ProvenTxStatusUnsent, Batch: batch}
+}
+
+func newSweepProcess(t *testing.T, repo *swSpyKnownTxRepo) *process {
+	t.Helper()
+	return &process{logger: logging.NewTestLogger(t), knownTxRepo: repo}
+}
+
+// TestSendWaitingTransactions_StopsBeforeStartingABatchItCannotFinish reproduces the
+// incident this guard exists for: the monitor budgets the whole run, and a run that
+// starts moments before its own scheduled instant gets a budget of milliseconds. The
+// sweep must then defer everything as one summary rather than let every batch fail on
+// its first query and emit an error line apiece.
+func TestSendWaitingTransactions_StopsBeforeStartingABatchItCannotFinish(t *testing.T) {
+	repo := &swSpyKnownTxRepo{pages: [][]*entity.KnownTxForStatusSync{{
+		waitingTx("aa", nil), waitingTx("bb", nil), waitingTx("cc", nil),
+	}}}
+	p := newSweepProcess(t, repo)
+
+	// Enough budget left to read the page, far too little to start a batch.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	result, err := p.SendWaitingTransactions(ctx, 0)
+
+	// Deferring the remainder is not a failure: reporting it as one makes the monitor
+	// log "Task failed" for an ordinary backlog.
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Zero(t, repo.statusCalls, "no batch may be started once the budget cannot cover one")
+}
+
+// TestSendWaitingTransactions_ContextErrorIsNotAHardFailure covers the batch that does
+// start inside the budget and then dies on it. That is the run running out of time, not
+// a defect in the batch, so it must not reach the joined error.
+func TestSendWaitingTransactions_ContextErrorIsNotAHardFailure(t *testing.T) {
+	for name, ctxErr := range map[string]error{
+		"deadline exceeded": context.DeadlineExceeded,
+		"canceled":          context.Canceled,
+	} {
+		t.Run(name, func(t *testing.T) {
+			repo := &swSpyKnownTxRepo{
+				pages:     [][]*entity.KnownTxForStatusSync{{waitingTx("aa", nil), waitingTx("bb", nil)}},
+				statusErr: ctxErr,
+			}
+			p := newSweepProcess(t, repo)
+
+			// No deadline on the context: the budget guard lets every batch start, so the
+			// context error can only come from the batch itself.
+			_, err := p.SendWaitingTransactions(context.Background(), 0)
+
+			require.NoError(t, err)
+			assert.Equal(t, 2, repo.statusCalls, "a context error in one batch must not stop the others")
+		})
+	}
+}
+
+// TestSendWaitingTransactions_RealBatchErrorStillJoins pins the other half of the
+// contract: filtering context errors must not swallow genuine ones.
+func TestSendWaitingTransactions_RealBatchErrorStillJoins(t *testing.T) {
+	boom := errors.New("boom: the database is on fire")
+	repo := &swSpyKnownTxRepo{
+		pages:     [][]*entity.KnownTxForStatusSync{{waitingTx("aa", nil), waitingTx("bb", nil)}},
+		statusErr: boom,
+	}
+	p := newSweepProcess(t, repo)
+
+	_, err := p.SendWaitingTransactions(context.Background(), 0)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, boom)
+	assert.Equal(t, 2, repo.statusCalls, "a failing batch must not strand the rest")
+}
+
+func TestCollectWaitingBatches(t *testing.T) {
+	batch := "shared-batch"
+
+	t.Run("groups by batch and gives every unbatched tx its own", func(t *testing.T) {
+		repo := &swSpyKnownTxRepo{pages: [][]*entity.KnownTxForStatusSync{{
+			waitingTx("aa", &batch), waitingTx("bb", &batch), waitingTx("cc", nil),
+		}}}
+		p := newSweepProcess(t, repo)
+
+		batches, err := p.collectWaitingBatches(context.Background(), p.logger, queryopts.Until{Time: time.Now()})
+
+		require.NoError(t, err)
+		require.Len(t, batches, 2)
+		assert.ElementsMatch(t, []string{"aa", "bb"}, batches[batch])
+		assert.Equal(t, []string{"cc"}, batches["cc"], "an unbatched tx is keyed by its own txID")
+	})
+
+	t.Run("a failing first page is a hard error when nothing was read", func(t *testing.T) {
+		repo := &swSpyKnownTxRepo{pageErrs: []error{errors.New("boom: query failed")}}
+		p := newSweepProcess(t, repo)
+
+		_, err := p.collectWaitingBatches(context.Background(), p.logger, queryopts.Until{Time: time.Now()})
+
+		require.Error(t, err)
+	})
+
+	t.Run("keeps the pages already read when a later page fails", func(t *testing.T) {
+		full := make([]*entity.KnownTxForStatusSync, 0, sendWaitingItemsPerPage)
+		for i := range sendWaitingItemsPerPage {
+			full = append(full, waitingTx(string(rune('a'+i%26))+strconv.Itoa(i), nil))
+		}
+		repo := &swSpyKnownTxRepo{
+			pages:    [][]*entity.KnownTxForStatusSync{full},
+			pageErrs: []error{nil, errors.New("boom: page two failed")},
+		}
+		p := newSweepProcess(t, repo)
+
+		batches, err := p.collectWaitingBatches(context.Background(), p.logger, queryopts.Until{Time: time.Now()})
+
+		// Broadcasting what was already read still makes progress; the rest waits for
+		// the next run.
+		require.NoError(t, err)
+		assert.Len(t, batches, sendWaitingItemsPerPage)
+	})
+
+	t.Run("stops paging once the context is done", func(t *testing.T) {
+		repo := &swSpyKnownTxRepo{}
+		p := newSweepProcess(t, repo)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		batches, err := p.collectWaitingBatches(ctx, p.logger, queryopts.Until{Time: time.Now()})
+
+		require.NoError(t, err)
+		assert.Empty(t, batches)
+		assert.Zero(t, repo.pageCalls)
+	})
+}
+
+func TestSweepBudget(t *testing.T) {
+	t.Run("allows everything when the context carries no deadline", func(t *testing.T) {
+		b := newSweepBudget(context.Background())
+		assert.True(t, b.allows(context.Background()))
+	})
+
+	t.Run("refuses once the remaining time is below the reserve", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		b := newSweepBudget(ctx)
+		assert.False(t, b.allows(ctx), "a reserve of %s cannot fit in 100ms", b.reserve())
+	})
+
+	t.Run("allows while the deadline is comfortably far away", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		b := newSweepBudget(ctx)
+		assert.True(t, b.allows(ctx))
+	})
+
+	t.Run("refuses a done context even without a deadline", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		b := newSweepBudget(context.Background())
+		assert.False(t, b.allows(ctx))
+	})
+
+	t.Run("reserve never drops below the floor, however fast the batches are", func(t *testing.T) {
+		b := newSweepBudget(context.Background())
+		for range 50 {
+			b.observe(time.Millisecond)
+		}
+		assert.Equal(t, sweepMinReserve, b.reserve())
+	})
+
+	t.Run("reserve grows with slow batches", func(t *testing.T) {
+		b := newSweepBudget(context.Background())
+		for range 50 {
+			b.observe(30 * time.Second)
+		}
+		assert.Greater(t, b.reserve(), sweepMinReserve)
+	})
+}
+
+func TestIsContextErr(t *testing.T) {
+	assert.True(t, isContextErr(context.DeadlineExceeded))
+	assert.True(t, isContextErr(context.Canceled))
+	assert.True(t, isContextErr(errors.Join(errors.New("wrapped"), context.DeadlineExceeded)))
+	assert.False(t, isContextErr(errors.New("boom: something else")))
+	assert.False(t, isContextErr(nil))
+}

--- a/pkg/storage/internal/metrics/metrics.go
+++ b/pkg/storage/internal/metrics/metrics.go
@@ -24,6 +24,7 @@ var (
 	funderClaims         metric.Int64Counter
 	funderNotEnoughFunds metric.Int64Counter
 	contentionRetries    metric.Int64Counter
+	broadcasterOverflow  metric.Int64Counter
 )
 
 func ensureInstruments() {
@@ -37,6 +38,8 @@ func ensureInstruments() {
 			metric.WithDescription("Funding failures surfaced as not-enough-funds"))
 		contentionRetries, _ = meter.Int64Counter("wallet.funder.contention_retries",
 			metric.WithDescription("Funding transaction retries after UTXO contention"))
+		broadcasterOverflow, _ = meter.Int64Counter("wallet.broadcaster.overflow_total",
+			metric.WithDescription("Transactions the delayed-broadcast queue could not accept, deferred to the send_waiting cron"))
 	})
 }
 
@@ -62,6 +65,70 @@ func RecordContentionRetry(ctx context.Context) {
 	if contentionRetries != nil {
 		contentionRetries.Add(ctx, 1)
 	}
+}
+
+// RecordBroadcasterOverflow counts transactions the delayed-broadcast queue was
+// too full to accept. They are not lost: they fall back to the send_waiting
+// cron, which drains far more slowly, so a non-zero rate here is the early
+// signal that the queue is undersized for the offered burst.
+func RecordBroadcasterOverflow(ctx context.Context, count int) {
+	ensureInstruments()
+	if broadcasterOverflow != nil && count > 0 {
+		broadcasterOverflow.Add(ctx, int64(count))
+	}
+}
+
+// QueueStatsFunc reports the current occupancy of the delayed-broadcast queue.
+// It runs once per metrics export interval, never on the broadcast path.
+type QueueStatsFunc func() (depth, capacity int)
+
+type broadcasterQueueGauges struct {
+	depth    metric.Int64ObservableGauge
+	capacity metric.Int64ObservableGauge
+}
+
+// RegisterBroadcasterQueueGauges registers the delayed-broadcast queue gauges
+// backed by stats. It returns an unregister func. With no MeterProvider set the
+// callback never fires.
+//
+// Depth is what predicts an overflow; the overflow counter only reports one
+// after it already happened.
+func RegisterBroadcasterQueueGauges(stats QueueStatsFunc) (func(), error) {
+	meter := otel.Meter(meterName)
+
+	gauges, err := newBroadcasterQueueGauges(meter)
+	if err != nil {
+		return nil, err
+	}
+
+	registration, err := meter.RegisterCallback(func(_ context.Context, observer metric.Observer) error {
+		depth, capacity := stats()
+		observer.ObserveInt64(gauges.depth, int64(depth))
+		observer.ObserveInt64(gauges.capacity, int64(capacity))
+		return nil
+	}, gauges.depth, gauges.capacity)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register broadcaster queue gauge callback: %w", err)
+	}
+
+	return func() { _ = registration.Unregister() }, nil
+}
+
+func newBroadcasterQueueGauges(meter metric.Meter) (broadcasterQueueGauges, error) {
+	var gauges broadcasterQueueGauges
+	var err error
+
+	gauges.depth, err = meter.Int64ObservableGauge("wallet.broadcaster.queue_depth",
+		metric.WithDescription("Transactions currently buffered in the delayed-broadcast queue"))
+	if err != nil {
+		return broadcasterQueueGauges{}, fmt.Errorf("failed to create broadcaster.queue_depth gauge: %w", err)
+	}
+	gauges.capacity, err = meter.Int64ObservableGauge("wallet.broadcaster.queue_capacity",
+		metric.WithDescription("Capacity of the delayed-broadcast queue"))
+	if err != nil {
+		return broadcasterQueueGauges{}, fmt.Errorf("failed to create broadcaster.queue_capacity gauge: %w", err)
+	}
+	return gauges, nil
 }
 
 // PoolRow is one (basket, status) bucket of the not-reserved UTXO inventory.

--- a/pkg/storage/internal/service/background_broadcaster.go
+++ b/pkg/storage/internal/service/background_broadcaster.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/bsv-blockchain/go-sdk/transaction"
 
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/txutils"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/logging"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
 )
@@ -229,6 +229,7 @@ type broadcastItem struct {
 func NewBackgroundBroadcaster(ctx context.Context, parentLogger *slog.Logger, broadcastHandler broadcaster, txBroadcastedChannel chan<- wdk.CurrentTxStatus, sizing Sizing) *BackgroundBroadcaster {
 	bbContext, cancel := context.WithCancel(ctx)
 	logger := logging.Child(parentLogger, "BackgroundBroadcaster")
+	logger.InfoContext(ctx, "BackgroundBroadcaster", "workers", sizing.workers(), "channelSize", sizing.channelSize())
 	return &BackgroundBroadcaster{
 		sizing:               sizing,
 		ctx:                  bbContext,
@@ -265,7 +266,7 @@ func (bb *BackgroundBroadcaster) Stop() {
 
 func (bb *BackgroundBroadcaster) Add(beef *transaction.Beef, txIDs []string) (added bool) {
 	bb.logger.InfoContext(bb.ctx, "Adding new beef to delayed broadcast", "txIDs", txIDs)
-	item := broadcastItem{beef: beef, txIDs: parentsFirst(beef, txIDs)}
+	item := broadcastItem{beef: beef, txIDs: txutils.ParentsFirst(beef, txIDs)}
 	select {
 	case bb.broadcastChannel <- item:
 		// Only an accepted item is remembered: what overflows to the cron fallback is
@@ -379,11 +380,11 @@ func (bb *BackgroundBroadcaster) firstUnpostedParentLocked(item broadcastItem) s
 // beef as a raw, un-mined transaction (transaction.RawTx): a mined parent
 // (RawTxAndBumpIndex) is already in the UTXO set, and a txid-only / absent parent
 // is not something this broadcaster is responsible for. A parent that is itself a
-// subject of the same item is not gate-worthy either — parentsFirst ordered it
+// subject of the same item is not gate-worthy either — ParentsFirst ordered it
 // ahead of its children, so it goes upstream first within the same request.
 // Caller must hold depMu.
 func (bb *BackgroundBroadcaster) firstUnpostedParentOfLocked(beef *transaction.Beef, txID string, subjects map[string]struct{}) string {
-	tx := beefTx(beef, txID)
+	tx := txutils.BeefTx(beef, txID)
 	if tx == nil {
 		return ""
 	}
@@ -405,70 +406,6 @@ func (bb *BackgroundBroadcaster) firstUnpostedParentOfLocked(beef *transaction.B
 		return parentID
 	}
 	return ""
-}
-
-// parentsFirst returns txIDs reordered so that a transaction spending another
-// transaction of the same batch comes after it, preserving the input order
-// otherwise. PostFromBEEF posts a batch in slice order and Arcade forwards
-// upstream in receive order, so an unordered batch could post a child before the
-// parent it shares a request with. The input slice is not modified.
-func parentsFirst(beef *transaction.Beef, txIDs []string) []string {
-	if beef == nil || len(txIDs) < 2 {
-		return append([]string(nil), txIDs...)
-	}
-
-	batch := make(map[string]struct{}, len(txIDs))
-	for _, txID := range txIDs {
-		batch[txID] = struct{}{}
-	}
-
-	ordered := make([]string, 0, len(txIDs))
-	visited := make(map[string]struct{}, len(txIDs))
-
-	var visit func(txID string)
-	visit = func(txID string) {
-		if _, seen := visited[txID]; seen {
-			return
-		}
-		visited[txID] = struct{}{} // marked before recursing, so a cycle cannot loop forever
-		for _, parentID := range batchParents(beef, txID, batch) {
-			visit(parentID)
-		}
-		ordered = append(ordered, txID)
-	}
-	for _, txID := range txIDs {
-		visit(txID)
-	}
-	return ordered
-}
-
-// batchParents returns the txids spent by txID that are also subjects of the same
-// batch.
-func batchParents(beef *transaction.Beef, txID string, batch map[string]struct{}) []string {
-	tx := beefTx(beef, txID)
-	if tx == nil {
-		return nil
-	}
-	var parents []string
-	for _, in := range tx.Inputs {
-		if in.SourceTXID == nil {
-			continue
-		}
-		parentID := in.SourceTXID.String()
-		if _, ok := batch[parentID]; ok {
-			parents = append(parents, parentID)
-		}
-	}
-	return parents
-}
-
-// beefTx looks a subject transaction up in a beef by its hex txid.
-func beefTx(beef *transaction.Beef, txID string) *transaction.Transaction {
-	hash, err := chainhash.NewHashFromHex(txID)
-	if err != nil {
-		return nil
-	}
-	return beef.FindTransactionByHash(hash)
 }
 
 // markPostedAndRelease records the posted txids and re-queues any children that

--- a/pkg/storage/internal/service/background_broadcaster.go
+++ b/pkg/storage/internal/service/background_broadcaster.go
@@ -277,6 +277,16 @@ func (bb *BackgroundBroadcaster) Add(beef *transaction.Beef, txIDs []string) (ad
 	}
 }
 
+// QueueStats reports the delayed-broadcast queue occupancy. It is read by the
+// metrics exporter, so it must stay allocation-free and lock-free: len/cap on a
+// buffered channel are both.
+func (bb *BackgroundBroadcaster) QueueStats() (depth, capacity int) {
+	if bb == nil {
+		return 0, 0
+	}
+	return len(bb.broadcastChannel), cap(bb.broadcastChannel)
+}
+
 func (bb *BackgroundBroadcaster) markEnqueued(txIDs []string) {
 	now := time.Now()
 	bb.depMu.Lock()

--- a/pkg/storage/provider.go
+++ b/pkg/storage/provider.go
@@ -58,6 +58,11 @@ type Provider struct {
 	// unregisterPoolGauges removes the OTel pool gauge callback on Stop;
 	// nil under the privacy strategy.
 	unregisterPoolGauges func()
+
+	// unregisterBroadcasterGauges removes the OTel delayed-broadcast queue gauge
+	// callback on Stop. Unlike the pool gauges this is registered for every
+	// strategy, because the delayed-broadcast queue is always in play.
+	unregisterBroadcasterGauges func()
 }
 
 type providersWrapper struct {
@@ -165,6 +170,7 @@ func NewGORMProvider(chain defs.BSVNetwork, services wdk.Services, opts ...Provi
 				FanoutOutputsPerTx: options.UTXOManagement.Throughput.FanoutOutputsPerTx,
 				TargetTPS:          options.UTXOManagement.Throughput.TargetTPS,
 			},
+			options.BackgroundBroadcaster,
 		),
 		options:          &options,
 		logger:           log,
@@ -172,6 +178,11 @@ func NewGORMProvider(chain defs.BSVNetwork, services wdk.Services, opts ...Provi
 		fuelDenomination: fuelDenomination,
 	}
 	p.defaultChangeBasket.Store(&defaultBasketCfg)
+
+	p.unregisterBroadcasterGauges, err = metrics.RegisterBroadcasterQueueGauges(p.actions.BroadcasterQueueStats)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register broadcaster queue gauges: %w", err)
+	}
 
 	if options.UTXOManagement.Enabled() {
 		p.unregisterPoolGauges, err = metrics.RegisterPoolGauges(metrics.PoolGaugeConfig{
@@ -215,6 +226,10 @@ func (p *Provider) Stop() {
 
 	if p.unregisterPoolGauges != nil {
 		p.unregisterPoolGauges()
+	}
+
+	if p.unregisterBroadcasterGauges != nil {
+		p.unregisterBroadcasterGauges()
 	}
 
 	if err := p.Database.Close(); err != nil {

--- a/pkg/storage/provider_options.go
+++ b/pkg/storage/provider_options.go
@@ -36,6 +36,10 @@ type ProviderConfig struct {
 	ChangeBasket   defs.ChangeBasket
 	UTXOManagement defs.UTXOManagement
 
+	// BackgroundBroadcaster sizes the delayed-broadcast queue. Zero fields keep
+	// the sizing derived from UTXOManagement (or the package defaults).
+	BackgroundBroadcaster defs.BackgroundBroadcaster
+
 	BackgroundBroadcasterContext context.Context
 	BackgroundBroadcasterChannel chan<- wdk.CurrentTxStatus
 }
@@ -169,6 +173,13 @@ func WithUTXOManagement(cfg defs.UTXOManagement) ProviderOption {
 	}
 }
 
+// WithBackgroundBroadcaster sets the delayed-broadcast queue sizing for the provider.
+func WithBackgroundBroadcaster(cfg defs.BackgroundBroadcaster) ProviderOption {
+	return func(o *ProviderConfig) {
+		o.BackgroundBroadcaster = cfg
+	}
+}
+
 func defaultProviderOptions(chaintracker chaintracker.ChainTracker) ProviderConfig {
 	return ProviderConfig{
 		DBConfig:                     defs.DefaultDBConfig(),
@@ -181,6 +192,7 @@ func defaultProviderOptions(chaintracker chaintracker.ChainTracker) ProviderConf
 		Commission:                   defs.DefaultCommission(),
 		ChangeBasket:                 defs.DefaultChangeBasket(),
 		UTXOManagement:               defs.DefaultUTXOManagement(),
+		BackgroundBroadcaster:        defs.DefaultBackgroundBroadcaster(),
 		Logger:                       slog.Default(),
 		BackgroundBroadcasterContext: context.Background(),
 	}

--- a/pkg/storage/provider_send_waiting_test.go
+++ b/pkg/storage/provider_send_waiting_test.go
@@ -291,3 +291,54 @@ func TestSendWaitingTransactions_DelayedBroadcastCountsOnlyActualPost(t *testing
 }
 
 // TODO: Add test case for batches when noSend..noSend..sendWith scenario is implemented
+
+// TestSendWaitingTransactions_BroadcastsInCreationOrder pins the sweep's ordering contract.
+// Arcade forwards to Teranode in the order it receives transactions, so a child spending an
+// unconfirmed parent has to be POSTed after it - and creation order is what puts a parent ahead
+// of its children. The sweep used to iterate a map, so the order it posted in was whatever Go's
+// map randomisation produced on that run.
+func TestSendWaitingTransactions_BroadcastsInCreationOrder(t *testing.T) {
+	// given:
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+	activeStorage := given.Provider().
+		WithRandomizer(randomizer.NewTestRandomizer()).
+		GORM()
+
+	// and: enough independent waiting transactions that hitting their creation order by
+	// chance is not something a passing run can be explained by (10! orderings).
+	const waitingTxs = 10
+	createdOrder := make([]string, 0, waitingTxs)
+	for i := range waitingTxs {
+		_, signedTx := given.Action(activeStorage).
+			WithDelayedBroadcast().
+			WillFailOnBroadcast().
+			WithSatoshisToInternalize(uint64(5000 + 100*i)).
+			WithSatoshisToSend(1).
+			Processed()
+		createdOrder = append(createdOrder, signedTx.TxID().String())
+	}
+
+	// and: all of them are queued as waiting.
+	thenDBState := testabilities.ThenDBState(t, activeStorage)
+	for _, txID := range createdOrder {
+		thenDBState.HasKnownTX(txID).WithStatus(wdk.ProvenTxStatusSending)
+	}
+
+	// and: the re-post will succeed this time.
+	for _, txID := range createdOrder {
+		given.Provider().ARC().WhenQueryingTx(txID).WillReturnTransactionWithoutMerklePath()
+	}
+
+	// and: only what the sweep posts counts - the failed initial sends are already recorded.
+	postsBeforeSweep := len(given.Provider().ARC().PostedTxIDs())
+
+	// when:
+	_, err := activeStorage.SendWaitingTransactions(t.Context(), -time.Minute)
+
+	// then:
+	require.NoError(t, err)
+
+	// and: every waiting transaction reached ARC, oldest first.
+	assert.Equal(t, createdOrder, given.Provider().ARC().PostedTxIDs()[postsBeforeSweep:])
+}

--- a/pkg/wallet/internal/actions/wallet_sign_action.go
+++ b/pkg/wallet/internal/actions/wallet_sign_action.go
@@ -101,14 +101,31 @@ func (s *SignAction) SignAction(ctx context.Context, args wallet.SignActionArgs,
 			logging.Error(err))
 	}
 
-	if result.Tx != nil && s.wdkArgs.Options.ReturnTXIDOnly.Value() {
+	// Past handleProcessAction the transaction has been handed to storage and
+	// broadcast, so swapping the bare txids in the reply for full transactions is
+	// not worth failing the action for - the caller would get an error for a
+	// transaction that is live on the network, and a settlement engine reacting to
+	// that either rebuilds and double-spends its own inputs or writes off an
+	// operation that actually succeeded. Same fallback, for the same reason, as in
+	// CreateAction: log and return the BEEF storage sent, which is a valid reply on
+	// its own (storage completes bare txids it knows when the BEEF comes back as an
+	// input).
+	//
+	// Guarded on the transaction alone, the way CreateAction is: the mapping above
+	// fills Tx in only when the caller did NOT ask for ReturnTXIDOnly, so pairing
+	// that check with ReturnTXIDOnly made the block unreachable and the stubs went
+	// out to the caller unresolved.
+	if result.Tx != nil {
 		tx, verifyErr := party.VerifyReturnedTxIDOnlyAtomicBEEF(ctx, wp.BeefParty, result.Txid, result.Tx)
 		if verifyErr != nil {
-			err = fmt.Errorf("failed to verify returned BEEF from storage: %w", verifyErr)
-			return nil, err
+			s.Logger.WarnContext(ctx,
+				"Could not resolve the txid-only entries in the returned BEEF after broadcast - returning the BEEF storage sent",
+				slog.String("txID", result.Txid.String()),
+				logging.Error(verifyErr),
+			)
+		} else {
+			result.Tx = tx
 		}
-
-		result.Tx = tx
 	}
 
 	return result, nil

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -655,13 +655,26 @@ func (w *Wallet) ListOutputs(ctx context.Context, args sdk.ListOutputsArgs, orig
 		// see BeefParty.PruneIfOversized for why it cannot happen any earlier.
 		defer w.party.BeefParty.PruneIfOversized(ctx)
 
-		var verifiedBeef primitives.BEEF
-		verifiedBeef, err = party.VerifyReturnedTxIDOnlyBeef(ctx, w.party.BeefParty, primitives.BEEF(result.BEEF))
-		if err != nil {
-			return nil, fmt.Errorf("failed to verify returned BEEF from storage: %w", err)
+		// Swapping the bare txids in the reply for full transactions is an
+		// optimisation, not a correctness requirement, so a failure here must not
+		// fail the call - see the same fallback in CreateAction. The wallet
+		// advertised what its shared graph held, and the graph can be dropped out
+		// from under an in-flight reply: the bound has a hard ceiling that fires
+		// even while leases are open (BeefParty.EmergencyResetFactor), which under
+		// sustained concurrency leaves this reply asking for transactions the
+		// graph no longer has. The BEEF storage sent is a valid reply on its own -
+		// storage completes bare txids it knows when the BEEF comes back as an
+		// input - so degrade to it instead of failing a read the caller would only
+		// retry.
+		verifiedBeef, verifyErr := party.VerifyReturnedTxIDOnlyBeef(ctx, w.party.BeefParty, primitives.BEEF(result.BEEF))
+		if verifyErr != nil {
+			w.logger.WarnContext(ctx,
+				"Could not resolve the txid-only entries in the returned BEEF - returning the BEEF storage sent",
+				logging.Error(verifyErr),
+			)
+		} else {
+			result.BEEF = primitives.ExplicitByteArray(verifiedBeef)
 		}
-
-		result.BEEF = primitives.ExplicitByteArray(verifiedBeef)
 	}
 
 	mappedResult, err := mapping.MapListOutputsResult(result)

--- a/pkg/wallet/wallet_list_outputs_test.go
+++ b/pkg/wallet/wallet_list_outputs_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/testutils"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/internal/testabilities"
 )
@@ -318,4 +319,66 @@ func (s *WalletTestSuite) TestWalletListOutputs() {
 		require.NotEmpty(t, resultWithoutLabels.Outputs)
 		assert.Empty(t, resultWithoutLabels.Outputs[0].Labels, "Labels should be empty when IncludeLabels=false")
 	})
+}
+
+// Resolving the txid-only stubs storage sends back is an optimisation, not a
+// correctness requirement: the BEEF storage sent is a valid reply on its own.
+// So a stub the wallet cannot resolve must degrade to that reply, the way
+// CreateAction already does, instead of failing a read the caller would only
+// retry.
+//
+// This is the shape the wallet ends up in when the shared graph is dropped out
+// from under an in-flight call - the bound has a hard ceiling that fires even
+// while leases are open (wdk.EmergencyResetFactor), which under sustained
+// concurrency leaves a reply asking for transactions the graph no longer has.
+func (s *WalletTestSuite) TestListOutputsFallsBackWhenAStubCannotBeResolved() {
+	t := s.T()
+
+	// given:
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+
+	// and:
+	aliceWallet := given.AliceWalletWithStorage(s.StorageType)
+
+	// and:
+	internalizeArgs := fixtures.DefaultWalletInternalizeActionArgsMatchingBRC29(t, sdk.InternalizeProtocolWalletPayment, testusers.Alice.KeyDeriver(t))
+	_, err := aliceWallet.InternalizeAction(t.Context(), internalizeArgs, fixtures.DefaultOriginator)
+	require.NoError(t, err, "Failed to internalize action for test setup")
+
+	// and:
+	_, subject, err := transaction.NewBeefFromAtomicBytes(internalizeArgs.Tx)
+	require.NoError(t, err)
+
+	// and: the party holds that transaction as a bare txid under a proof, which
+	// is what the known-txid list is built from but not what resolving a reply
+	// accepts - so the wallet advertises a transaction it cannot produce.
+	stranded := transaction.NewBeef()
+	stranded.MergeTxidOnly(subject)
+	proof := testutils.MockValidMerklePath(t, subject.String(), 800_000)
+	stranded.MergeBump(&proof)
+	strandedBytes, err := stranded.Bytes()
+	require.NoError(t, err)
+	require.NoError(t, aliceWallet.GetBeefParty().MergeBeefFromParty(t.Context(), storagePartyID, strandedBytes))
+
+	// and:
+	args := fixtures.DefaultWalletListOutputsArgs()
+	args.Include = sdk.OutputIncludeEntireTransactions
+
+	// when:
+	result, err := aliceWallet.ListOutputs(t.Context(), args, fixtures.DefaultOriginator)
+
+	// then:
+	require.NoError(t, err, "an unresolvable stub must not fail the call")
+	require.NotNil(t, result)
+	assert.NotEmpty(t, result.Outputs, shouldHaveAtLeastOneOutputMsg)
+	require.NotEmpty(t, result.BEEF, "the BEEF storage sent must still be returned")
+
+	// and: what comes back is storage's own reply, stub and all
+	beef, err := transaction.NewBeefFromBytes(result.BEEF)
+	require.NoError(t, err)
+	btx, ok := beef.Transactions[*subject]
+	require.Truef(t, ok, "returned BEEF is missing tx %s", subject)
+	assert.Equal(t, transaction.TxIDOnly, btx.DataFormat,
+		"storage answered with a stub, so that is what the fallback returns")
 }

--- a/pkg/wallet/wallet_sign_action_test.go
+++ b/pkg/wallet/wallet_sign_action_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/transaction"
 	sdk "github.com/bsv-blockchain/go-sdk/wallet"
 	"github.com/go-softwarelab/common/pkg/seq"
 	"github.com/go-softwarelab/common/pkg/to"
@@ -15,6 +16,7 @@ import (
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/walletargs"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/asserttx"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/testabilities/testutils"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet"
 	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wallet/internal/testabilities"
 )
@@ -602,4 +604,71 @@ func (s *WalletTestSuite) TestWalletSignAction_SigningNotExistingAction() {
 		require.Error(t, err)
 		require.Nil(t, signActionResult)
 	})
+}
+
+// By the time SignAction resolves the txid-only stubs in its reply the
+// transaction has already been broadcast, so a stub the wallet cannot resolve
+// must degrade to the BEEF storage sent rather than fail the action - a caller
+// that gets an error for a live transaction either rebuilds and double-spends
+// its own inputs or writes off an operation that succeeded.
+//
+// Same fallback, and same reasoning, as TestCreateActionResolvesKnownTxidStubs'
+// counterpart in CreateAction.
+func (s *WalletTestSuite) TestSignActionFallsBackWhenAStubCannotBeResolved() {
+	t := s.T()
+
+	const topUpValue = testValueForFunding
+	const inputValue = 100
+
+	// given:
+	given, cleanup := testabilities.Given(t)
+	defer cleanup()
+
+	// and:
+	input := given.InputForUser(testusers.Alice).WithSatoshis(inputValue).WithNoUnlockingScript()
+
+	// and:
+	aliceWallet := given.AliceWalletWithStorage(s.StorageType)
+
+	// and:
+	txFromFaucet, _ := given.Faucet(aliceWallet).TopUp(topUpValue)
+
+	// and:
+	given.Services().BHS().OnMerkleRootVerifyResponse(input.BlockHeight(), input.MerklePath().Hex(), "CONFIRMED")
+
+	// and: the party holds the funding transaction as a bare txid under a proof,
+	// which is what the known-txid list is built from but not what resolving a
+	// reply accepts - so the wallet advertises a transaction it cannot produce.
+	funding := txFromFaucet.ID()
+	stranded := transaction.NewBeef()
+	stranded.MergeTxidOnly(funding)
+	proof := testutils.MockValidMerklePath(t, funding.String(), 800_000)
+	stranded.MergeBump(&proof)
+	strandedBytes, err := stranded.Bytes()
+	require.NoError(t, err)
+	require.NoError(t, aliceWallet.GetBeefParty().MergeBeefFromParty(t.Context(), storagePartyID, strandedBytes))
+
+	// and:
+	args := fixtures.DefaultWalletCreateActionArgs(
+		t,
+		walletargs.WithInput(input),
+		walletargs.WithSignAndProcess(false),
+	)
+
+	createActionResult, err := aliceWallet.CreateAction(t.Context(), args, fixtures.DefaultOriginator)
+	require.NoError(t, err)
+
+	// when:
+	signActionResult, err := aliceWallet.SignAction(t.Context(), sdk.SignActionArgs{
+		Reference: createActionResult.SignableTransaction.Reference,
+		Spends: map[uint32]sdk.SignActionSpend{
+			0: {UnlockingScript: input.UnlockingScript().Bytes()},
+		},
+	}, fixtures.DefaultOriginator)
+
+	// then: the action completes on the BEEF it already had, for a transaction
+	// that is by now on the network
+	require.NoError(t, err, "an unresolvable stub must not fail an already broadcast action")
+	require.NotNil(t, signActionResult)
+	require.NotEmpty(t, signActionResult.Tx, "the caller asked for the transaction, so it must still be returned")
 }


### PR DESCRIPTION
## What Changed

- **Delayed-broadcast queue is now sizeable by the operator.** New `defs.BackgroundBroadcaster` (`workers`, `channel_size`), wired through `infra` config as a `background_broadcaster:` block and through the provider as `storage.WithBackgroundBroadcaster`. Resolution is per field: an explicit value wins over the sizing derived from the throughput strategy, and a zero falls through to the package defaults — so a deployment not on the throughput strategy can still widen just the queue. Validation caps it at 1024 workers / 100k queue items.
- **Queue observability.** `wallet.broadcaster.overflow_total` counter plus depth/capacity observable gauges, and a windowed overflow warning that the `send_waiting` sweep flushes, so the tail of a one-off burst is never silently dropped.
- **Monitor task deadline derived from the configured interval** instead of `gocron.Job.NextRun()`. `ActiveTask` now carries `Interval`, and `contextWithTimeout` budgets from it.
- **`send_waiting` sweep now runs to a budget.** An EWMA of observed batch durations decides whether another batch fits before the deadline; the remainder is deferred to the next run as one summary line. Page-read failures after earlier pages succeeded no longer sink the whole sweep, and context errors are reported as deferrals rather than joined into the returned error.
- **Parents-first ordering applied everywhere a batch is posted.** `parentsFirst` promoted out of the broadcaster into `txutils.ParentsFirst` and applied to `broadcastTxs` as well; new `retainClaimed` keeps the caller's ordering instead of adopting whatever order the claim query returned; sweep batches are collected oldest-first with a `Paging.ThenBy` tie-break so OFFSET paging is stable.
- **BEEF-party resolution failures now degrade instead of failing the call.** `listOutputs` and `signAction` fall back to the BEEF storage sent, the way `createAction` already did. The `signAction` guard was also corrected — it paired `result.Tx != nil` with `ReturnTXIDOnly`, which the result mapping makes mutually exclusive, so the block had never executed.

## Why It Was Necessary

- The queue size was hard-wired to the throughput strategy's derivation. A deployment running bursty traffic outside that strategy had no way to widen it, and everything that overflowed fell through to the `send_waiting` cron, which drains far more slowly. Overflow was also invisible: nothing counted it, so an undersized queue looked like unexplained latency.
- `NextRun()` is not a reliable budget source. gocron can start a run a few milliseconds *before* its scheduled instant and still report that same instant as the next run — subtracting it from `now` yielded single-digit milliseconds instead of the interval. Every batch in the run then failed instantly on an already-expired context: observed in production as hundreds of identical errors from a sweep that lasted 34ms in total.
- Without a budget, a sweep that overran its slot died mid-batch, and a batch killed after `ClaimKnownTxsForBroadcast` is left marked `sending`/`was_broadcast` without ever having been posted.
- Arcade forwards to Teranode in receive order, so a child posted before the unconfirmed parent it spends is rejected. `broadcastTxs` was posting in whatever order the claim query happened to return — typically by txid hex, which says nothing about dependency order.
- Under the load of the 1000-trade test the client reported ~24 `tx with only txid not found in beef party` errors, all on `listOutputs`. The shared BEEF graph has a hard ceiling that resets it even while leases are open, which leaves an in-flight reply asking for transactions the graph no longer holds. Resolving those stubs is a wire optimisation, not a correctness requirement — storage's own BEEF is a valid reply, and storage completes bare txids it knows when that BEEF comes back as an input. `createAction` already degraded this way; the other two did not.

## Testing Performed

- `go test ./pkg/wallet/... ./pkg/storage/...` — green, including both the SQLite and remote-storage variants of `WalletTestSuite`.
- New unit coverage: `pkg/defs/background_broadcaster_test.go` (validation bounds), `pkg/monitor/task_budget_test.go`, `pkg/storage/internal/actions/broadcaster_overflow_test.go`, `broadcaster_sizing_test.go`, `process_send_waiting_budget_test.go`, `pkg/internal/txutils/parents_first_test.go`, `pkg/storage/provider_send_waiting_test.go`.
- New regression tests for the fallback: `TestListOutputsFallsBackWhenAStubCannotBeResolved` and `TestSignActionFallsBackWhenAStubCannotBeResolved`. Both seed the beef party with a bare txid under a merkle proof, which is what the known-txid list is built from but not what resolving a reply accepts — reproducing the client's failure without racing threads.
- Both fallback tests were verified to discriminate, not just pass: the `listOutputs` one fails on the unpatched code with `an unresolvable stub must not fail the call`, and the `signAction` one fails against a guard-fixed-but-fallback-less build with `an unresolvable stub must not fail an already broadcast action`.
- Confirmed the `signAction` fallback actually fires rather than passing vacuously — the run logs `Could not resolve the txid-only entries in the returned BEEF after broadcast`.

## Impact / Risk

- **Config is backwards compatible.** Both new fields default to zero, which means "not configured" and preserves the sizing every existing deployment gets today.
- **The fallbacks trade strictness for availability.** A wallet that cannot resolve a stub now returns storage's BEEF and logs a warning instead of erroring. Watch for `Could not resolve the txid-only entries in the returned BEEF` in production — a sustained rate means the graph is being reset under load and the knownTxids optimisation is not paying off, which is worth investigating separately even though it no longer breaks callers.
- **Ordering changes affect every delayed broadcast**, not just batched ones. `retainClaimed` is a no-op when the claim accepted everything (the common case), and `ParentsFirst` is stable, so creation order survives wherever there is no dependency to respect.
- **`Paging.ThenBy` touches shared paging code** used beyond the sweep. It is opt-in — an empty `ThenBy` leaves the ordering exactly as before.