### PR TITLE
fix(beef): let callers stop shipping ancestry storage already holds

### DIFF
--- a/pkg/internal/assembler/create_action_source_tx_test.go
+++ b/pkg/internal/assembler/create_action_source_tx_test.go
@@ -1,0 +1,151 @@
+package assembler_test
+
+import (
+	"testing"
+
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/script"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	sdk "github.com/bsv-blockchain/go-sdk/wallet"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/assembler"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/internal/fixtures/testusers"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk"
+	"github.com/bsv-blockchain/go-wallet-toolbox/pkg/wdk/primitives"
+)
+
+// A caller-provided input needs its parent transaction to assemble, and until
+// now the only place the assembler looked was the inputBeef echoed back in the
+// storage response. That made the persisted blob load-bearing for assembly: a
+// caller could not trim the ancestry it ships even when storage already held
+// every parent, because assembly would then fail with
+// "every signable transaction input must have a source transaction".
+//
+// Storage populates StorageCreateTransactionSdkInput.SourceTransaction for
+// exactly these inputs, so the assembler can fall back to it.
+
+// givenParentTransaction returns a spendable parent and its serialised bytes.
+func givenParentTransaction(t *testing.T) (*transaction.Transaction, []byte) {
+	t.Helper()
+
+	lockingScript, err := script.NewFromHex("76a914aabbccddeeff00112233445566778899aabbccdd88ac")
+	require.NoError(t, err)
+
+	parent := transaction.NewTransaction()
+	prev, err := chainhash.NewHashFromHex(
+		"0000000000000000000000000000000000000000000000000000000000000001")
+	require.NoError(t, err)
+	parent.AddInput(&transaction.TransactionInput{
+		SourceTXID:       prev,
+		SourceTxOutIndex: 0,
+		SequenceNumber:   transaction.DefaultSequenceNumber,
+	})
+	parent.AddOutput(&transaction.TransactionOutput{Satoshis: 1000, LockingScript: lockingScript})
+
+	return parent, parent.Bytes()
+}
+
+// givenResultWithProvidedInput builds the storage response for a single
+// caller-provided input, with whatever inputBeef the caller is meant to have
+// shipped back.
+func givenResultWithProvidedInput(
+	t *testing.T,
+	parent *transaction.Transaction,
+	parentRaw []byte,
+	inputBeef []byte,
+	attachSourceTx bool,
+) (*wdk.StorageCreateActionResult, []sdk.CreateActionInput) {
+	t.Helper()
+
+	txid := parent.TxID()
+	unlockingLen := new(primitives.PositiveInteger)
+	*unlockingLen = 108
+
+	in := &wdk.StorageCreateTransactionSdkInput{
+		Vin:                   0,
+		SourceTxID:            txid.String(),
+		SourceVout:            0,
+		SourceSatoshis:        1000,
+		SourceLockingScript:   parent.Outputs[0].LockingScript.String(),
+		UnlockingScriptLength: unlockingLen,
+		ProvidedBy:            wdk.ProvidedByYou,
+		Type:                  wdk.OutputTypeCustom,
+	}
+	if attachSourceTx {
+		in.SourceTransaction = parentRaw
+	}
+
+	result := &wdk.StorageCreateActionResult{
+		InputBeef: inputBeef,
+		Inputs:    []*wdk.StorageCreateTransactionSdkInput{in},
+		Version:   1,
+		Reference: "ref",
+	}
+
+	provided := []sdk.CreateActionInput{{
+		Outpoint:              transaction.Outpoint{Txid: *txid, Index: 0},
+		InputDescription:      "provided input",
+		UnlockingScriptLength: 108,
+	}}
+
+	return result, provided
+}
+
+func TestAssemblerFallsBackToStorageSourceTransaction(t *testing.T) {
+	keyDeriver := givenKeyDeriver(t, testusers.Alice)
+	parent, parentRaw := givenParentTransaction(t)
+
+	t.Run("assembles with an empty inputBeef when storage supplied the parent", func(t *testing.T) {
+		// given: the caller shipped no ancestry at all
+		result, provided := givenResultWithProvidedInput(t, parent, parentRaw, nil, true)
+
+		// when:
+		assembled, err := assembler.NewCreateActionTransactionAssembler(keyDeriver, provided, result).Assemble()
+
+		// then:
+		require.NoError(t, err)
+		require.Len(t, assembled.Inputs, 1)
+		require.NotNil(t, assembled.Inputs[0].SourceTransaction,
+			"the input must carry a source transaction or the atomic BEEF cannot be built")
+		require.Equal(t, parent.TxID().String(), assembled.Inputs[0].SourceTransaction.TxID().String())
+	})
+
+	t.Run("the assembled transaction can still produce an atomic BEEF", func(t *testing.T) {
+		// This is the check that actually mattered: ToAtomicBEEF rejects any
+		// signable input whose source transaction is nil.
+		result, provided := givenResultWithProvidedInput(t, parent, parentRaw, nil, true)
+
+		assembled, err := assembler.NewCreateActionTransactionAssembler(keyDeriver, provided, result).Assemble()
+		require.NoError(t, err)
+
+		beef, err := assembled.ToAtomicBEEF(false)
+		require.NoError(t, err)
+		require.NotEmpty(t, beef)
+	})
+
+	t.Run("prefers the inputBeef when it carries the parent", func(t *testing.T) {
+		// Existing behaviour must be unchanged where the BEEF has the parent:
+		// the fallback engages only where assembly would previously have failed.
+		beef := transaction.NewBeefV2()
+		_, err := beef.MergeRawTx(parentRaw, nil)
+		require.NoError(t, err)
+		beefBytes, err := beef.Bytes()
+		require.NoError(t, err)
+
+		result, provided := givenResultWithProvidedInput(t, parent, parentRaw, beefBytes, false)
+
+		assembled, err := assembler.NewCreateActionTransactionAssembler(keyDeriver, provided, result).Assemble()
+		require.NoError(t, err)
+		require.Equal(t, parent.TxID().String(), assembled.Inputs[0].SourceTransaction.TxID().String())
+	})
+
+	t.Run("names the outpoint when neither route has the parent", func(t *testing.T) {
+		result, provided := givenResultWithProvidedInput(t, parent, parentRaw, nil, false)
+
+		_, err := assembler.NewCreateActionTransactionAssembler(keyDeriver, provided, result).Assemble()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no source transaction for input")
+		require.Contains(t, err.Error(), parent.TxID().String())
+	})
+}

--- a/pkg/internal/assembler/create_action_tx_assembler.go
+++ b/pkg/internal/assembler/create_action_tx_assembler.go
@@ -227,6 +227,9 @@ func (a *CreateActionTransactionAssembler) sourceTransactionFor(it *wdk.StorageC
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse source transaction for input (outpoint: %s.%d): %w", it.SourceTxID, it.SourceVout, err)
 	}
+	if got := sourceTx.TxID().String(); got != it.SourceTxID {
+		return nil, fmt.Errorf("source transaction txid mismatch for input (outpoint: %s.%d): expected %s got %s", it.SourceTxID, it.SourceVout, it.SourceTxID, got)
+	}
 
 	return sourceTx, nil
 }

--- a/pkg/internal/assembler/create_action_tx_assembler.go
+++ b/pkg/internal/assembler/create_action_tx_assembler.go
@@ -176,7 +176,10 @@ func (a *CreateActionTransactionAssembler) toTxInputFromArgs(it *wdk.StorageCrea
 		return nil, fmt.Errorf("unexpected input (outpoint: %s) not found in provided inputs", key)
 	}
 
-	sourceTx := a.inputBEEF.FindTransaction(it.SourceTxID)
+	sourceTx, err := a.sourceTransactionFor(it)
+	if err != nil {
+		return nil, err
+	}
 
 	return &transaction.TransactionInput{
 		SourceTXID:        sourceTxID,
@@ -187,6 +190,47 @@ func (a *CreateActionTransactionAssembler) toTxInputFromArgs(it *wdk.StorageCrea
 	}, nil
 }
 
+// sourceTransactionFor resolves the parent transaction of a caller-provided
+// input, preferring the inputBEEF and falling back to the raw bytes storage
+// already attached to the input itself.
+//
+// The fallback is what lets a caller stop shipping ancestry it does not need to
+// ship. Every signable input must carry a SourceTransaction — assembling an
+// atomic BEEF fails outright without one — and until now the only place the
+// assembler looked was the inputBEEF echoed back in the storage response. That
+// made the response BEEF load-bearing for assembly, so a caller could not pass a
+// trimmed (or absent) inputBEEF even when storage already held every parent it
+// needed: the persisted blob had to stay large purely so this lookup would
+// succeed.
+//
+// Storage populates StorageCreateTransactionSdkInput.SourceTransaction for
+// exactly these inputs when IncludeInputSourceRawTxs is set, reading raw_tx
+// straight off the known-tx row (see create.go, inputToStorageInput). Preferring
+// the BEEF keeps existing behaviour byte-for-byte; the fallback only engages
+// where assembly would previously have failed.
+func (a *CreateActionTransactionAssembler) sourceTransactionFor(it *wdk.StorageCreateTransactionSdkInput) (*transaction.Transaction, error) {
+	if sourceTx := a.inputBEEF.FindTransaction(it.SourceTxID); sourceTx != nil {
+		return sourceTx, nil
+	}
+
+	if len(it.SourceTransaction) == 0 {
+		// Neither route has it. Returning nil here would surface later as the
+		// opaque "every signable transaction input must have a source
+		// transaction"; name the outpoint instead.
+		return nil, fmt.Errorf(
+			"no source transaction for input (outpoint: %s.%d): absent from inputBeef and not supplied by storage",
+			it.SourceTxID, it.SourceVout,
+		)
+	}
+
+	sourceTx, err := transaction.NewTransactionFromBytes(it.SourceTransaction)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse source transaction for input (outpoint: %s.%d): %w", it.SourceTxID, it.SourceVout, err)
+	}
+
+	return sourceTx, nil
+}
+
 func (a *CreateActionTransactionAssembler) isInputFromArgs(it *wdk.StorageCreateTransactionSdkInput) bool {
 	key := fmt.Sprintf("%s.%d", it.SourceTxID, it.SourceVout)
 	_, ok := a.providedInputsByOutpoint[key]
@@ -194,6 +238,15 @@ func (a *CreateActionTransactionAssembler) isInputFromArgs(it *wdk.StorageCreate
 }
 
 func (a *CreateActionTransactionAssembler) parseInputBEEF() error {
+	// An absent inputBeef is legitimate now that a caller may decline to ship
+	// ancestry it does not need to: sourceTransactionFor falls back to the raw
+	// bytes storage attaches to each input. Start from an empty BEEF so lookups
+	// miss cleanly instead of failing the whole assembly here.
+	if len(a.createActionResult.InputBeef) == 0 {
+		a.inputBEEF = transaction.NewBeefV2()
+		return nil
+	}
+
 	inputBEEF, err := transaction.NewBeefFromBytes(a.createActionResult.InputBeef)
 	if err != nil {
 		return fmt.Errorf("cannot parse inputBeef: %w", err)

--- a/pkg/storage/internal/actions/create_process_inputs.go
+++ b/pkg/storage/internal/actions/create_process_inputs.go
@@ -329,10 +329,23 @@ func (proc *inputsProcessor) hydrateUnanchoredAncestry() error {
 			slog.Int("txIDsToHydrate", len(needed)),
 		)
 
+		// WithDirectSourcesOnly bounds what comes back to the direct parents,
+		// rather than the whole ancestor graph behind them.
+		//
+		// The validator needs each unproven raw transaction's own sources, which
+		// is one generation, and the loop above re-checks and fetches again if a
+		// further generation turns out to be needed. Pulling the full graph here
+		// instead merges every ancestor's stored input_beef blob (see
+		// recursiveBuildValidBEEF), which on a chain that is not confirming means
+		// re-merging the entire unmined history of the wallet — and then
+		// persisting it, so the next transaction inherits a larger blob again.
+		// The broadcast path already asks for direct sources only for the same
+		// reason; this makes createAction consistent with it.
 		if _, err = proc.parent.knownTxRepo.GetBEEFForTxIDs(
 			proc.ctx,
 			seq.FromSlice(needed),
 			entity.WithMergeToBEEF(proc.beef),
+			entity.WithDirectSourcesOnly(),
 			entity.WithStatusesToFilterOut(wdk.ProvenTxReqProblematicStatuses...),
 		); err != nil {
 			return fmt.Errorf("failed to merge storage ancestry for %s: %w", strings.Join(needed, ", "), err)


### PR DESCRIPTION
## The problem

`createAction` persists the caller's `inputBEEF` verbatim onto `bsv_known_txes.input_beef`. A caller spending its own outputs therefore stores a copy of ancestry storage is already holding — and BEEF prunes only back to a *mined* ancestor, so on a chain that is not confirming it never prunes and the blob grows without bound.

Measured on a 2,000-trade load run against teratestnet (which produced 7 blocks in 65 minutes, leaving 2,948 unmined transactions against 1 completed):

| | |
|---|---:|
| mean `input_beef`, start → end of one run | 1,892 B → **1,038,633 B** (549×) |
| `raw_tx` on those same rows | 349 B |
| `bsv_known_txes` | **10 GB** from 10,013 rows |
| throughput decay over the run | 8.03 → 0.27 trades/s |

Mints were unaffected throughout (~200 ms, 6-byte BEEF) because they are the one operation with no provided inputs. Transfers and burns degraded ~15×.

## Why a caller could not simply stop supplying it

**1. The assembler had one place to look.** `toTxInputFromArgs` resolved each provided input's `SourceTransaction` only from the `inputBeef` echoed back in the storage response, and `ToAtomicBEEF` fails outright on a nil source transaction. So the persisted blob had to stay large purely so that lookup would succeed — even though storage already attaches the parent's raw bytes to the input itself (`StorageCreateTransactionSdkInput.SourceTransaction`, read from `raw_tx` when `IncludeInputSourceRawTxs` is set). It now falls back to those bytes.

**2. Hydration pulled the whole graph back in.** `hydrateUnanchoredAncestry` called `GetBEEFForTxIDs` without `WithDirectSourcesOnly`, so it merged every ancestor's stored `input_beef` via `recursiveBuildValidBEEF` — and the result is then persisted, handing the next transaction a larger blob again. The validator needs one generation, and the loop already re-checks and fetches again if a further one turns out to be required. `broadcastTxs` already asks for direct sources only; this makes `createAction` consistent with it.

An absent `inputBeef` also becomes legitimate rather than a parse error, which is what lets a caller decline to ship ancestry at all.

## Compatibility

The `inputBeef` is still **preferred**, so behaviour is unchanged wherever it carries the parent; the fallback engages only where assembly would previously have failed. Where neither route has the parent, the error now names the outpoint instead of surfacing later as the opaque "every signable transaction input must have a source transaction".

## Result

With both changes, a caller passing `InputBEEF: nil` for inputs storage already knows stores txid stubs instead — 72 bytes for a two-input transfer, 39 for a one-input burn — flat against wallet history rather than growing with it.

Re-running the same 2,000 trades, same workload, same 10,013 transactions:

| | before | after |
|---|---:|---:|
| mean `input_beef` | 1,038,633 B | **34 B** |
| `bsv_known_txes` | 10 GB | **7,408 kB** |
| schema total | 10 GB | **45 MB** |
| wall clock | 59m 53s | **14m 09s** |
| trades/s | 0.56 | **2.35** |
| failures | 0 | 0 |

The mean stayed flat for the whole run (4,096 → 17 → 6 → 5 bytes) rather than rising.

One trade worth noting: index scans against `bsv_known_txes` went **up**, 316,105 → 28,752,603. Each now returns a single row with no TOAST to detoast, where before a handful of multi-megabyte reads dominated — a clear net win here, but it is a trade rather than free.

## Tests

Four new cases in `create_action_source_tx_test.go` covering: assembly with an empty `inputBeef`, that the result still produces an atomic BEEF, that the `inputBeef` is preferred when present, and the named-outpoint error. All four verified to fail without the change (`cannot parse inputBeef: EOF`). Full `./pkg/...` suite passes with zero failures.
