### PR TITLE
perf(beef): Read ancestry one generation per query, and index the join tables

### DIFF
--- a/pkg/internal/storage/database/models/output_tags.go
+++ b/pkg/internal/storage/database/models/output_tags.go
@@ -18,14 +18,13 @@ type OutputTag struct {
 	//
 	// The primary key cannot answer that - its leading column is output_id - so
 	// without this the lookup falls back to scanning the whole join table, and
-	// the table gains a row per tag per output forever. Measured on a wallet
-	// after 2,000 trades: 19,571 sequential scans reading 92,989,035 tuples from
-	// 8,000 rows, the single largest source of tuple reads in the schema.
+	// that table gains a row per tag per output for the life of the wallet.
 	//
-	// Column order follows the predicate: equality columns first, then output_id
-	// so the subquery is answered from the index alone. Partial on deleted_at
-	// because the soft delete appends `deleted_at IS NULL` to every read.
-	OutputID  uint   `gorm:"primary_key;index:idx_output_tags_name_user,priority:3,where:deleted_at IS NULL"`
-	TagName   string `gorm:"primary_key;index:idx_output_tags_name_user,priority:1,where:deleted_at IS NULL"`
-	TagUserID int    `gorm:"primary_key;index:idx_output_tags_name_user,priority:2,where:deleted_at IS NULL"`
+	// Column order follows the predicate: the equality columns first, then
+	// output_id so the subquery is answered from the index alone. Partial on
+	// deleted_at because the soft delete appends `deleted_at IS NULL` to every
+	// read.
+	OutputID  uint   `gorm:"primaryKey;index:idx_output_tags_name_user,priority:3,where:deleted_at IS NULL"`
+	TagName   string `gorm:"primaryKey;index:idx_output_tags_name_user,priority:1,where:deleted_at IS NULL"`
+	TagUserID int    `gorm:"primaryKey;index:idx_output_tags_name_user,priority:2,where:deleted_at IS NULL"`
 }

--- a/pkg/internal/storage/database/models/output_tags.go
+++ b/pkg/internal/storage/database/models/output_tags.go
@@ -11,7 +11,21 @@ type OutputTag struct {
 	UpdatedAt time.Time
 	DeletedAt gorm.DeletedAt `gorm:"index"`
 
-	OutputID  uint   `gorm:"primary_key"`
-	TagName   string `gorm:"primary_key"`
-	TagUserID int    `gorm:"primary_key"`
+	// idx_output_tags_name_user serves the tag filter, which selects output_id
+	// by tag name:
+	//
+	//	WHERE tag_name IN (...) AND tag_user_id = ?
+	//
+	// The primary key cannot answer that - its leading column is output_id - so
+	// without this the lookup falls back to scanning the whole join table, and
+	// the table gains a row per tag per output forever. Measured on a wallet
+	// after 2,000 trades: 19,571 sequential scans reading 92,989,035 tuples from
+	// 8,000 rows, the single largest source of tuple reads in the schema.
+	//
+	// Column order follows the predicate: equality columns first, then output_id
+	// so the subquery is answered from the index alone. Partial on deleted_at
+	// because the soft delete appends `deleted_at IS NULL` to every read.
+	OutputID  uint   `gorm:"primary_key;index:idx_output_tags_name_user,priority:3,where:deleted_at IS NULL"`
+	TagName   string `gorm:"primary_key;index:idx_output_tags_name_user,priority:1,where:deleted_at IS NULL"`
+	TagUserID int    `gorm:"primary_key;index:idx_output_tags_name_user,priority:2,where:deleted_at IS NULL"`
 }

--- a/pkg/internal/storage/database/models/tx_labels.go
+++ b/pkg/internal/storage/database/models/tx_labels.go
@@ -12,11 +12,10 @@ type TransactionLabel struct {
 	DeletedAt gorm.DeletedAt `gorm:"index"`
 
 	// idx_transaction_labels_name_user is the label-side twin of
-	// idx_output_tags_name_user: the label filter selects transaction_id by label
-	// name, which the primary key cannot serve because it leads with
-	// transaction_id. Measured on the same wallet: 28,982 sequential scans, and
-	// 154 tuples fetched per index scan where a selective lookup returns ~1.
-	TransactionID uint   `gorm:"primary_key;index:idx_transaction_labels_name_user,priority:3,where:deleted_at IS NULL"`
-	LabelName     string `gorm:"primary_key;index:idx_transaction_labels_name_user,priority:1,where:deleted_at IS NULL"`
-	LabelUserID   int    `gorm:"primary_key;index:idx_transaction_labels_name_user,priority:2,where:deleted_at IS NULL"`
+	// idx_output_tags_name_user: the label filter selects transaction_id by
+	// label name, which the primary key cannot serve because it leads with
+	// transaction_id.
+	TransactionID uint   `gorm:"primaryKey;index:idx_transaction_labels_name_user,priority:3,where:deleted_at IS NULL"`
+	LabelName     string `gorm:"primaryKey;index:idx_transaction_labels_name_user,priority:1,where:deleted_at IS NULL"`
+	LabelUserID   int    `gorm:"primaryKey;index:idx_transaction_labels_name_user,priority:2,where:deleted_at IS NULL"`
 }

--- a/pkg/internal/storage/database/models/tx_labels.go
+++ b/pkg/internal/storage/database/models/tx_labels.go
@@ -11,7 +11,12 @@ type TransactionLabel struct {
 	UpdatedAt time.Time
 	DeletedAt gorm.DeletedAt `gorm:"index"`
 
-	TransactionID uint   `gorm:"primary_key"`
-	LabelName     string `gorm:"primary_key"`
-	LabelUserID   int    `gorm:"primary_key"`
+	// idx_transaction_labels_name_user is the label-side twin of
+	// idx_output_tags_name_user: the label filter selects transaction_id by label
+	// name, which the primary key cannot serve because it leads with
+	// transaction_id. Measured on the same wallet: 28,982 sequential scans, and
+	// 154 tuples fetched per index scan where a selective lookup returns ~1.
+	TransactionID uint   `gorm:"primary_key;index:idx_transaction_labels_name_user,priority:3,where:deleted_at IS NULL"`
+	LabelName     string `gorm:"primary_key;index:idx_transaction_labels_name_user,priority:1,where:deleted_at IS NULL"`
+	LabelUserID   int    `gorm:"primary_key;index:idx_transaction_labels_name_user,priority:2,where:deleted_at IS NULL"`
 }

--- a/pkg/internal/storage/repo/known_tx_get_beef.go
+++ b/pkg/internal/storage/repo/known_tx_get_beef.go
@@ -109,21 +109,22 @@ func (p *KnownTx) preFetchInto(ctx context.Context, dst map[string]models.KnownT
 	return modelsBatch, nil
 }
 
-// preFetchAncestry reads the ancestry breadth-first, ONE QUERY PER GENERATION.
+// preFetchAncestry reads the ancestry breadth-first, one query per generation.
 //
 // The recursive build reads any ancestor it has not already been handed with an
-// individual `First()`. Two generations used to be pre-read in bulk, which
-// covers a build whose subjects are already proved but not one that has to walk
-// back through unmined history — and on a chain that is not confirming, that is
-// every build. Measured on a wallet holding 10,002 transactions: 28,720,064
-// index scans against bsv_known_txes, roughly 2,870 round trips per
-// transaction, with the wallet process pinned at 446% CPU while postgres sat
-// flat at 27%. Eighty percent of the recursive build's time was inside
-// gorm.First, not in merging or hashing.
+// individual First(). Pre-reading two generations covers a build whose subjects
+// are already proved, but not one that has to walk back through unmined
+// history - and on a chain that is not confirming promptly, that is every
+// build. The walk then costs one round trip per ancestor, which is dominated by
+// per-statement overhead rather than by the lookup itself.
 //
-// The rows read are exactly the ones the recursion would have read anyway; only
-// the number of round trips changes. Bounded by maxDepthOfRecursion, which the
-// recursion enforces too, and it stops as soon as a generation adds nothing.
+// The rows read here are exactly the ones the recursion would have read anyway;
+// only the number of statements changes. Note that index scan counts do not
+// fall as a result - each value in an IN list still costs a probe - which is
+// the point: the probe was never the expensive part.
+//
+// Bounded by maxDepthOfRecursion, which the recursion enforces too, and it
+// stops as soon as a generation adds nothing.
 func (p *KnownTx) preFetchAncestry(ctx context.Context, dst map[string]models.KnownTx, seedIDs []string, options entity.GetBEEFOptions) error {
 	frontier := seedIDs
 

--- a/pkg/internal/storage/repo/known_tx_get_beef.go
+++ b/pkg/internal/storage/repo/known_tx_get_beef.go
@@ -63,16 +63,8 @@ func (p *KnownTx) GetBEEFForTxIDs(ctx context.Context, txIDs iter.Seq[string], o
 	var preFetched map[string]models.KnownTx
 	if len(missingTxIDs) > 0 {
 		preFetched = make(map[string]models.KnownTx)
-		if err := p.preFetchInto(ctx, preFetched, missingTxIDs, options); err != nil {
+		if err := p.preFetchAncestry(ctx, preFetched, missingTxIDs, options); err != nil {
 			return nil, err
-		}
-
-		// Every build descends into the subjects' direct parents, so read them
-		// in one query rather than one per input.
-		if parentIDs := directParentIDs(preFetched, options); len(parentIDs) > 0 {
-			if err := p.preFetchInto(ctx, preFetched, parentIDs, options); err != nil {
-				return nil, err
-			}
 		}
 	}
 
@@ -87,7 +79,7 @@ func (p *KnownTx) GetBEEFForTxIDs(ctx context.Context, txIDs iter.Seq[string], o
 
 // preFetchInto reads the given known txs in one query and adds them to dst,
 // leaving entries already present untouched.
-func (p *KnownTx) preFetchInto(ctx context.Context, dst map[string]models.KnownTx, txIDs []string, options entity.GetBEEFOptions) error {
+func (p *KnownTx) preFetchInto(ctx context.Context, dst map[string]models.KnownTx, txIDs []string, options entity.GetBEEFOptions) ([]models.KnownTx, error) {
 	wanted := make([]string, 0, len(txIDs))
 	for _, txID := range txIDs {
 		if _, ok := dst[txID]; !ok {
@@ -95,7 +87,7 @@ func (p *KnownTx) preFetchInto(ctx context.Context, dst map[string]models.KnownT
 		}
 	}
 	if len(wanted) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	query := p.db.WithContext(ctx).
@@ -108,12 +100,51 @@ func (p *KnownTx) preFetchInto(ctx context.Context, dst map[string]models.KnownT
 
 	var modelsBatch []models.KnownTx
 	if err := query.Where("tx_id IN ?", wanted).Find(&modelsBatch).Error; err != nil {
-		return fmt.Errorf("failed to pre-fetch known txs: %w", err)
+		return nil, fmt.Errorf("failed to pre-fetch known txs: %w", err)
 	}
 
 	for _, m := range modelsBatch {
 		dst[m.TxID] = m
 	}
+	return modelsBatch, nil
+}
+
+// preFetchAncestry reads the ancestry breadth-first, ONE QUERY PER GENERATION.
+//
+// The recursive build reads any ancestor it has not already been handed with an
+// individual `First()`. Two generations used to be pre-read in bulk, which
+// covers a build whose subjects are already proved but not one that has to walk
+// back through unmined history — and on a chain that is not confirming, that is
+// every build. Measured on a wallet holding 10,002 transactions: 28,720,064
+// index scans against bsv_known_txes, roughly 2,870 round trips per
+// transaction, with the wallet process pinned at 446% CPU while postgres sat
+// flat at 27%. Eighty percent of the recursive build's time was inside
+// gorm.First, not in merging or hashing.
+//
+// The rows read are exactly the ones the recursion would have read anyway; only
+// the number of round trips changes. Bounded by maxDepthOfRecursion, which the
+// recursion enforces too, and it stops as soon as a generation adds nothing.
+func (p *KnownTx) preFetchAncestry(ctx context.Context, dst map[string]models.KnownTx, seedIDs []string, options entity.GetBEEFOptions) error {
+	frontier := seedIDs
+
+	for depth := 0; depth < maxDepthOfRecursion && len(frontier) > 0; depth++ {
+		added, err := p.preFetchInto(ctx, dst, frontier, options)
+		if err != nil {
+			return err
+		}
+		if len(added) == 0 {
+			return nil
+		}
+
+		// DirectSourcesOnly makes the parents terminal, so nothing below them is
+		// ever read and pre-reading it would be waste.
+		if options.DirectSourcesOnly && depth >= 1 {
+			return nil
+		}
+
+		frontier = parentIDsOf(added, dst, options)
+	}
+
 	return nil
 }
 
@@ -143,16 +174,17 @@ func needsInputBEEF(tx *transaction.Transaction, options entity.GetBEEFOptions, 
 	return false
 }
 
-// directParentIDs returns the txids spent by the already-fetched transactions.
+// parentIDsOf returns the txids spent by one generation of fetched transactions,
+// skipping any already present in fetched.
 // A raw tx that cannot be parsed is skipped: the build reports that properly.
-func directParentIDs(fetched map[string]models.KnownTx, options entity.GetBEEFOptions) []string {
+func parentIDsOf(generation []models.KnownTx, fetched map[string]models.KnownTx, options entity.GetBEEFOptions) []string {
 	// A proved transaction ends the walk, so its parents are never read - unless
 	// MinProofLevel deliberately withholds the proof and forces the walk on.
 	provenIsTerminal := options.MinProofLevel == 0
 
-	seen := make(map[string]struct{}, len(fetched))
+	seen := make(map[string]struct{}, len(generation))
 	var parents []string
-	for _, model := range fetched {
+	for _, model := range generation {
 		if model.RawTx == nil {
 			continue
 		}


### PR DESCRIPTION
Follow-up to #1014. Two costs that only became visible once that change stopped the stored-BEEF growth from masking them, both found by profiling the wallet process under sustained load.

## Ancestry reads — one query per generation, not one per ancestor

`recursiveBuildValidBEEF` reads any ancestor it wasn't handed with an individual `First()`. Two generations were pre-read in bulk, which covers a build whose subjects are already proved — but not one walking back through unmined history, and on a chain that isn't confirming that's every build.

Profiling at 2,000 trades: `recursiveBuildValidBEEF` was **24.9% of all CPU, and 80.4% of that was inside `gorm.(*DB).First`**. The wallet process sat at 446% CPU while postgres stayed **flat at 27%** for the whole run. The cost was never the query — it was ORM and round-trip overhead paid roughly **2,870 times per transaction**.

`preFetchAncestry` walks breadth-first, reading each generation in one query. Bounded by the same `maxDepthOfRecursion` the recursion already enforces, stops as soon as a generation adds nothing, and skips deeper generations entirely under `DirectSourcesOnly` since parents are terminal there. The rows read are exactly the ones the recursion would have read; only the statement count changes.

`parentIDsOf` replaces `directParentIDs`, taking one generation rather than the whole accumulated map — otherwise each round rescans everything already fetched.

Flagging for review so it isn't a surprise: **index scan counts do not drop** (28.7M → 33.7M), because each value in an `IN` list still costs a probe. That's consistent with the profile — the probe was never the expensive part.

## Join table indexes

`bsv_output_tags` and `bsv_transaction_labels` are both modelled with a composite primary key led by the *foreign* key, while every lookup filters the other way round, by tag or label name. The primary key can't serve that, so the lookup scans the whole join table — and both tables gain a row per name per row, forever.

Measured after 2,000 trades:

| | sequential scans | tuples read |
|---|---:|---:|
| `bsv_output_tags` (8,000 rows) | 19,571 | 92,989,035 |
| `bsv_transaction_labels` | 28,982 | — (154 per index scan) |

Declared on the models, following the existing partial-index precedent on `idx_user_utxos_claim`. Sequential scans fall to 3 and the 93M tuple reads to zero.

**On its own this did not improve throughput**, and I'd rather say so plainly — an 8,000-row table sitting in cache is cheap to scan however often you do it. It's included because the cost grows with history and the fix is free, not because it moved the benchmark.

## Measured

2,000 trades, 16 in flight, fresh schema per arm, zero failures throughout:

| arm | trades/s | lifecycle p50 | wall clock |
|---|---:|---:|---:|
| #1014 alone | 2.33 | 12.8 s | 14m 20s |
| \+ join table indexes | 1.81 | 20.1 s | 18m 23s |
| \+ ancestry batching | **3.89** | **9.2 s** | **8m 34s** |

Against the pre-#1014 baseline that is **0.56 → 3.89 trades/s**, and 59m 53s → 8m 34s.

The middle row is a single run that went the wrong way. It sits within the range where a repeat is warranted before concluding anything, and the batching row below it carries the same indexes — I didn't want to quietly drop an inconvenient data point.

Full `./pkg/...` suite passes, zero failures, on top of the merged #1014.
