### PR TITLE
feat: bump go-sdk

### DIFF
--- a/examples/complex_wallet_examples/certifier_server_example/go.mod
+++ b/examples/complex_wallet_examples/certifier_server_example/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 toolchain go1.26.6
 
 require (
-	github.com/bsv-blockchain/go-sdk v1.3.4
+	github.com/bsv-blockchain/go-sdk v1.4.1
 	github.com/bsv-blockchain/go-wallet-toolbox v0.184.13
 	github.com/go-softwarelab/common v1.8.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/examples/complex_wallet_examples/certifier_server_example/go.sum
+++ b/examples/complex_wallet_examples/certifier_server_example/go.sum
@@ -78,8 +78,8 @@ github.com/bsv-blockchain/go-p2p-message-bus v0.1.23 h1:JitBGy9N/lRXaixGneo+UCmV
 github.com/bsv-blockchain/go-p2p-message-bus v0.1.23/go.mod h1:ysf6HtQ+6CFM3R97H6OcOtrcfc28iL/ZUVdHijchu2M=
 github.com/bsv-blockchain/go-safe-conversion v1.2.0 h1:HwLWaxqm2OyU5/2BRQ8kwdn25QyX2HXr0JkfSyTG3DU=
 github.com/bsv-blockchain/go-safe-conversion v1.2.0/go.mod h1:62Eq2980j4BygfqJhd/ObGRHET8ubEy2rBdGi4k6nsw=
-github.com/bsv-blockchain/go-sdk v1.3.4 h1:qcAh8xPXncuKs3CnUPxmULTNFMX1RaEk8M/aR9qLbdQ=
-github.com/bsv-blockchain/go-sdk v1.3.4/go.mod h1:OgwTIUwBL74L5DUT+595i+7WPediUqxhxnzC9rIK0og=
+github.com/bsv-blockchain/go-sdk v1.4.1 h1:J2hECn17QkLXq8K8O0m0qA7yih4YmWFTX6o9Ox72Tf8=
+github.com/bsv-blockchain/go-sdk v1.4.1/go.mod h1:p2aRf3+hHx8uaQazzVBbX/iFv/vatCFbazrM7RmvT08=
 github.com/bsv-blockchain/go-subtree v1.4.5 h1:PDyujago1K6il1oG1GBH2NzNygELfTI0cwFZy98R6wU=
 github.com/bsv-blockchain/go-subtree v1.4.5/go.mod h1:omuv2wkd3ZJpuqNlyP4M4f9cY6fLDbuTbHAM8F/ptOk=
 github.com/bsv-blockchain/go-teranode-p2p-client v0.2.9 h1:7l/lm0zbFuTvxF2br261iEd3XN/bYtdIfqewYi/Y1A4=

--- a/examples/complex_wallet_examples/create_faucet_server/go.mod
+++ b/examples/complex_wallet_examples/create_faucet_server/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 toolchain go1.26.6
 
 require (
-	github.com/bsv-blockchain/go-sdk v1.3.4
+	github.com/bsv-blockchain/go-sdk v1.4.1
 	github.com/bsv-blockchain/go-wallet-toolbox v0.184.13
 	github.com/go-softwarelab/common v1.8.0
 	github.com/gofiber/fiber/v2 v2.52.15

--- a/examples/complex_wallet_examples/create_faucet_server/go.sum
+++ b/examples/complex_wallet_examples/create_faucet_server/go.sum
@@ -80,8 +80,8 @@ github.com/bsv-blockchain/go-p2p-message-bus v0.1.23 h1:JitBGy9N/lRXaixGneo+UCmV
 github.com/bsv-blockchain/go-p2p-message-bus v0.1.23/go.mod h1:ysf6HtQ+6CFM3R97H6OcOtrcfc28iL/ZUVdHijchu2M=
 github.com/bsv-blockchain/go-safe-conversion v1.2.0 h1:HwLWaxqm2OyU5/2BRQ8kwdn25QyX2HXr0JkfSyTG3DU=
 github.com/bsv-blockchain/go-safe-conversion v1.2.0/go.mod h1:62Eq2980j4BygfqJhd/ObGRHET8ubEy2rBdGi4k6nsw=
-github.com/bsv-blockchain/go-sdk v1.3.4 h1:qcAh8xPXncuKs3CnUPxmULTNFMX1RaEk8M/aR9qLbdQ=
-github.com/bsv-blockchain/go-sdk v1.3.4/go.mod h1:OgwTIUwBL74L5DUT+595i+7WPediUqxhxnzC9rIK0og=
+github.com/bsv-blockchain/go-sdk v1.4.1 h1:J2hECn17QkLXq8K8O0m0qA7yih4YmWFTX6o9Ox72Tf8=
+github.com/bsv-blockchain/go-sdk v1.4.1/go.mod h1:p2aRf3+hHx8uaQazzVBbX/iFv/vatCFbazrM7RmvT08=
 github.com/bsv-blockchain/go-subtree v1.4.5 h1:PDyujago1K6il1oG1GBH2NzNygELfTI0cwFZy98R6wU=
 github.com/bsv-blockchain/go-subtree v1.4.5/go.mod h1:omuv2wkd3ZJpuqNlyP4M4f9cY6fLDbuTbHAM8F/ptOk=
 github.com/bsv-blockchain/go-teranode-p2p-client v0.2.9 h1:7l/lm0zbFuTvxF2br261iEd3XN/bYtdIfqewYi/Y1A4=

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.6
 require (
 	github.com/bsv-blockchain/go-bsv-middleware v0.13.7
 	github.com/bsv-blockchain/go-chaintracks v1.2.11
-	github.com/bsv-blockchain/go-sdk v1.3.4
+	github.com/bsv-blockchain/go-sdk v1.4.1
 	github.com/bsv-blockchain/go-teranode-p2p-client v0.2.9
 	github.com/bsv-blockchain/universal-test-vectors v0.6.1
 	github.com/filecoin-project/go-jsonrpc v0.10.2

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/bsv-blockchain/go-p2p-message-bus v0.1.23 h1:JitBGy9N/lRXaixGneo+UCmV
 github.com/bsv-blockchain/go-p2p-message-bus v0.1.23/go.mod h1:ysf6HtQ+6CFM3R97H6OcOtrcfc28iL/ZUVdHijchu2M=
 github.com/bsv-blockchain/go-safe-conversion v1.2.0 h1:HwLWaxqm2OyU5/2BRQ8kwdn25QyX2HXr0JkfSyTG3DU=
 github.com/bsv-blockchain/go-safe-conversion v1.2.0/go.mod h1:62Eq2980j4BygfqJhd/ObGRHET8ubEy2rBdGi4k6nsw=
-github.com/bsv-blockchain/go-sdk v1.3.4 h1:qcAh8xPXncuKs3CnUPxmULTNFMX1RaEk8M/aR9qLbdQ=
-github.com/bsv-blockchain/go-sdk v1.3.4/go.mod h1:OgwTIUwBL74L5DUT+595i+7WPediUqxhxnzC9rIK0og=
+github.com/bsv-blockchain/go-sdk v1.4.1 h1:J2hECn17QkLXq8K8O0m0qA7yih4YmWFTX6o9Ox72Tf8=
+github.com/bsv-blockchain/go-sdk v1.4.1/go.mod h1:p2aRf3+hHx8uaQazzVBbX/iFv/vatCFbazrM7RmvT08=
 github.com/bsv-blockchain/go-subtree v1.4.5 h1:PDyujago1K6il1oG1GBH2NzNygELfTI0cwFZy98R6wU=
 github.com/bsv-blockchain/go-subtree v1.4.5/go.mod h1:omuv2wkd3ZJpuqNlyP4M4f9cY6fLDbuTbHAM8F/ptOk=
 github.com/bsv-blockchain/go-teranode-p2p-client v0.2.9 h1:7l/lm0zbFuTvxF2br261iEd3XN/bYtdIfqewYi/Y1A4=

--- a/manual_tests/go.mod
+++ b/manual_tests/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 toolchain go1.26.6
 
 require (
-	github.com/bsv-blockchain/go-sdk v1.3.4
+	github.com/bsv-blockchain/go-sdk v1.4.1
 	github.com/bsv-blockchain/go-wallet-toolbox v1.24.3
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/manual_tests/go.sum
+++ b/manual_tests/go.sum
@@ -82,8 +82,8 @@ github.com/bsv-blockchain/go-p2p-message-bus v0.1.23 h1:JitBGy9N/lRXaixGneo+UCmV
 github.com/bsv-blockchain/go-p2p-message-bus v0.1.23/go.mod h1:ysf6HtQ+6CFM3R97H6OcOtrcfc28iL/ZUVdHijchu2M=
 github.com/bsv-blockchain/go-safe-conversion v1.2.0 h1:HwLWaxqm2OyU5/2BRQ8kwdn25QyX2HXr0JkfSyTG3DU=
 github.com/bsv-blockchain/go-safe-conversion v1.2.0/go.mod h1:62Eq2980j4BygfqJhd/ObGRHET8ubEy2rBdGi4k6nsw=
-github.com/bsv-blockchain/go-sdk v1.3.4 h1:qcAh8xPXncuKs3CnUPxmULTNFMX1RaEk8M/aR9qLbdQ=
-github.com/bsv-blockchain/go-sdk v1.3.4/go.mod h1:OgwTIUwBL74L5DUT+595i+7WPediUqxhxnzC9rIK0og=
+github.com/bsv-blockchain/go-sdk v1.4.1 h1:J2hECn17QkLXq8K8O0m0qA7yih4YmWFTX6o9Ox72Tf8=
+github.com/bsv-blockchain/go-sdk v1.4.1/go.mod h1:p2aRf3+hHx8uaQazzVBbX/iFv/vatCFbazrM7RmvT08=
 github.com/bsv-blockchain/go-subtree v1.4.5 h1:PDyujago1K6il1oG1GBH2NzNygELfTI0cwFZy98R6wU=
 github.com/bsv-blockchain/go-subtree v1.4.5/go.mod h1:omuv2wkd3ZJpuqNlyP4M4f9cY6fLDbuTbHAM8F/ptOk=
 github.com/bsv-blockchain/go-teranode-p2p-client v0.2.9 h1:7l/lm0zbFuTvxF2br261iEd3XN/bYtdIfqewYi/Y1A4=


### PR DESCRIPTION
## What Changed
- Bumped `github.com/bsv-blockchain/go-sdk` from `v1.3.4` to `v1.4.1`.
- Applied the bump consistently across all modules: root module plus `manual_tests/`, `examples/complex_wallet_examples/certifier_server_example/`, and `examples/complex_wallet_examples/create_faucet_server/` (`go.mod`/`go.sum` only — no application code changes).

## Why It Was Necessary
- go-sdk v1.4.x introduces a **process-wide secp256k1 backend at the shared EC primitives**, delivering optimized ECDSA `Verify` performance. It uses native secp256k1 bindings when CGO and a supported platform are available, and falls back to the pure-Go implementation otherwise — so signature verification gets faster without changing default behavior.
- Keeps us on the current go-sdk line, which also pulls in a thread-safety fix (mutex-guarded `IdentityKey` write access) and `golang.org/x/crypto` v0.56.0.

## Testing Performed
- `go build ./...` and `go test ./...` pass on the root module.
- CI green across all four bumped modules.

## Impact / Risk
- **Low.** Dependency-only change; no public API or business-logic changes on our side.
- ECDSA Verify is faster with no default-behavior change — the native secp256k1 backend is opt-in/CGO-gated with a pure-Go fallback, so pure-Go builds behave as before.
- Transitive updates: `golang.org/x/crypto` v0.54.0 → v0.56.0, `golang.org/x/net` bump, and Go 1.26 deprecated-ECDSA-field-access handling are all contained within go-sdk.